### PR TITLE
Feature/revert subscription status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The changelog for `SuperwallKit`. Also see the [releases](https://github.com/sup
 
 ### Breaking Changes
 
-- Removes `isUserSubscribed()` from the `SuperwallDelegate` and replaces this with a published instance variable `subscriptionStatus`. This is a class with static variables that defaults to `.unknown` on first install and the cached value on subsequent app opens. If you're using a `SubscriptionController` to handle subscription-related logic, you must set `subscriptionStatus` every time the user's subscription status changes. If you're letting Superwall handle subscription-related logic, this value will be updated with the device receipt.
+- Removes `isUserSubscribed()` from the `SuperwallDelegate` and replaces this with a published instance variable `subscriptionStatus`. This is enum that defaults to `.unknown` on first install and the cached value on subsequent app opens. If you're using a `SubscriptionController` to handle subscription-related logic, you must set `subscriptionStatus` every time the user's subscription status changes. If you're letting Superwall handle subscription-related logic, this value will be updated with the device receipt.
 - `hasActiveSubscriptionDidChange(to:)` is replaced in favour of `subscriptionStatusDidChange(to:)`.
 - Makes `Superwall.shared.options` internal so that options must be set in `configure`.
 

--- a/Examples/SwiftUI/Superwall-SwiftUI/WelcomeView.swift
+++ b/Examples/SwiftUI/Superwall-SwiftUI/WelcomeView.swift
@@ -67,7 +67,7 @@ struct WelcomeView: View {
     BrandedButton(title: "Log In") {
       Task {
         SuperwallService.setName(to: name)
-        await SuperwallService.identify()
+        SuperwallService.identify()
         isLoggedIn = true
       }
     }

--- a/Examples/UIKit+RevenueCat/Superwall-UIKit+RevenueCat/TrackEventViewController.swift
+++ b/Examples/UIKit+RevenueCat/Superwall-UIKit+RevenueCat/TrackEventViewController.swift
@@ -36,7 +36,7 @@ final class TrackEventViewController: UIViewController {
 
   override func viewDidLoad() {
     super.viewDidLoad()
-    subscribedCancellable = Superwall.shared.$subscriptionStatus
+    subscribedCancellable = Superwall.shared.subscriptionStatus
       .receive(on: DispatchQueue.main)
       .sink { [weak self] status in
         switch status {
@@ -44,7 +44,7 @@ final class TrackEventViewController: UIViewController {
           self?.subscriptionLabel.text = "You currently have an active subscription. Therefore, the paywall will never show. For the purposes of this app, delete and reinstall the app to clear subscriptions.\n\nYou will need to wait a few minutes until the subscription expires on RevenueCat's side before trying again."
         case .inactive:
           self?.subscriptionLabel.text = "You do not have an active subscription so the paywall will show when clicking the button."
-        default:
+        case .unknown:
           self?.subscriptionLabel.text = "Loading subscription status."
         }
       }

--- a/Examples/UIKit-ObjC/Superwall-UIKit-ObjC/Services/SSASuperwallService.m
+++ b/Examples/UIKit-ObjC/Superwall-UIKit-ObjC/Services/SSASuperwallService.m
@@ -69,9 +69,9 @@ static inline SWKPurchaseResult SWKPurchaseResultFromTransactionState(SKPaymentT
     // Listen for changes to the subscription state.
     [[NSNotificationCenter defaultCenter] addObserverForName:SSAStoreKitServiceDidUpdateSubscribedState object:nil queue:[NSOperationQueue mainQueue] usingBlock:^(NSNotification * _Nonnull note) {
       if ([SSAStoreKitService sharedService].isSubscribed) {
-        [Superwall sharedInstance].subscriptionStatus = [SWKSubscriptionStatus active];
+        [Superwall sharedInstance].subscriptionStatus = SWKSubscriptionStatusActive;
       } else {
-        [Superwall sharedInstance].subscriptionStatus = [SWKSubscriptionStatus inactive];
+        [Superwall sharedInstance].subscriptionStatus = SWKSubscriptionStatusInactive;
       }
     }];
   }

--- a/Examples/UIKit-Swift/Superwall-UIKit-Swift/TrackEventViewController.swift
+++ b/Examples/UIKit-Swift/Superwall-UIKit-Swift/TrackEventViewController.swift
@@ -45,8 +45,6 @@ final class TrackEventViewController: UIViewController {
           self?.subscriptionLabel.text = "You currently have an active subscription. Therefore, the paywall will never show. For the purposes of this app, delete and reinstall the app to clear subscriptions."
         case .inactive:
           self?.subscriptionLabel.text = "You do not have an active subscription so the paywall will show when clicking the button."
-        default:
-          break
         }
       }
     navigationItem.hidesBackButton = true

--- a/Sources/SuperwallKit/Analytics/Internal Tracking/Trackable Events/TrackableSuperwallEvent.swift
+++ b/Sources/SuperwallKit/Analytics/Internal Tracking/Trackable Events/TrackableSuperwallEvent.swift
@@ -182,7 +182,7 @@ enum InternalSuperwallEvent {
     var customParameters: [String: Any] = [:]
     func getSuperwallParameters() async -> [String: Any] {
       return [
-        "subscription_status": subscriptionStatus.value.description
+        "subscription_status": subscriptionStatus.description
       ]
     }
   }

--- a/Sources/SuperwallKit/Config/Options/PaywallOptions.swift
+++ b/Sources/SuperwallKit/Config/Options/PaywallOptions.swift
@@ -17,13 +17,6 @@ public final class PaywallOptions: NSObject {
   /// from the paywall, or closes the paywall.
   public var isHapticFeedbackEnabled = true
 
-  /// Enables the sending of non-Superwall tracked events and properties back to the Superwall servers.
-  /// Defaults to `true`.
-  ///
-  /// Set this to `false` to stop external data collection. This will not affect
-  /// your ability to create triggers based on properties.
-  public var isExternalDataCollectionEnabled = true
-
   /// Defines the messaging of the alert presented to the user when restoring a transaction fails.
 
   @objc(SWKRestoreFailed)

--- a/Sources/SuperwallKit/Delegate/SubscriptionStatus.swift
+++ b/Sources/SuperwallKit/Delegate/SubscriptionStatus.swift
@@ -6,57 +6,30 @@
 //
 
 import Foundation
-import UIKit
-/// A class representing the subscription status of the user.
+
+/// An enum representing the subscription status of the user.
 @objc(SWKSubscriptionStatus)
-@objcMembers
-public final class SubscriptionStatus: NSObject, Codable {
-  enum Value: CustomStringConvertible, Codable {
-    /// The user has an active subscription.
-    case active
-
-    /// The user doesn't have an active subscription.
-    case inactive
-
-    /// The subscription status is unknown.
-    case unknown
-
-    var description: String {
-      switch self {
-      case .active:
-        return "ACTIVE"
-      case .inactive:
-        return "INACTIVE"
-      case .unknown:
-        return "UNKNOWN"
-      }
-    }
-
-  }
-  let value: Value
-
-  enum CodingKeys: CodingKey {
-    case value
-  }
-
-  init(_ value: Value) {
-    self.value = value
-  }
-
-  public override func isEqual(_ object: Any?) -> Bool {
-    if let status = object as? SubscriptionStatus {
-      return status.value == value
-    }
-    return false
-  }
-
-    /// The user has an active subscription.
-  public static let active = SubscriptionStatus(.active)
+public enum SubscriptionStatus: Int, Codable {
+  /// The user has an active subscription.
+  case active
 
   /// The user doesn't have an active subscription.
-  public static let inactive = SubscriptionStatus(.inactive)
+  case inactive
 
   /// The subscription status is unknown.
-  public static let unknown = SubscriptionStatus(.unknown)
+  case unknown
 }
 
+// MARK: - CustomStringConvertible
+extension SubscriptionStatus: CustomStringConvertible {
+  public var description: String {
+    switch self {
+    case .active:
+      return "ACTIVE"
+    case .inactive:
+      return "INACTIVE"
+    case .unknown:
+      return "UNKNOWN"
+    }
+  }
+}

--- a/Sources/SuperwallKit/Delegate/SuperwallDelegate.swift
+++ b/Sources/SuperwallKit/Delegate/SuperwallDelegate.swift
@@ -74,21 +74,6 @@ public protocol SuperwallDelegate: AnyObject {
   /// use the published properties of ``Superwall/subscriptionStatus`` to react to
   /// changes as they happen.
   ///
-  /// You can still `switch` on it to determine its value:
-  ///
-  /// ```
-  ///  switch newValue {
-  ///  case .active:
-  ///    break
-  ///  case .inactive:
-  ///    break
-  ///  case .unknown:
-  ///    break
-  ///  default:
-  ///    break
-  ///  }
-  /// ```
-  ///
   /// - Parameters:
   ///   - newValue: The new value of ``Superwall/subscriptionStatus``.
   func subscriptionStatusDidChange(to newValue: SubscriptionStatus)

--- a/Sources/SuperwallKit/Documentation.docc/AdvancedConfiguration.md
+++ b/Sources/SuperwallKit/Documentation.docc/AdvancedConfiguration.md
@@ -75,7 +75,7 @@ or
   Superwall.shared.subscriptionStatus = .inactive
 ```
 
-This is a ``SubscriptionStatus`` class that has three static variables:
+This is a ``SubscriptionStatus`` enum that has three possible cases:
 
 1. **`.unknown`**: This is the default value. In this state, paywalls will not show until the state changes to `.active` or `.inactive`.
 

--- a/Sources/SuperwallKit/Superwall.swift
+++ b/Sources/SuperwallKit/Superwall.swift
@@ -109,21 +109,6 @@ public final class Superwall: NSObject, ObservableObject {
   /// ``SuperwallDelegate/subscriptionStatusDidChange(to:)-24teh``
   /// to receive a callback with the new value every time it changes.
   ///
-  /// You can still `switch` on it to determine its value:
-  ///
-  /// ```
-  ///  switch Superwall.shared.subscriptionStatus {
-  ///  case .active:
-  ///    break
-  ///  case .inactive:
-  ///    break
-  ///  case .unknown:
-  ///    break
-  ///  default:
-  ///    break
-  ///  }
-  /// ```
-  ///
   /// To learn more, see <doc:AdvancedConfiguration>.
   @Published
   public var subscriptionStatus: SubscriptionStatus = .unknown


### PR DESCRIPTION
## Changes in this pull request

Reverts subscription status back to being an enum.

### Checklist

- [x] All tests pass. Demo project builds and runs.
- [ ] I added tests, an experiment, or detailed why my change isn't tested.
- [x] I added an entry to the `CHANGELOG.md` for any breaking changes, enhancements, or bug fixes.
- [x] I have run `swiftlint` in the main directory and fixed any issues.
- [ ] I have updated the SDK documentation as well as the online docs.
- [ ] I have reviewed the [contributing guide](https://github.com/superwall-me/paywall-ios/tree/master/.github/CONTRIBUTING.md)
