### PR TITLE
Feature/remove subscription controller

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The changelog for `SuperwallKit`. Also see the [releases](https://github.com/sup
 
 ### Breaking Changes
 
+- Changes `SubscriptionController` to `PurchaseController`. You now set this in `Superwall.shared.configure`, rather than via the delegate.
 - Removes `isUserSubscribed()` from the `SuperwallDelegate` and replaces this with a published instance variable `subscriptionStatus`. This is enum that defaults to `.unknown` on first install and the cached value on subsequent app opens. If you're using a `SubscriptionController` to handle subscription-related logic, you must set `subscriptionStatus` every time the user's subscription status changes. If you're letting Superwall handle subscription-related logic, this value will be updated with the device receipt.
 - `hasActiveSubscriptionDidChange(to:)` is replaced in favour of `subscriptionStatusDidChange(to:)`.
 - Makes `Superwall.shared.options` internal so that options must be set in `configure`.

--- a/Examples/SwiftUI/README.md
+++ b/Examples/SwiftUI/README.md
@@ -47,7 +47,7 @@ Build and run the app and you'll see the welcome screen:
 
 SuperwallKit is [configured](Superwall-SwiftUI/Services/SuperwallService.swift#L31) on app launch, setting an `apiKey` and `delegate`.
 
-The SDK sends back events received from the paywall via the delegate methods in [SuperwallService.swift](Superwall-SwiftUI/Services/SuperwallService.swift#L67). You use these methods to make and restore purchases and react to analytical events.
+The SDK sends back events received from the paywall via the delegate methods in [SuperwallService.swift](Superwall-SwiftUI/Services/SuperwallService.swift#L67).
 
 ## Logging In
 

--- a/Examples/SwiftUI/Superwall-SwiftUI/Services/StoreKitService.swift
+++ b/Examples/SwiftUI/Superwall-SwiftUI/Services/StoreKitService.swift
@@ -5,7 +5,7 @@
 //  Created by Yusuf Tör on 05/04/2022.
 //
 
-// Uncomment if you're implementing the SubscriptionController in SuperwallService.swift:
+// Uncomment if you're implementing the PurchaseController in SuperwallService.swift:
 /*
 import StoreKit
 import SuperwallKit

--- a/Examples/SwiftUI/Superwall-SwiftUI/Services/SuperwallService.swift
+++ b/Examples/SwiftUI/Superwall-SwiftUI/Services/SuperwallService.swift
@@ -20,8 +20,8 @@ final class SuperwallService {
 
   static func configure() {
     // Superwall handles subscription logic by default. However, if you'd
-    // like more control you can handle it yourself via the SubscriptionController
-    // in the delegate. If you're doing that, uncomment the following and other comments
+    // like more control you can handle it yourself by providing a PurchaseController.
+    // If you're doing that, uncomment the following and other comments
     // further down:
 
     // Task {
@@ -30,7 +30,8 @@ final class SuperwallService {
 
     Superwall.configure(
       apiKey: apiKey,
-      delegate: shared
+      delegate: shared/*,
+      purchaseController: shared*/
     )
 
     // Getting our logged in status from Superwall.
@@ -142,15 +143,12 @@ extension SuperwallService: SuperwallDelegate {
     }
     */
   }
-
-  // Uncomment if you would like to handle subscription-related logic yourself:
-  /*
-  func subscriptionController() -> SubscriptionController? {
-    return self
-  }
 }
 
-extension SuperwallService: SubscriptionController {
+// Uncomment to implement the PurchaseController:
+/*
+// MARK: - PurchaseController
+extension SuperwallService: PurchaseController {
   func purchase(product: SKProduct) async -> PurchaseResult {
     return await StoreKitService.shared.purchase(product)
   }
@@ -158,5 +156,5 @@ extension SuperwallService: SubscriptionController {
   func restorePurchases() async -> Bool {
     return await StoreKitService.shared.restorePurchases()
   }
-  */
 }
+*/

--- a/Examples/UIKit+RevenueCat/README.md
+++ b/Examples/UIKit+RevenueCat/README.md
@@ -49,7 +49,7 @@ Build and run the app and you'll see the welcome screen:
 
 SuperwallKit and RevenueCat are both [configured](Superwall-UIKit+RevenueCat/PaywallManager.swift#L37) on app launch, setting an `apiKey` and `delegate`.
 
-The SDK sends back events received from the paywall via the delegate methods in [PaywallManager.swift](Superwall-UIKit+RevenueCat/PaywallManager.swift#L170). The delegate is responsible for sending back analytical events and providing a `SubscriptionController`. This is a protocol implemented by the PaywallManager that handles purchasing and restoring logic.
+The SDK sends back events received from the paywall via the delegate methods in [PaywallManager.swift](Superwall-UIKit+RevenueCat/PaywallManager.swift#L170). A `PurchaseController` is provided by `PaywallManager` on configuring the SDK that handles purchasing and restoring logic.
 
 ## Logging In
 

--- a/Examples/UIKit+RevenueCat/Superwall-UIKit+RevenueCat/PaywallManager.swift
+++ b/Examples/UIKit+RevenueCat/Superwall-UIKit+RevenueCat/PaywallManager.swift
@@ -43,7 +43,8 @@ final class PaywallManager: NSObject {
 
     Superwall.configure(
       apiKey: superwallApiKey,
-      delegate: shared
+      delegate: shared,
+      purchaseController: shared
     )
   }
 
@@ -101,8 +102,8 @@ final class PaywallManager: NSObject {
   }
 }
 
-// MARK: - SubscriptionController
-extension PaywallManager: SubscriptionController {
+// MARK: - PurchaseController
+extension PaywallManager: PurchaseController {
   /// Restore purchases
   func restorePurchases() async -> Bool {
     return await restore()
@@ -157,10 +158,6 @@ extension PaywallManager: PurchasesDelegate {
 
 // MARK: - Superwall Delegate
 extension PaywallManager: SuperwallDelegate {
-  func subscriptionController() -> SubscriptionController? {
-    return self
-  }
-
   func didTrackSuperwallEventInfo(_ info: SuperwallEventInfo) {
     print("analytics event called", info.event.description)
 

--- a/Examples/UIKit+RevenueCat/Superwall-UIKit+RevenueCat/TrackEventViewController.swift
+++ b/Examples/UIKit+RevenueCat/Superwall-UIKit+RevenueCat/TrackEventViewController.swift
@@ -36,7 +36,7 @@ final class TrackEventViewController: UIViewController {
 
   override func viewDidLoad() {
     super.viewDidLoad()
-    subscribedCancellable = Superwall.shared.subscriptionStatus
+    subscribedCancellable = Superwall.shared.$subscriptionStatus
       .receive(on: DispatchQueue.main)
       .sink { [weak self] status in
         switch status {

--- a/Examples/UIKit-ObjC/Superwall-UIKit-ObjC/SSATrackEventViewController.m
+++ b/Examples/UIKit-ObjC/Superwall-UIKit-ObjC/SSATrackEventViewController.m
@@ -49,6 +49,7 @@
   __weak typeof(self) weakSelf = self;
   [[Superwall sharedInstance] trackWithEvent:@"campaign_trigger"
                      params:nil
+                  presenter:nil
                    products:nil
    ignoreSubscriptionStatus:NO
   presentationStyleOverride:SWKPaywallPresentationStyleNone

--- a/Examples/UIKit-ObjC/Superwall-UIKit-ObjC/SSATrackEventViewController.m
+++ b/Examples/UIKit-ObjC/Superwall-UIKit-ObjC/SSATrackEventViewController.m
@@ -48,11 +48,6 @@
 - (IBAction)trackEvent:(id)sender {
   __weak typeof(self) weakSelf = self;
   [[Superwall sharedInstance] trackWithEvent:@"campaign_trigger"
-                     params:nil
-                  presenter:nil
-                   products:nil
-   ignoreSubscriptionStatus:NO
-  presentationStyleOverride:SWKPaywallPresentationStyleNone
                      onSkip:^(enum SWKPaywallSkippedReason reason, NSError * _Nullable error) {
     [weakSelf paywallSkippedWithReason:reason error:error];
   }

--- a/Examples/UIKit-ObjC/Superwall-UIKit-ObjC/Services/SSASuperwallService.m
+++ b/Examples/UIKit-ObjC/Superwall-UIKit-ObjC/Services/SSASuperwallService.m
@@ -101,11 +101,12 @@ static inline SWKPurchaseResult SWKPurchaseResultFromTransactionState(SKPaymentT
   [[SSAStoreKitService sharedService] updateSubscribedState];
 
   // Configure Superwall.
-  [Superwall configureWithApiKey:kDemoAPIKey delegate:self purchaseController:nil options:nil completion:nil];
+
+  [Superwall configureWithApiKey:kDemoAPIKey delegate:self];
 }
 
 - (void)logInWithCompletion:(nullable void (^)(void))completion {
-  [[Superwall sharedInstance] identifyWithUserId:kDemoAPIKey options:nil completionHandler:^(NSError * _Nullable error) {
+  [[Superwall sharedInstance] identifyWithUserId:kDemoAPIKey completionHandler:^(NSError * _Nullable error) {
     switch (error.code) {
       case SWKIdentityErrorMissingUserId:
         NSLog(@"The provided userId was empty");

--- a/Examples/UIKit-ObjC/Superwall-UIKit-ObjC/Services/SSASuperwallService.m
+++ b/Examples/UIKit-ObjC/Superwall-UIKit-ObjC/Services/SSASuperwallService.m
@@ -101,7 +101,7 @@ static inline SWKPurchaseResult SWKPurchaseResultFromTransactionState(SKPaymentT
   [[SSAStoreKitService sharedService] updateSubscribedState];
 
   // Configure Superwall.
-  [Superwall configureWithApiKey:kDemoAPIKey delegate:self options:nil completion:nil];
+  [Superwall configureWithApiKey:kDemoAPIKey delegate:self purchaseController:nil options:nil completion:nil];
 }
 
 - (void)logInWithCompletion:(nullable void (^)(void))completion {

--- a/Examples/UIKit-Swift/README.md
+++ b/Examples/UIKit-Swift/README.md
@@ -46,7 +46,7 @@ Build and run the app and you'll see the welcome screen:
 
 SuperwallKit is [configured](Superwall-UIKit-Swift/Services/SuperwallService.swift#L30) on app launch, setting an `apiKey` and `delegate`.
 
-The SDK sends back events received from the paywall via the delegate methods in [SuperwallService.swift](Superwall-UIKit-Swift/Services/SuperwallService.swift#L64). You use these methods to make and restore purchases and react to analytical events. 
+The SDK sends back events received from the paywall via the delegate methods in [SuperwallService.swift](Superwall-UIKit-Swift/Services/SuperwallService.swift#L64).
 
 ## Logging In
 

--- a/Examples/UIKit-Swift/Superwall-UIKit-Swift/Services/StoreKitService.swift
+++ b/Examples/UIKit-Swift/Superwall-UIKit-Swift/Services/StoreKitService.swift
@@ -5,8 +5,8 @@
 //  Created by Yusuf Tör on 05/04/2022.
 //
 
-// Uncomment if you're implementing the SubscriptionController in SuperwallService.swift:
-/*
+// Uncomment if you're implementing the PurchaseController in SuperwallService.swift:
+
 import StoreKit
 import SuperwallKit
 
@@ -129,4 +129,3 @@ extension StoreKitService: SKPaymentTransactionObserver {
     }
   }
 }
-*/

--- a/Examples/UIKit-Swift/Superwall-UIKit-Swift/Services/SuperwallService.swift
+++ b/Examples/UIKit-Swift/Superwall-UIKit-Swift/Services/SuperwallService.swift
@@ -19,8 +19,8 @@ final class SuperwallService {
 
   static func configure() {
     // Superwall handles subscription logic by default. However, if you'd
-    // like more control you can handle it yourself via the SubscriptionController
-    // in the delegate. If you're doing that, uncomment the following and other comments
+    // like more control you can handle it yourself by providing a PurchaseController.
+    // If you're doing that, uncomment the following and other comments
     // further down:
 
     // Task {
@@ -29,7 +29,8 @@ final class SuperwallService {
 
     Superwall.configure(
       apiKey: apiKey,
-      delegate: shared
+      delegate: shared/*,
+      purchaseController: shared*/
     )
   }
 
@@ -138,16 +139,12 @@ extension SuperwallService: SuperwallDelegate {
     }
     */
   }
-
-  // Uncomment if you would like to handle subscription-related logic yourself:
-  /*
-  func subscriptionController() -> SubscriptionController? {
-    return self
-  }
 }
 
-// MARK: - SubscriptionController
-extension SuperwallService: SubscriptionController {
+// Uncomment to implement the PurchaseController:
+/*
+// MARK: - PurchaseController
+extension SuperwallService: PurchaseController {
   func purchase(product: SKProduct) async -> PurchaseResult {
     return await StoreKitService.shared.purchase(product)
   }
@@ -155,5 +152,5 @@ extension SuperwallService: SubscriptionController {
   func restorePurchases() async -> Bool {
     return await StoreKitService.shared.restorePurchases()
   }
-  */
 }
+*/

--- a/Sources/SuperwallKit/Config/Options/PaywallOptions.swift
+++ b/Sources/SuperwallKit/Config/Options/PaywallOptions.swift
@@ -36,7 +36,7 @@ public final class PaywallOptions: NSObject {
   /// Defines the messaging of the alert presented to the user when restoring a transaction fails.
   public var restoreFailed = RestoreFailed()
 
-  /// Pre-loads and caches trigger paywalls and products when you initialize the SDK via ``Superwall/configure(apiKey:delegate:options:completion:)-7fafw``. Defaults to `true`.
+  /// Pre-loads and caches trigger paywalls and products when you initialize the SDK via ``Superwall/configure(apiKey:delegate:purchaseController:options:completion:)-5y99b``. Defaults to `true`.
   ///
   /// Set this to `false` to load and cache paywalls and products in a just-in-time fashion.
   ///

--- a/Sources/SuperwallKit/Config/Options/SuperwallOptions.swift
+++ b/Sources/SuperwallKit/Config/Options/SuperwallOptions.swift
@@ -9,7 +9,7 @@ import Foundation
 
 /// Options for configuring Superwall, including paywall presentation and appearance.
 ///
-/// Pass an instance of this class to ``Superwall/configure(apiKey:delegate:options:completion:)-7fafw``.
+/// Pass an instance of this class to ``Superwall/configure(apiKey:delegate:purchaseController:options:completion:)-5y99b``.
 @objc(SWKSuperwallOptions)
 @objcMembers
 public final class SuperwallOptions: NSObject {

--- a/Sources/SuperwallKit/Delegate/PurchaseResult.swift
+++ b/Sources/SuperwallKit/Delegate/PurchaseResult.swift
@@ -17,7 +17,7 @@ enum InternalPurchaseResult {
 
 /// An enum that defines the possible outcomes of attempting to purchase a product.
 ///
-/// When implementing the ``SubscriptionController/purchase(product:)`` delegate
+/// When implementing the ``PurchaseController/purchase(product:)`` delegate
 /// method, all cases should be considered.
 public enum PurchaseResult: Sendable, Equatable {
   /// The purchase was cancelled.
@@ -95,7 +95,7 @@ public enum PurchaseResultObjc: Int, Sendable, Equatable {
 
   /// The purchase failed for a reason other than the user cancelling or the payment pending.
   ///
-  /// Send the `Error` back in the ``SubscriptionControllerObjc/purchase(product:completion:)``
+  /// Send the `Error` back in the ``PurchaseControllerObjc/purchase(product:completion:)``
   /// completion block to Superwall to alert the user.
   case failed
 }

--- a/Sources/SuperwallKit/Delegate/Subscription Controller/PurchaseController.swift
+++ b/Sources/SuperwallKit/Delegate/Subscription Controller/PurchaseController.swift
@@ -14,7 +14,7 @@ import StoreKit
 ///
 /// However, if you'd like more control, you can return a ``PurchaseController`` in
 /// the delegate when configuring the SDK via
-/// ``Superwall/configure(apiKey:delegate:options:completion:)-7fafw``.
+/// ``Superwall/configure(apiKey:delegate:purchaseController:options:completion:)-5y99b``.
 ///
 /// When implementing this, you also need to set the subscription status using
 /// ``Superwall/subscriptionStatus``.

--- a/Sources/SuperwallKit/Delegate/Subscription Controller/PurchaseController.swift
+++ b/Sources/SuperwallKit/Delegate/Subscription Controller/PurchaseController.swift
@@ -12,17 +12,17 @@ import StoreKit
 ///
 /// By default, the Superwall SDK handles all subscription-related logic.
 ///
-/// However, if you'd like more control, you can return a ``SubscriptionController`` in
+/// However, if you'd like more control, you can return a ``PurchaseController`` in
 /// the delegate when configuring the SDK via
 /// ``Superwall/configure(apiKey:delegate:options:completion:)-7fafw``.
 ///
 /// When implementing this, you also need to set the subscription status using
 /// ``Superwall/subscriptionStatus``.
 ///
-/// To learn how to implement the ``SubscriptionController`` in your app
+/// To learn how to implement the ``PurchaseController`` in your app
 /// and best practices, see <doc:AdvancedConfiguration>.
 @MainActor
-public protocol SubscriptionController: AnyObject {
+public protocol PurchaseController: AnyObject {
   /// Called when the user initiates purchasing of a product.
   ///
   /// Add your purchase logic here and return its result. You can use Apple's StoreKit APIs,

--- a/Sources/SuperwallKit/Delegate/Subscription Controller/PurchaseControllerObjc.swift
+++ b/Sources/SuperwallKit/Delegate/Subscription Controller/PurchaseControllerObjc.swift
@@ -14,7 +14,7 @@ import StoreKit
 ///
 /// However, if you'd like more control, you can return a ``PurchaseControllerObjc`` in
 /// the delegate when configuring the SDK via
-/// ``Superwall/configure(apiKey:delegate:options:completion:)-7fafw``.
+/// ``Superwall/configure(apiKey:delegate:purchaseController:options:completion:)-5y99b``.
 ///
 /// When implementing this, you also need to set the subscription status using
 /// ``Superwall/subscriptionStatus``.

--- a/Sources/SuperwallKit/Delegate/Subscription Controller/PurchaseControllerObjc.swift
+++ b/Sources/SuperwallKit/Delegate/Subscription Controller/PurchaseControllerObjc.swift
@@ -12,18 +12,18 @@ import StoreKit
 ///
 /// By default, the Superwall SDK handles all subscription-related logic.
 ///
-/// However, if you'd like more control, you can return a ``SubscriptionControllerObjc`` in
+/// However, if you'd like more control, you can return a ``PurchaseControllerObjc`` in
 /// the delegate when configuring the SDK via
 /// ``Superwall/configure(apiKey:delegate:options:completion:)-7fafw``.
 ///
 /// When implementing this, you also need to set the subscription status using
 /// ``Superwall/subscriptionStatus``.
 ///
-/// To learn how to implement the ``SubscriptionControllerObjc`` in your app
+/// To learn how to implement the ``PurchaseControllerObjc`` in your app
 /// and best practices, see <doc:AdvancedConfiguration>.
 @MainActor
-@objc(SWKSubscriptionController)
-public protocol SubscriptionControllerObjc: AnyObject {
+@objc(SWKPurchaseController)
+public protocol PurchaseControllerObjc: AnyObject {
   /// Called when the user initiates purchasing of a product.
   ///
   /// Add your purchase logic here and call the completion block with the result. You can use Apple's StoreKit APIs,

--- a/Sources/SuperwallKit/Delegate/SuperwallDelegate.swift
+++ b/Sources/SuperwallKit/Delegate/SuperwallDelegate.swift
@@ -15,8 +15,6 @@ import Foundation
 /// 
 /// To learn how to conform to the delegate in your app and best practices, see <doc:AdvancedConfiguration>.
 public protocol SuperwallDelegate: AnyObject {
-  func subscriptionController() -> SubscriptionController?
-
   /// Called when the user taps an element on your paywall that has the click action `Custom action`,
   /// or a `data-pw-custom` tag attached.
   ///
@@ -98,10 +96,6 @@ public protocol SuperwallDelegate: AnyObject {
 }
 
 public extension SuperwallDelegate {
-  func subscriptionController() -> SubscriptionController? {
-    return nil
-  }
-
   func handleCustomPaywallAction(withName name: String) {}
 
   func willDismissPaywall() {}

--- a/Sources/SuperwallKit/Delegate/SuperwallDelegate.swift
+++ b/Sources/SuperwallKit/Delegate/SuperwallDelegate.swift
@@ -11,7 +11,7 @@ import Foundation
 ///
 /// The delegate methods receive callbacks from the SDK in response to certain events that happen on the paywall.
 ///
-/// You pass this in when configuring the SDK via ``Superwall/configure(apiKey:delegate:options:completion:)-7fafw``.
+/// You pass this in when configuring the SDK via ``Superwall/configure(apiKey:delegate:purchaseController:options:completion:)-5y99b``.
 /// 
 /// To learn how to conform to the delegate in your app and best practices, see <doc:AdvancedConfiguration>.
 public protocol SuperwallDelegate: AnyObject {

--- a/Sources/SuperwallKit/Delegate/SuperwallDelegateAdapter.swift
+++ b/Sources/SuperwallKit/Delegate/SuperwallDelegateAdapter.swift
@@ -10,12 +10,13 @@ import Combine
 
 /// An adapter between the internal SDK and the public swift/objective c delegate.
 final class SuperwallDelegateAdapter {
-  var hasSubscriptionController: Bool {
-    return swiftDelegate?.subscriptionController() != nil
-      || objcDelegate?.subscriptionController?() != nil
+  var hasPurchaseController: Bool {
+    return swiftPurchaseController != nil || objcPurchaseController != nil
   }
   weak var swiftDelegate: SuperwallDelegate?
   weak var objcDelegate: SuperwallDelegateObjc?
+  weak var swiftPurchaseController: PurchaseController?
+  weak var objcPurchaseController: PurchaseControllerObjc?
 
 /// Called on init of the Superwall instance via ``Superwall/configure(apiKey:delegate:options:completion:)-7fafw``.
   ///
@@ -23,10 +24,14 @@ final class SuperwallDelegateAdapter {
   /// separately to the initial ``Superwall/configure(apiKey:delegate:options:completion:)-7fafw`` function.
   init(
     swiftDelegate: SuperwallDelegate?,
-    objcDelegate: SuperwallDelegateObjc?
+    objcDelegate: SuperwallDelegateObjc?,
+    swiftPurchaseController: PurchaseController?,
+    objcPurchaseController: PurchaseControllerObjc?
   ) {
     self.swiftDelegate = swiftDelegate
     self.objcDelegate = objcDelegate
+    self.swiftPurchaseController = swiftPurchaseController
+    self.objcPurchaseController = objcPurchaseController
   }
 
   @MainActor
@@ -143,23 +148,17 @@ extension SuperwallDelegateAdapter: ProductPurchaser {
   func purchase(
     product: StoreProduct
   ) async -> PurchaseResult {
-    if let swiftDelegate = swiftDelegate {
-      guard let subscriptionController = swiftDelegate.subscriptionController() else {
-        return .failed(PurchaseError.noSubscriptionController)
-      }
+    if let purchaseController = swiftPurchaseController {
       guard let sk1Product = product.sk1Product else {
         return .failed(PurchaseError.productUnavailable)
       }
-      return await subscriptionController.purchase(product: sk1Product)
-    } else if let objcDelegate = objcDelegate {
-      guard let subscriptionController = objcDelegate.subscriptionController?() else {
-        return .failed(PurchaseError.noSubscriptionController)
-      }
+      return await purchaseController.purchase(product: sk1Product)
+    } else if let purchaseController = objcPurchaseController {
       guard let sk1Product = product.sk1Product else {
         return .failed(PurchaseError.productUnavailable)
       }
       return await withCheckedContinuation { continuation in
-        subscriptionController.purchase(product: sk1Product) { result, error in
+        purchaseController.purchase(product: sk1Product) { result, error in
           if let error = error {
             continuation.resume(returning: .failed(error))
           } else {
@@ -186,17 +185,11 @@ extension SuperwallDelegateAdapter: TransactionRestorer {
   @MainActor
   func restorePurchases() async -> Bool {
     var didRestore = false
-    if let swiftDelegate = swiftDelegate {
-      guard let subscriptionController = swiftDelegate.subscriptionController() else {
-        return false
-      }
-      didRestore = await subscriptionController.restorePurchases()
-    } else if let objcDelegate = objcDelegate {
-      guard let subscriptionController = objcDelegate.subscriptionController?() else {
-        return false
-      }
+    if let purchaseController = swiftPurchaseController {
+      didRestore = await purchaseController.restorePurchases()
+    } else if let purchaseController = objcPurchaseController {
       didRestore = await withCheckedContinuation { continuation in
-        subscriptionController.restorePurchases { didRestore in
+        purchaseController.restorePurchases { didRestore in
           continuation.resume(returning: didRestore)
         }
       }

--- a/Sources/SuperwallKit/Delegate/SuperwallDelegateAdapter.swift
+++ b/Sources/SuperwallKit/Delegate/SuperwallDelegateAdapter.swift
@@ -18,10 +18,10 @@ final class SuperwallDelegateAdapter {
   weak var swiftPurchaseController: PurchaseController?
   weak var objcPurchaseController: PurchaseControllerObjc?
 
-/// Called on init of the Superwall instance via ``Superwall/configure(apiKey:delegate:options:completion:)-7fafw``.
+/// Called on init of the Superwall instance via ``Superwall/configure(apiKey:delegate:purchaseController:options:completion:)-5y99b``.
   ///
   /// We check to see if the delegates being set are non-nil because they may have been set
-  /// separately to the initial ``Superwall/configure(apiKey:delegate:options:completion:)-7fafw`` function.
+  /// separately to the initial ``Superwall/configure(apiKey:delegate:purchaseController:options:completion:)-5y99b`` function.
   init(
     swiftDelegate: SuperwallDelegate?,
     objcDelegate: SuperwallDelegateObjc?,

--- a/Sources/SuperwallKit/Delegate/SuperwallDelegateObjc.swift
+++ b/Sources/SuperwallKit/Delegate/SuperwallDelegateObjc.swift
@@ -11,7 +11,7 @@ import Foundation
 ///
 /// The delegate methods receive callbacks from the SDK in response to certain events that happen on the paywall.
 ///
-/// You pass this in when configuring the SDK via ``Superwall/configure(apiKey:delegate:options:completion:)-7fafw``.
+/// You pass this in when configuring the SDK via ``Superwall/configure(apiKey:delegate:purchaseController:options:completion:)-5y99b``.
 ///
 /// To learn how to conform to the delegate in your app and best practices, see <doc:AdvancedConfiguration>.
 @objc(SWKSuperwallDelegate)

--- a/Sources/SuperwallKit/Delegate/SuperwallDelegateObjc.swift
+++ b/Sources/SuperwallKit/Delegate/SuperwallDelegateObjc.swift
@@ -16,8 +16,6 @@ import Foundation
 /// To learn how to conform to the delegate in your app and best practices, see <doc:AdvancedConfiguration>.
 @objc(SWKSuperwallDelegate)
 public protocol SuperwallDelegateObjc: AnyObject {
-  @objc optional func subscriptionController() -> SubscriptionControllerObjc?
-
   /// Called when the user taps a button on your paywall that has a `data-pw-custom` tag attached.
   ///
   /// To learn more about using this function, see <doc:CustomPaywallButtons>. To learn about the types of tags that
@@ -73,7 +71,7 @@ public protocol SuperwallDelegateObjc: AnyObject {
   /// Alternatively, you can use the published properties of ``Superwall/subscriptionStatus``
   /// to react to changes as they happen.
   ///
-  /// - Note: If you are implementing a ``SubscriptionController`` to handle your apps subscription-related
+  /// - Note: If you are implementing a ``PurchaseController`` to handle your apps subscription-related
   /// logic, you should rely on your own logic and not this method.
   ///
   /// - Parameters:

--- a/Sources/SuperwallKit/Dependencies/DependencyContainer.swift
+++ b/Sources/SuperwallKit/Dependencies/DependencyContainer.swift
@@ -41,12 +41,16 @@ final class DependencyContainer {
   init(
     swiftDelegate: SuperwallDelegate? = nil,
     objcDelegate: SuperwallDelegateObjc? = nil,
+    swiftPurchaseController: PurchaseController? = nil,
+    objcPurchaseController: PurchaseControllerObjc? = nil,
     options: SuperwallOptions? = nil
   ) {
     storeKitManager = StoreKitManager(factory: self)
     delegateAdapter = SuperwallDelegateAdapter(
       swiftDelegate: swiftDelegate,
-      objcDelegate: objcDelegate
+      objcDelegate: objcDelegate,
+      swiftPurchaseController: swiftPurchaseController,
+      objcPurchaseController: objcPurchaseController
     )
     localizationManager = LocalizationManager()
     storage = Storage(factory: self)

--- a/Sources/SuperwallKit/Documentation.docc/AdvancedConfiguration.md
+++ b/Sources/SuperwallKit/Documentation.docc/AdvancedConfiguration.md
@@ -4,13 +4,12 @@ Use options and custom subscription-related logic for more control over the SDK.
 
 ## Overview
 
-By default, Superwall handles all subscription-related logic. However, if you're using RevenueCat, or you just want more control, you can return a ``SuperwallKit/SubscriptionController`` in
- the delegate when configuring the SDK via
- ``Superwall/configure(apiKey:delegate:options:completion:)-7fafw``. In addition, you can customise aspects of the SDK by passing in a ``SuperwallOptions`` object on configure.
+By default, Superwall handles all subscription-related logic. However, if you're using RevenueCat, or you just want more control, you can return a ``PurchaseController`` when configuring the SDK via
+ ``Superwall/configure(apiKey:delegate:purchaseController:options:completion:)-5y99b``. In addition, you can customise aspects of the SDK by passing in a ``SuperwallOptions`` object on configure.
 
 ## Creating a Subscription Controller
 
-A subscription controller handles purchasing and restoring via protocol methods that you implement. You return your subscription controller via a `subscriptionController()` method in the ``SuperwallDelegate``, which you pass in when configuring the SDK:
+A purchase controller handles purchasing and restoring via protocol methods that you implement. You pass in your purchase controller when configuring the SDK:
 
 ```swift
 import SuperwallKit
@@ -22,20 +21,13 @@ final class SuperwallService {
   static func initialize() {
     Superwall.configure(
       apiKey: apiKey,
-      delegate: shared
+      purchaseController: shared
     )
   }
 }
 
-// MARK: - Superwall Delegate
-extension SuperwallService: SuperwallDelegate {
-  func subscriptionController() -> SubscriptionController {
-    return self
-  }
-}
-
-// MARK: - SubscriptionController
-extension SuperwallService: SubscriptionController {
+// MARK: - PurchaseController
+extension SuperwallService: PurchaseController {
   // 1
   func purchase(product: SKProduct) async -> PurchaseResult {
     // TODO: Purchase the product here and return its result.
@@ -51,9 +43,9 @@ extension SuperwallService: SubscriptionController {
 }
 ```
 
-All methods of the ``SubscriptionController`` are mandatory and receive callbacks from the SDK in response to certain events that happen on the paywall. It is up to you to fill these methods with the appropriate code. Here's what each method is responsible for:
+All methods of the ``PurchaseController`` are mandatory and receive callbacks from the SDK in response to certain events that happen on the paywall. It is up to you to fill these methods with the appropriate code. Here's what each method is responsible for:
 
-1. Purchasing a given product. In here, enter your code that you use to purchase a product. If you're using RevenueCat, you'll need to turn off StoreKit2 when initialising the SDK. Then, handle the result by returning a `PurchaseResult`. This is an enum that contains the following cases, all of which must be handled. Check out our example apps for further information about handling these cases:
+1. Purchasing a given product. In here, enter your code that you use to purchase a product. If you're using RevenueCat, you _can_ use StoreKit2 but it's recommended not to. Then, handle the result by returning a ``PurchaseResult``. This is an enum that contains the following cases, all of which must be handled. Check out our example apps for further information about handling these cases:
     - `.cancelled`: The purchase was cancelled.
     - `.purchased`: The product was purchased.
     - `.pending`: The purchase is pending and requires action from the developer.
@@ -63,7 +55,7 @@ All methods of the ``SubscriptionController`` are mandatory and receive callback
 
 ## Setting User Subscription Status
 
-In addition to creating a `SubscriptionController`, you need to tell the SDK the user's subscription status every time it changes. To do this, you need to set ``Superwall/subscriptionStatus``:
+In addition to providing a `PurchaseController`, you need to tell the SDK the user's subscription status every time it changes. To do this, you need to set ``Superwall/subscriptionStatus``:
 
 ```
   Superwall.shared.subscriptionStatus = .active

--- a/Sources/SuperwallKit/Documentation.docc/Extensions/SuperwallExtension.md
+++ b/Sources/SuperwallKit/Documentation.docc/Extensions/SuperwallExtension.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-The ``Superwall`` class is used to access all the features of the SDK. Before using any of the features, you must call ``Superwall/configure(apiKey:delegate:options:completion:)-7fafw`` to configure the SDK.
+The ``Superwall`` class is used to access all the features of the SDK. Before using any of the features, you must call ``Superwall/configure(apiKey:delegate:purchaseController:options:completion:)-5y99b`` to configure the SDK.
 
 ## Topics
 
@@ -11,8 +11,8 @@ The ``Superwall`` class is used to access all the features of the SDK. Before us
 - <doc:GettingStarted>
 - <doc:Ecosystem>
 - <doc:AdvancedConfiguration>
-- ``configure(apiKey:delegate:options:completion:)-7fafw``
-- ``configure(apiKey:delegate:options:completion:)-ogg1``
+- ``configure(apiKey:delegate:purchaseController:options:completion:)-5y99b``
+- ``configure(apiKey:delegate:purchaseController:options:completion:)-2x9j3``
 - ``shared``
 - ``SuperwallDelegate``
 - ``SuperwallDelegateObjc``
@@ -24,7 +24,6 @@ The ``Superwall`` class is used to access all the features of the SDK. Before us
 - ``SubscriptionStatus``
 - ``SuperwallOptions``
 - ``PaywallOptions``
-- ``options``
 - ``preloadAllPaywalls()``
 - ``preloadPaywalls(forEvents:)``
 
@@ -36,7 +35,7 @@ The ``Superwall`` class is used to access all the features of the SDK. Before us
 - ``getTrackResult(forEvent:params:)``
 - ``getTrackResult(forEvent:params:completion:)``
 - ``getTrackInfo(forEvent:params:)``
-- ``publisher(forEvent:params:paywallOverrides:)``
+- ``publisher(forEvent:params:presenter:paywallOverrides:)``
 - ``dismiss()``
 - ``dismiss(completion:)``
 - ``PaywallInfo``

--- a/Sources/SuperwallKit/Documentation.docc/Extensions/SuperwallExtension.md
+++ b/Sources/SuperwallKit/Documentation.docc/Extensions/SuperwallExtension.md
@@ -18,8 +18,8 @@ The ``Superwall`` class is used to access all the features of the SDK. Before us
 - ``SuperwallDelegateObjc``
 - ``delegate``
 - ``objcDelegate``
-- ``SubscriptionController``
-- ``SubscriptionControllerObjc``
+- ``PurchaseController``
+- ``PurchaseControllerObjc``
 - ``subscriptionStatus``
 - ``SubscriptionStatus``
 - ``SuperwallOptions``

--- a/Sources/SuperwallKit/Documentation.docc/GettingStarted.md
+++ b/Sources/SuperwallKit/Documentation.docc/GettingStarted.md
@@ -4,7 +4,7 @@ Configuring the SDK.
 
 ## Overview
 
-To get up and running, you need to get your **API Key** from the Superwall Dashboard. You then configure the SDK using ``Superwall/configure(apiKey:delegate:options:completion:)-7fafw`` and then present your paywall.
+To get up and running, you need to get your **API Key** from the Superwall Dashboard. You then configure the SDK using ``Superwall/configure(apiKey:delegate:purchaseController:options:completion:)-5y99b`` and then present your paywall.
 
 ## Getting your API Key
 
@@ -17,7 +17,7 @@ On that page, you will see your **Public API Key**. Copy this for the next step.
 
 ### Configuring the SDK
 
-To configure the SDK, you must call ``Superwall/configure(apiKey:delegate:options:completion:)-7fafw`` as soon as your app launches from `application(_:didFinishLaunchingWithOptions:)`:
+To configure the SDK, you must call ``Superwall/configure(apiKey:delegate:purchaseController:options:completion:)-5y99b`` as soon as your app launches from `application(_:didFinishLaunchingWithOptions:)`:
 
 ```swift
 import SuperwallKit

--- a/Sources/SuperwallKit/Documentation.docc/SuperwallKit.md
+++ b/Sources/SuperwallKit/Documentation.docc/SuperwallKit.md
@@ -18,6 +18,6 @@ Superwall makes it easy to show paywalls in your app using UIKit or SwiftUI. If 
 
 ### The Delegate
 - ``SuperwallDelegate``
-- ``SubscriptionController``
+- ``PurchaseController``
 - <doc:CustomPaywallButtons>
 - <doc:ThirdPartyAnalytics>

--- a/Sources/SuperwallKit/Identity/PublicIdentity.swift
+++ b/Sources/SuperwallKit/Identity/PublicIdentity.swift
@@ -38,6 +38,20 @@ public extension Superwall {
   ///
   ///  - Parameters:
   ///     - userId: Your user's unique identifier, as defined by your backend system.
+  ///  - Throws: An error of type ``IdentityError``.
+  @available(swift, obsoleted: 1.0)
+  @objc func identify(
+    userId: String
+  ) async throws {
+    try await identify(userId: userId)
+  }
+
+  /// Creates an account with Superwall. This links a `userId` to Superwall's automatically generated alias.
+  ///
+  /// Call this as soon as you have a `userId`.
+  ///
+  ///  - Parameters:
+  ///     - userId: Your user's unique identifier, as defined by your backend system.
   ///     - options: An ``IdentityOptions`` object, whose property
   ///     ``IdentityOptions/restorePaywallAssignments`` you can set to `true`
   ///     to tell the SDK to wait to restore paywall assignments from the server before presenting any paywalls.

--- a/Sources/SuperwallKit/Paywall/Presentation/PublicPresentation.swift
+++ b/Sources/SuperwallKit/Paywall/Presentation/PublicPresentation.swift
@@ -4,7 +4,7 @@
 //
 //  Created by Jake Mor on 10/9/21.
 //
-// swiftlint:disable line_length
+// swiftlint:disable line_length file_length
 
 import Foundation
 import Combine
@@ -67,14 +67,23 @@ public extension Superwall {
   ///
   /// - Parameters:
   ///   -  event: The name of the event you wish to track.
-  ///   - params: Optional parameters you'd like to pass with your event. These can be referenced within the rules of your campaign. Keys beginning with `$` are reserved for Superwall and will be dropped. Values can be any JSON encodable value, URLs or Dates. Arrays and dictionaries as values are not supported at this time, and will be dropped.
-  ///   - presenter: An optional `UIViewController` from which to present the paywall from. If you don't provide one, the paywall will present from a new `UIViewController` in a new `UIWindow`. Defaults to `nil`.
-  ///   - products: An optional ``PaywallProducts`` object whose products replace the remotely defined paywall products. Defauls to `nil`.
+  ///   - params: Optional parameters you'd like to pass with your event. These can be referenced within the rules of your campaign.
+  ///   Keys beginning with `$` are reserved for Superwall and will be dropped. Values can be any JSON encodable value, URLs or Dates.
+  ///    Arrays and dictionaries as values are not supported at this time, and will be dropped.
+  ///   - presenter: An optional `UIViewController` from which to present the paywall from. If you don't provide one, the paywall
+  ///    will present from a new `UIViewController` in a new `UIWindow`. Defaults to `nil`.
+  ///   - products: An optional ``PaywallProducts`` object whose products replace the remotely defined paywall products. Defaults
+  ///    to `nil`.
   ///   - ignoreSubscriptionStatus: Presents the paywall regardless of subscription status if `true`. Defaults to `false`.
-  ///   - presentationStyleOverride: A `PaywallPresentationStyle` object that overrides the presentation style of the paywall set on the dashboard. Defaults to `.none`.
-  ///   - onPresent: A completion block that gets called immediately after the paywall is presented. Defaults to `nil`.  Accepts a ``PaywallInfo`` object containing information about the paywall.
-  ///   - onDismiss: A completion block that gets called when the paywall is dismissed by the user, by way of purchasing, restoring or manually dismissing. Defaults to `nil`. Accepts a `Bool` that is `true` if the user purchased a product and `false` if not, a `String?` equal to the product id of the purchased product (if any) and a ``PaywallInfo`` object containing information about the paywall.
-  ///   - onSkip: A completion block that gets called when the paywall's presentation is skipped. Defaults to `nil`.  Accepts a ``PaywallSkippedReasonObjc`` object and an `NSError` with more details.
+  ///   - presentationStyleOverride: A `PaywallPresentationStyle` object that overrides the presentation style of the paywall
+  ///   set on the dashboard. Defaults to `.none`.
+  ///   - onPresent: A completion block that gets called immediately after the paywall is presented. Defaults to `nil`.  Accepts a
+  ///   ``PaywallInfo`` object containing information about the paywall.
+  ///   - onDismiss: A completion block that gets called when the paywall is dismissed by the user, by way of purchasing, restoring or manually
+  ///    dismissing. Defaults to `nil`. Accepts a `Bool` that is `true` if the user purchased a product and `false` if not, a `String?` equal
+  ///     to the product id of the purchased product (if any) and a ``PaywallInfo`` object containing information about the paywall.
+  ///   - onSkip: A completion block that gets called when the paywall's presentation is skipped. Defaults to `nil`.  Accepts a
+  ///   ``PaywallSkippedReasonObjc`` object and an `NSError` with more details.
   @available(swift, obsoleted: 1.0)
   @objc func track(
     event: String,
@@ -87,7 +96,7 @@ public extension Superwall {
     onPresent: ((PaywallInfo) -> Void)? = nil,
     onDismiss: ((PaywallDismissedResultStateObjc, String?, PaywallInfo) -> Void)? = nil
   ) {
-    internalObjcTrack(
+    objcTrack(
       event: event,
       params: params,
       presenter: presenter,
@@ -100,7 +109,7 @@ public extension Superwall {
     )
   }
 
-  private func internalObjcTrack(
+  private func objcTrack(
     event: String,
     params: [String: Any]? = nil,
     presenter: UIViewController? = nil,
@@ -205,13 +214,20 @@ public extension Superwall {
     }
   }
 
-  /// An Objective-C-only method that shows a paywall to the user when: An event you provide is tied to an active trigger inside a campaign on the [Superwall Dashboard](https://superwall.com/dashboard); and the user matches a rule in the campaign. **Note**: Please use ``SuperwallKit/Superwall/setUserAttributes(_:)`` if you’re using Swift.
+  /// An Objective-C-only method that shows a paywall to the user when: An event you provide is tied to an
+  /// active trigger inside a campaign on the [Superwall Dashboard](https://superwall.com/dashboard);
+  ///  and the user matches a rule in the campaign. **Note**: Please use ``SuperwallKit/Superwall/setUserAttributes(_:)``
+  ///   if you’re using Swift.
   ///
-  /// Triggers enable you to retroactively decide where or when to show a specific paywall in your app. Use this method when you want to remotely control paywall presentation in response to your own analytics event and utilize completion handlers associated with the paywall presentation state.
+  /// Triggers enable you to retroactively decide where or when to show a specific paywall in your app. Use this method
+  ///  when you want to remotely control paywall presentation in response to your own analytics event and utilize
+  ///   completion handlers associated with the paywall presentation state.
   ///
-  /// Before using this method, you'll first need to create a campaign and add a trigger associated with the event name on the [Superwall Dashboard](https://superwall.com/dashboard).
+  /// Before using this method, you'll first need to create a campaign and add a trigger associated with the event name
+  ///  on the [Superwall Dashboard](https://superwall.com/dashboard).
   ///
-  /// The paywall shown to the user is determined by the rules defined in the campaign. Paywalls are sticky, in that when a user is assigned a paywall within a rule, they will continue to see that paywall unless you remove the paywall from the rule.
+  /// The paywall shown to the user is determined by the rules defined in the campaign. Paywalls are sticky, in that when
+  ///  a user is assigned a paywall within a rule, they will continue to see that paywall unless you remove the paywall from the rule.
   ///
   /// For more information, see <doc:TrackingEvents>.
   ///
@@ -219,45 +235,65 @@ public extension Superwall {
   ///   -  event: The name of the event you wish to track.
   @available(swift, obsoleted: 1.0)
   @objc func track(event: String) {
-    track(event: event)
+    objcTrack(event: event)
   }
 
-  /// An Objective-C-only method that shows a paywall to the user when: An event you provide is tied to an active trigger inside a campaign on the [Superwall Dashboard](https://superwall.com/dashboard); and the user matches a rule in the campaign. **Note**: Please use ``SuperwallKit/Superwall/setUserAttributes(_:)`` if you’re using Swift.
+  /// An Objective-C-only method that shows a paywall to the user when: An event you provide is tied to an
+  /// active trigger inside a campaign on the [Superwall Dashboard](https://superwall.com/dashboard);
+  ///  and the user matches a rule in the campaign. **Note**: Please use ``SuperwallKit/Superwall/setUserAttributes(_:)``
+  ///   if you’re using Swift.
   ///
-  /// Triggers enable you to retroactively decide where or when to show a specific paywall in your app. Use this method when you want to remotely control paywall presentation in response to your own analytics event and utilize completion handlers associated with the paywall presentation state.
+  /// Triggers enable you to retroactively decide where or when to show a specific paywall in your app. Use this method
+  ///  when you want to remotely control paywall presentation in response to your own analytics event and utilize
+  ///   completion handlers associated with the paywall presentation state.
   ///
-  /// Before using this method, you'll first need to create a campaign and add a trigger associated with the event name on the [Superwall Dashboard](https://superwall.com/dashboard).
+  /// Before using this method, you'll first need to create a campaign and add a trigger associated with the event name
+  ///  on the [Superwall Dashboard](https://superwall.com/dashboard).
   ///
-  /// The paywall shown to the user is determined by the rules defined in the campaign. Paywalls are sticky, in that when a user is assigned a paywall within a rule, they will continue to see that paywall unless you remove the paywall from the rule.
+  /// The paywall shown to the user is determined by the rules defined in the campaign. Paywalls are sticky, in that when
+  ///  a user is assigned a paywall within a rule, they will continue to see that paywall unless you remove the paywall from the rule.
   ///
   /// For more information, see <doc:TrackingEvents>.
   ///
   /// - Parameters:
   ///   -  event: The name of the event you wish to track.
-  ///   - params: Optional parameters you'd like to pass with your event. These can be referenced within the rules of your campaign. Keys beginning with `$` are reserved for Superwall and will be dropped. Values can be any JSON encodable value, URLs or Dates. Arrays and dictionaries as values are not supported at this time, and will be dropped.
+  ///   - params: Optional parameters you'd like to pass with your event. These can be referenced within the rules of your campaign.
+  ///   Keys beginning with `$` are reserved for Superwall and will be dropped. Values can be any JSON encodable value, URLs or Dates.
+  ///    Arrays and dictionaries as values are not supported at this time, and will be dropped.
   @available(swift, obsoleted: 1.0)
   @objc func track(
     event: String,
     params: [String: Any]? = nil
   ) {
-    track(event: event, params: params)
+    objcTrack(event: event, params: params)
   }
 
-  /// An Objective-C-only method that shows a paywall to the user when: An event you provide is tied to an active trigger inside a campaign on the [Superwall Dashboard](https://superwall.com/dashboard); and the user matches a rule in the campaign. **Note**: Please use ``SuperwallKit/Superwall/setUserAttributes(_:)`` if you’re using Swift.
+  /// An Objective-C-only method that shows a paywall to the user when: An event you provide is tied to an
+  /// active trigger inside a campaign on the [Superwall Dashboard](https://superwall.com/dashboard);
+  ///  and the user matches a rule in the campaign. **Note**: Please use ``SuperwallKit/Superwall/setUserAttributes(_:)``
+  ///   if you’re using Swift.
   ///
-  /// Triggers enable you to retroactively decide where or when to show a specific paywall in your app. Use this method when you want to remotely control paywall presentation in response to your own analytics event and utilize completion handlers associated with the paywall presentation state.
+  /// Triggers enable you to retroactively decide where or when to show a specific paywall in your app. Use this method
+  ///  when you want to remotely control paywall presentation in response to your own analytics event and utilize
+  ///   completion handlers associated with the paywall presentation state.
   ///
-  /// Before using this method, you'll first need to create a campaign and add a trigger associated with the event name on the [Superwall Dashboard](https://superwall.com/dashboard).
+  /// Before using this method, you'll first need to create a campaign and add a trigger associated with the event name
+  ///  on the [Superwall Dashboard](https://superwall.com/dashboard).
   ///
-  /// The paywall shown to the user is determined by the rules defined in the campaign. Paywalls are sticky, in that when a user is assigned a paywall within a rule, they will continue to see that paywall unless you remove the paywall from the rule.
+  /// The paywall shown to the user is determined by the rules defined in the campaign. Paywalls are sticky, in that when
+  ///  a user is assigned a paywall within a rule, they will continue to see that paywall unless you remove the paywall from the rule.
   ///
   /// For more information, see <doc:TrackingEvents>.
   ///
   /// - Parameters:
   ///   -  event: The name of the event you wish to track.
-  ///   - onPresent: A completion block that gets called immediately after the paywall is presented. Defaults to `nil`.  Accepts a ``PaywallInfo`` object containing information about the paywall.
-  ///   - onDismiss: A completion block that gets called when the paywall is dismissed by the user, by way of purchasing, restoring or manually dismissing. Defaults to `nil`. Accepts a `Bool` that is `true` if the user purchased a product and `false` if not, a `String?` equal to the product id of the purchased product (if any) and a ``PaywallInfo`` object containing information about the paywall.
-  ///   - onSkip: A completion block that gets called when the paywall's presentation is skipped. Defaults to `nil`.  Accepts a ``PaywallSkippedReasonObjc`` object and an `NSError` with more details.
+  ///   - onPresent: A completion block that gets called immediately after the paywall is presented. Defaults to `nil`.  Accepts a
+  ///   ``PaywallInfo`` object containing information about the paywall.
+  ///   - onDismiss: A completion block that gets called when the paywall is dismissed by the user, by way of purchasing, restoring or manually
+  ///    dismissing. Defaults to `nil`. Accepts a `Bool` that is `true` if the user purchased a product and `false` if not, a `String?` equal
+  ///     to the product id of the purchased product (if any) and a ``PaywallInfo`` object containing information about the paywall.
+  ///   - onSkip: A completion block that gets called when the paywall's presentation is skipped. Defaults to `nil`.  Accepts a
+  ///   ``PaywallSkippedReasonObjc`` object and an `NSError` with more details.
   @available(swift, obsoleted: 1.0)
   @objc func track(
     event: String,
@@ -265,7 +301,7 @@ public extension Superwall {
     onPresent: ((PaywallInfo) -> Void)? = nil,
     onDismiss: ((PaywallDismissedResultStateObjc, String?, PaywallInfo) -> Void)? = nil
   ) {
-    internalObjcTrack(
+    objcTrack(
       event: event,
       onSkip: onSkip,
       onPresent: onPresent,
@@ -273,27 +309,33 @@ public extension Superwall {
     )
   }
 
-  /// An Objective-C-only method that shows a paywall to the user when: An event you provide is tied to an active trigger inside a campaign on the [Superwall Dashboard](https://superwall.com/dashboard); and the user matches a rule in the campaign. **Note**: Please use ``SuperwallKit/Superwall/setUserAttributes(_:)`` if you’re using Swift.
+  /// An Objective-C-only method that shows a paywall to the user when: An event you provide is tied to an
+  /// active trigger inside a campaign on the [Superwall Dashboard](https://superwall.com/dashboard);
+  ///  and the user matches a rule in the campaign. **Note**: Please use ``SuperwallKit/Superwall/setUserAttributes(_:)``
+  ///   if you’re using Swift.
   ///
-  /// Triggers enable you to retroactively decide where or when to show a specific paywall in your app. Use this method when you want to remotely control paywall presentation in response to your own analytics event and utilize completion handlers associated with the paywall presentation state.
+  /// Triggers enable you to retroactively decide where or when to show a specific paywall in your app. Use this method
+  ///  when you want to remotely control paywall presentation in response to your own analytics event and utilize
+  ///   completion handlers associated with the paywall presentation state.
   ///
-  /// Before using this method, you'll first need to create a campaign and add a trigger associated with the event name on the [Superwall Dashboard](https://superwall.com/dashboard).
+  /// Before using this method, you'll first need to create a campaign and add a trigger associated with the event name
+  ///  on the [Superwall Dashboard](https://superwall.com/dashboard).
   ///
-  /// The paywall shown to the user is determined by the rules defined in the campaign. Paywalls are sticky, in that when a user is assigned a paywall within a rule, they will continue to see that paywall unless you remove the paywall from the rule.
+  /// The paywall shown to the user is determined by the rules defined in the campaign. Paywalls are sticky, in that when
+  ///  a user is assigned a paywall within a rule, they will continue to see that paywall unless you remove the paywall from the rule.
   ///
   /// For more information, see <doc:TrackingEvents>.
   ///
   /// - Parameters:
   ///   -  event: The name of the event you wish to track.
-  ///   - params: Optional parameters you'd like to pass with your event. These can be referenced within the rules of your campaign. Keys beginning with `$` are reserved for Superwall and will be dropped. Values can be any JSON encodable value, URLs or Dates. Arrays and dictionaries as values are not supported at this time, and will be dropped.
-  ///   - presenter: An optional `UIViewController` from which to present the paywall from. If you don't provide one, the paywall will present from a new `UIViewController` in a new `UIWindow`. Defaults to `nil`.
-  ///   - products: An optional ``PaywallProducts`` object whose products replace the remotely defined paywall products. Defauls to `nil`.
-  ///   - ignoreSubscriptionStatus: Presents the paywall regardless of subscription status if `true`. Defaults to `false`.
-  ///   - presentationStyleOverride: A `PaywallPresentationStyle` object that overrides the presentation style of the paywall set on the dashboard. Defaults to `.none`.
-  ///   - onPresent: A completion block that gets called immediately after the paywall is presented. Defaults to `nil`.  Accepts a ``PaywallInfo`` object containing information about the paywall.
-  ///   - onDismiss: A completion block that gets called when the paywall is dismissed by the user, by way of purchasing, restoring or manually dismissing. Defaults to `nil`. Accepts a `Bool` that is `true` if the user purchased a product and `false` if not, a `String?` equal to the product id of the purchased product (if any) and a ``PaywallInfo`` object containing information about the paywall.
-  ///   - onSkip: A completion block that gets called when the paywall's presentation is skipped. Defaults to `nil`.  Accepts a ``PaywallSkippedReasonObjc`` object and an `NSError` with more details.
-  @available(swift, obsoleted: 1.0)
+  ///   - params: Optional parameters you'd like to pass with your event. These can be referenced within the rules of your campaign.
+  ///   - onPresent: A completion block that gets called immediately after the paywall is presented. Defaults to `nil`.  Accepts a
+  ///   ``PaywallInfo`` object containing information about the paywall.
+  ///   - onDismiss: A completion block that gets called when the paywall is dismissed by the user, by way of purchasing, restoring or manually
+  ///    dismissing. Defaults to `nil`. Accepts a `Bool` that is `true` if the user purchased a product and `false` if not, a `String?` equal
+  ///     to the product id of the purchased product (if any) and a ``PaywallInfo`` object containing information about the paywall.
+  ///   - onSkip: A completion block that gets called when the paywall's presentation is skipped. Defaults to `nil`.  Accepts a
+  ///   ``PaywallSkippedReasonObjc`` object and an `NSError` with more details.@available(swift, obsoleted: 1.0)
   @objc func track(
     event: String,
     params: [String: Any]? = nil,
@@ -301,7 +343,7 @@ public extension Superwall {
     onPresent: ((PaywallInfo) -> Void)? = nil,
     onDismiss: ((PaywallDismissedResultStateObjc, String?, PaywallInfo) -> Void)? = nil
   ) {
-    internalObjcTrack(
+    objcTrack(
       event: event,
       params: params,
       onSkip: onSkip,

--- a/Sources/SuperwallKit/StoreKit/Coordinator/StoreKitCoordinator.swift
+++ b/Sources/SuperwallKit/StoreKit/Coordinator/StoreKitCoordinator.swift
@@ -46,8 +46,8 @@ struct StoreKitCoordinator {
       self.txnChecker = sk1ProductPurchaser
     }
 
-    let hasSubscriptionController = delegateAdapter.hasSubscriptionController
-    if hasSubscriptionController {
+    let hasPurchaseController = delegateAdapter.hasPurchaseController
+    if hasPurchaseController {
       self.productPurchaser = delegateAdapter
       self.txnRestorer = delegateAdapter
     } else {
@@ -60,8 +60,8 @@ struct StoreKitCoordinator {
   ///
   /// Called when a user updates the delegate.
   mutating func didToggleDelegate() {
-    let hasSubscriptionController = delegateAdapter.hasSubscriptionController
-    if hasSubscriptionController {
+    let hasPurchaseController = delegateAdapter.hasPurchaseController
+    if hasPurchaseController {
       self.productPurchaser = delegateAdapter
       self.txnRestorer = delegateAdapter
     } else {

--- a/Sources/SuperwallKit/StoreKit/StoreKitManager.swift
+++ b/Sources/SuperwallKit/StoreKit/StoreKitManager.swift
@@ -133,7 +133,7 @@ extension StoreKitManager {
 
   /// Loads the purchased products from the receipt,
   nonisolated func loadPurchasedProducts() async {
-    if Superwall.shared.dependencyContainer.delegateAdapter.hasSubscriptionController {
+    if Superwall.shared.dependencyContainer.delegateAdapter.hasPurchaseController {
       return
     }
     Logger.debug(

--- a/Sources/SuperwallKit/StoreKit/Transactions/Purchasing/ProductPurchaserSK1.swift
+++ b/Sources/SuperwallKit/StoreKit/Transactions/Purchasing/ProductPurchaserSK1.swift
@@ -276,9 +276,9 @@ extension ProductPurchaserSK1: SKPaymentTransactionObserver {
     }
   }
 
-  /// Finishes transactions only if the delegate doesn't return a ``SubscriptionController``.
+  /// Finishes transactions only if the delegate doesn't return a ``PurchaseController``.
   private func finishIfPossible(_ transaction: SKPaymentTransaction) {
-    if delegateAdapter.hasSubscriptionController {
+    if delegateAdapter.hasPurchaseController {
       return
     }
 

--- a/Sources/SuperwallKit/StoreKit/Transactions/Purchasing/PurchaseManager.swift
+++ b/Sources/SuperwallKit/StoreKit/Transactions/Purchasing/PurchaseManager.swift
@@ -13,7 +13,6 @@ enum PurchaseError: LocalizedError {
   case unknown
   case noTransactionDetected
   case unverifiedTransaction
-  case noSubscriptionController
 
   var errorDescription: String? {
     switch self {
@@ -23,8 +22,6 @@ enum PurchaseError: LocalizedError {
       return "No receipt was found on device for the product transaction."
     case .unverifiedTransaction:
       return "The product transaction could not be verified."
-    case .noSubscriptionController:
-      return "No Subscription Controller found."
     case .unknown:
       return "An unknown error occurred."
     }

--- a/Sources/SuperwallKit/Superwall.swift
+++ b/Sources/SuperwallKit/Superwall.swift
@@ -1,4 +1,4 @@
-// swiftlint:disable file_length
+// swiftlint:disable file_length type_body_length
 
 import Foundation
 import StoreKit

--- a/Sources/SuperwallKit/Superwall.swift
+++ b/Sources/SuperwallKit/Superwall.swift
@@ -92,9 +92,8 @@ public final class Superwall: NSObject, ObservableObject {
 
   /// A published property that indicates the subscription status of the user.
   ///
-  /// If you're handling subscription-related logic yourself via a
-  /// ``SubscriptionController``, you must set this property whenever
-  /// the subscription status of a user changes.
+  /// If you're handling subscription-related logic yourself, you must set this
+  /// property whenever the subscription status of a user changes.
   /// However, if you're letting Superwall handle subscription-related logic, its value will
   /// be synced with the user's purchases on device.
   ///
@@ -182,12 +181,16 @@ public final class Superwall: NSObject, ObservableObject {
     apiKey: String,
     swiftDelegate: SuperwallDelegate? = nil,
     objcDelegate: SuperwallDelegateObjc? = nil,
+    swiftPurchaseController: PurchaseController? = nil,
+    objcPurchaseController: PurchaseControllerObjc? = nil,
     options: SuperwallOptions? = nil,
     completion: (() -> Void)?
   ) {
     let dependencyContainer = DependencyContainer(
       swiftDelegate: swiftDelegate,
       objcDelegate: objcDelegate,
+      swiftPurchaseController: swiftPurchaseController,
+      objcPurchaseController: objcPurchaseController,
       options: options
     )
     self.init(dependencyContainer: dependencyContainer)
@@ -267,6 +270,7 @@ public final class Superwall: NSObject, ObservableObject {
   public static func configure(
     apiKey: String,
     delegate: SuperwallDelegate? = nil,
+    purchaseController: PurchaseController? = nil,
     options: SuperwallOptions? = nil,
     completion: (() -> Void)? = nil
   ) -> Superwall {
@@ -282,6 +286,8 @@ public final class Superwall: NSObject, ObservableObject {
       apiKey: apiKey,
       swiftDelegate: delegate,
       objcDelegate: nil,
+      swiftPurchaseController: purchaseController,
+      objcPurchaseController: nil,
       options: options,
       completion: completion
     )
@@ -302,6 +308,7 @@ public final class Superwall: NSObject, ObservableObject {
   public static func configure(
     apiKey: String,
     delegate: SuperwallDelegateObjc? = nil,
+    purchaseController: PurchaseControllerObjc? = nil,
     options: SuperwallOptions? = nil,
     completion: (() -> Void)? = nil
   ) -> Superwall {
@@ -317,6 +324,8 @@ public final class Superwall: NSObject, ObservableObject {
       apiKey: apiKey,
       swiftDelegate: nil,
       objcDelegate: delegate,
+      swiftPurchaseController: nil,
+      objcPurchaseController: purchaseController,
       options: options,
       completion: completion
     )

--- a/Sources/SuperwallKit/Superwall.swift
+++ b/Sources/SuperwallKit/Superwall.swift
@@ -312,6 +312,56 @@ public final class Superwall: NSObject, ObservableObject {
     options: SuperwallOptions? = nil,
     completion: (() -> Void)? = nil
   ) -> Superwall {
+    return objcConfigure(
+      apiKey: apiKey,
+      delegate: delegate,
+      purchaseController: purchaseController,
+      options: options,
+      completion: completion
+    )
+  }
+
+  /// Objective-C only function that configures a shared instance of ``SuperwallKit/Superwall`` for use throughout your app.
+  ///
+  /// Call this as soon as your app finishes launching in `application(_:didFinishLaunchingWithOptions:)`. Check out our <doc:GettingStarted> article for a tutorial on how to configure the SDK.
+  /// - Parameters:
+  ///   - apiKey: Your Public API Key that you can get from the Superwall dashboard settings. If you don't have an account, you can [sign up for free](https://superwall.com/sign-up).
+  ///   - delegate: An optional class that conforms to ``SuperwallDelegate``. The delegate methods receive callbacks from the SDK in response to certain events on the paywall.
+  ///   - options: A ``SuperwallOptions`` object which allows you to customise the appearance and behavior of the paywall.
+  ///   - completion: An optional completion handler that lets you know when Superwall has finished configuring.
+  /// - Returns: The newly configured ``SuperwallKit/Superwall`` instance.
+  @discardableResult
+  @available(swift, obsoleted: 1.0)
+  public static func configure(
+    apiKey: String,
+    delegate: SuperwallDelegateObjc? = nil
+  ) -> Superwall {
+    return objcConfigure(
+      apiKey: apiKey,
+      delegate: delegate
+    )
+  }
+
+  /// Objective-C only function that configures a shared instance of ``SuperwallKit/Superwall`` for use throughout your app.
+  ///
+  /// Call this as soon as your app finishes launching in `application(_:didFinishLaunchingWithOptions:)`. Check out our <doc:GettingStarted> article for a tutorial on how to configure the SDK.
+  /// - Parameters:
+  ///   - apiKey: Your Public API Key that you can get from the Superwall dashboard settings. If you don't have an account, you can [sign up for free](https://superwall.com/sign-up).
+  /// - Returns: The newly configured ``SuperwallKit/Superwall`` instance.
+  @discardableResult
+  @available(swift, obsoleted: 1.0)
+  public static func configure(apiKey: String) -> Superwall {
+    // Convenience method for objc
+    return objcConfigure(apiKey: apiKey)
+  }
+
+  private static func objcConfigure(
+    apiKey: String,
+    delegate: SuperwallDelegateObjc? = nil,
+    purchaseController: PurchaseControllerObjc? = nil,
+    options: SuperwallOptions? = nil,
+    completion: (() -> Void)? = nil
+  ) -> Superwall {
     guard superwall == nil else {
       Logger.debug(
         logLevel: .warn,

--- a/Sources/SuperwallKit/Superwall.swift
+++ b/Sources/SuperwallKit/Superwall.swift
@@ -5,13 +5,13 @@ import StoreKit
 import Combine
 
 /// The primary class for integrating Superwall into your application. After configuring via
-/// ``configure(apiKey:delegate:options:completion:)-7fafw``, It provides access to
+/// ``configure(apiKey:delegate:purchaseController:options:completion:)-5y99b``, It provides access to
 /// all its featured via instance functions and variables.
 @objcMembers
 public final class Superwall: NSObject, ObservableObject {
   // MARK: - Public Properties
   /// The optional purchasing delegate of the Superwall instance. Set this in
-  /// ``configure(apiKey:delegate:options:completion:)-7fafw``
+  /// ``configure(apiKey:delegate:purchaseController:options:completion:)-5y99b``
   /// when you want to manually handle the purchasing logic within your app.
   public var delegate: SuperwallDelegate? {
     get {
@@ -24,7 +24,7 @@ public final class Superwall: NSObject, ObservableObject {
   }
 
   /// The optional purchasing delegate of the Superwall instance. Set this in
-  /// ``configure(apiKey:delegate:options:completion:)-7fafw``
+  /// ``configure(apiKey:delegate:purchaseController:options:completion:)-5y99b``
   /// when you want to manually handle the purchasing logic within your app.
   @available(swift, obsoleted: 1.0)
   @objc(delegate)
@@ -60,7 +60,7 @@ public final class Superwall: NSObject, ObservableObject {
   }
 
   /// A convenience variable to access and change the paywall options that you passed
-  /// to ``configure(apiKey:delegate:options:completion:)-7fafw``.
+  /// to ``configure(apiKey:delegate:purchaseController:options:completion:)-5y99b``.
   var options: SuperwallOptions {
     return dependencyContainer.configManager.options
   }
@@ -113,19 +113,19 @@ public final class Superwall: NSObject, ObservableObject {
   public var subscriptionStatus: SubscriptionStatus = .unknown
 
   /// A published property that is `true` when Superwall has finished configuring via
-  /// ``configure(apiKey:delegate:options:completion:)-7fafw``.
+  /// ``configure(apiKey:delegate:purchaseController:options:completion:)-5y99b``.
   ///
   /// If you're using Combine or SwiftUI, you can subscribe or bind to this to get
   /// notified when configuration has completed.
   ///
   /// Alternatively, you can use the completion handler from
-  /// ``configure(apiKey:delegate:options:completion:)-7fafw``.
+  /// ``configure(apiKey:delegate:purchaseController:options:completion:)-5y99b``.
   @Published
   public var isConfigured = false
 
   /// The configured shared instance of ``Superwall``.
   ///
-  /// - Warning: You must call ``configure(apiKey:delegate:options:completion:)-7fafw``
+  /// - Warning: You must call ``configure(apiKey:delegate:purchaseController:options:completion:)-5y99b``
   /// to initialize ``Superwall`` before using this.
   @objc(sharedInstance)
   public static var shared: Superwall {


### PR DESCRIPTION
## Changes in this pull request

- Changes `SubscriptionController` to `PurchaseController`.
- Moves it from the delegate into a `purchaseController` variable.
- Adds in convenience methods for objc.


### Checklist

- [x] All tests pass. Demo project builds and runs.
- [ ] I added tests, an experiment, or detailed why my change isn't tested.
- [x] I added an entry to the `CHANGELOG.md` for any breaking changes, enhancements, or bug fixes.
- [x] I have run `swiftlint` in the main directory and fixed any issues.
- [ ] I have updated the SDK documentation as well as the online docs.
- [ ] I have reviewed the [contributing guide](https://github.com/superwall-me/paywall-ios/tree/master/.github/CONTRIBUTING.md)
