### PR TITLE
fix(identity): dead lock when setting same user id

### DIFF
--- a/Sources/SuperwallKit/Identity/IdentityManager.swift
+++ b/Sources/SuperwallKit/Identity/IdentityManager.swift
@@ -144,6 +144,7 @@ class IdentityManager {
       // If they're sending the same userId as before, then they're
       // already logged in.
       if self._appUserId == userId {
+        self.group.leave()
         return
       }
 


### PR DESCRIPTION
## Changes in this pull request

When calling `Superwall.shared.identify(userId: "abc")` when opening app instead of only during login, IdentityManager.didSetIdentity is never execute since the queue is stuck. Bug repro: set identity in AppDelegate and open app twice (works first time, fails afterwards).

This bug also blocks future calls to `Superwall.shared.getPresentationResult` that never returns since `identityManager.hasIdentity` is always false in AwaitIdentifyOperator, and never opens future paywalls.

### Checklist

- [ ] All tests pass. Demo project builds and runs.
- [ ] I added tests, an experiment, or detailed why my change isn't tested.
-> Not sure about testing, I don't see any tests calling `identify()`.
- [ ] I added an entry to the `CHANGELOG.md` for any breaking changes, enhancements, or bug fixes.
- [x] I have run `swiftlint` in the main directory and fixed any issues.
- [ ] I have updated the SDK documentation as well as the online docs.
- [x] I have reviewed the [contributing guide](https://github.com/superwall-me/paywall-ios/tree/master/.github/CONTRIBUTING.md)
