### PR TITLE
Feature/remove presentation preparation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ The changelog for `SuperwallKit`. Also see the [releases](https://github.com/sup
 - Exposes `PaywallOverrides` and `PaywallViewController` to Objective-C.
 - Adds Objective-C convenience methods to `PaywallOverrides`.
 - Adds a `device.isFirstSession` property that you can use in paywall rules. This is `true` for the very first time a user opens the app. When the user closes and reopens the app, this will be `false`.
-- Removes the need to tell us when you're going to present/have presented a `PaywallViewController`.
+- Removes the need to tell us when you're going to present/have presented a `PaywallViewController` that has been retrieved using `getPaywallViewController(...)`.
 
 ### Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The changelog for `SuperwallKit`. Also see the [releases](https://github.com/sup
 
 ### Breaking Changes
 
-- Adds a `PaywallViewControllerDelegate` to the getPaywalliewController functions. This is mandatory and is how you control what happens after a paywall is dismissed.
+- Adds a `PaywallViewControllerDelegate` to the `getPaywallViewController` functions. This is mandatory and is how you control what happens after a paywall is dismissed.
 - The completion block of `getPaywallViewController(forEvent:params:paywallOverrides:delegate:completion:)` now accepts an optional `PaywallViewController`, an optional `PaywallSkippedReason` and an optional `Error`. This makes it easier to understand when the paywall was skipped vs when a real error occurred.
 - Renamed the `PaywallResult` case `closed` to `declined`.
 
@@ -14,6 +14,11 @@ The changelog for `SuperwallKit`. Also see the [releases](https://github.com/sup
 
 - Exposes `PaywallOverrides` and `PaywallViewController` to Objective-C.
 - Adds a `device.isFirstSession` property that you can use in paywall rules. This is `true` for the very first time a user opens the app. When the user closes and reopens the app, this will be `false`.
+- Removes the need to tell us when you're going to present/have presented a `PaywallViewController`.
+
+### Fixes
+
+- Fixes a crash when calling `reset()` when a paywall is displayed.
 
 ## 3.0.0-rc.5
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,9 @@ The changelog for `SuperwallKit`. Also see the [releases](https://github.com/sup
 
 ### Breaking Changes
 
-- `getPaywallViewController(forEvent:params:paywallOverrides:completion:)` now accepts an optional `PaywallViewController`, an optional `PaywallSkippedReason` and an optional `Error`. This makes it easier to understand when the paywall was skipped vs when a real error occurred.
+- Adds a `PaywallViewControllerDelegate` to the getPaywalliewController functions. This is mandatory and is how you control what happens after a paywall is dismissed.
+- The completion block of `getPaywallViewController(forEvent:params:paywallOverrides:delegate:completion:)` now accepts an optional `PaywallViewController`, an optional `PaywallSkippedReason` and an optional `Error`. This makes it easier to understand when the paywall was skipped vs when a real error occurred.
+- Renamed the `PaywallResult` case `closed` to `declined`.
 
 ### Enhancements
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The changelog for `SuperwallKit`. Also see the [releases](https://github.com/sup
 ### Enhancements
 
 - Exposes `PaywallOverrides` and `PaywallViewController` to Objective-C.
+- Adds Objective-C convenience methods to `PaywallOverrides`.
 - Adds a `device.isFirstSession` property that you can use in paywall rules. This is `true` for the very first time a user opens the app. When the user closes and reopens the app, this will be `false`.
 - Removes the need to tell us when you're going to present/have presented a `PaywallViewController`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The changelog for `SuperwallKit`. Also see the [releases](https://github.com/sup
 ### Enhancements
 
 - Exposes `PaywallOverrides` and `PaywallViewController` to Objective-C.
+- Adds a `device.isFirstSession` property that you can use in paywall rules. This is `true` for the very first time a user opens the app. When the user closes and reopens the app, this will be `false`.
 
 ## 3.0.0-rc.5
 

--- a/Examples/UIKit-Swift/Superwall-UIKit-Swift/HomeViewController.swift
+++ b/Examples/UIKit-Swift/Superwall-UIKit-Swift/HomeViewController.swift
@@ -59,45 +59,37 @@ final class HomeViewController: UIViewController {
   }
 
   @IBAction private func launchFeature() {
-//    let handler = PaywallPresentationHandler()
-//    handler.onDismiss { paywallInfo in
-//      print("The paywall dismissed. PaywallInfo:", paywallInfo)
-//    }
-//    handler.onPresent { paywallInfo in
-//      print("The paywall presented. PaywallInfo:", paywallInfo)
-//    }
-//    handler.onError { error in
-//      print("The paywall presentation failed with error \(error)")
-//    }
-//    handler.onSkip { reason in
-//      switch reason {
-//      case .userIsSubscribed:
-//        print("Paywall not shown because user is subscribed.")
-//      case .holdout(let experiment):
-//        print("Paywall not shown because user is in a holdout group in Experiment: \(experiment.id)")
-//      case .noRuleMatch:
-//        print("Paywall not shown because user doesn't match any rules.")
-//      case .eventNotFound:
-//        print("Paywall not shown because this event isn't part of a campaign.")
-//      }
-//    }
-//    Superwall.shared.register(event: "campaign_trigger", handler: handler) {
-//      // code in here can be remotely configured to execute. Either
-//      // (1) always after presentation or
-//      // (2) only if the user pays
-//      // code is always executed if no paywall is configured to show
-//      self.presentAlert(
-//        title: "Feature Launched",
-//        message: "Wrap your awesome features in register calls like this to remotely paywall your app. You can remotely decide whether these are paid features."
-//      )
-//    }
-    Task {
-      do {
-        let paywallVc = try await Superwall.shared.getPaywallViewController(forEvent: "campaign_trigger")
-        self.present(paywallVc, animated: true)
-      } catch {
-        print(error)
+    let handler = PaywallPresentationHandler()
+    handler.onDismiss { paywallInfo in
+      print("The paywall dismissed. PaywallInfo:", paywallInfo)
+    }
+    handler.onPresent { paywallInfo in
+      print("The paywall presented. PaywallInfo:", paywallInfo)
+    }
+    handler.onError { error in
+      print("The paywall presentation failed with error \(error)")
+    }
+    handler.onSkip { reason in
+      switch reason {
+      case .userIsSubscribed:
+        print("Paywall not shown because user is subscribed.")
+      case .holdout(let experiment):
+        print("Paywall not shown because user is in a holdout group in Experiment: \(experiment.id)")
+      case .noRuleMatch:
+        print("Paywall not shown because user doesn't match any rules.")
+      case .eventNotFound:
+        print("Paywall not shown because this event isn't part of a campaign.")
       }
+    }
+    Superwall.shared.register(event: "campaign_trigger", handler: handler) {
+      // code in here can be remotely configured to execute. Either
+      // (1) always after presentation or
+      // (2) only if the user pays
+      // code is always executed if no paywall is configured to show
+      self.presentAlert(
+        title: "Feature Launched",
+        message: "Wrap your awesome features in register calls like this to remotely paywall your app. You can remotely decide whether these are paid features."
+      )
     }
   }
 

--- a/Examples/UIKit-Swift/Superwall-UIKit-Swift/HomeViewController.swift
+++ b/Examples/UIKit-Swift/Superwall-UIKit-Swift/HomeViewController.swift
@@ -59,37 +59,45 @@ final class HomeViewController: UIViewController {
   }
 
   @IBAction private func launchFeature() {
-    let handler = PaywallPresentationHandler()
-    handler.onDismiss { paywallInfo in
-      print("The paywall dismissed. PaywallInfo:", paywallInfo)
-    }
-    handler.onPresent { paywallInfo in
-      print("The paywall presented. PaywallInfo:", paywallInfo)
-    }
-    handler.onError { error in
-      print("The paywall presentation failed with error \(error)")
-    }
-    handler.onSkip { reason in
-      switch reason {
-      case .userIsSubscribed:
-        print("Paywall not shown because user is subscribed.")
-      case .holdout(let experiment):
-        print("Paywall not shown because user is in a holdout group in Experiment: \(experiment.id)")
-      case .noRuleMatch:
-        print("Paywall not shown because user doesn't match any rules.")
-      case .eventNotFound:
-        print("Paywall not shown because this event isn't part of a campaign.")
+//    let handler = PaywallPresentationHandler()
+//    handler.onDismiss { paywallInfo in
+//      print("The paywall dismissed. PaywallInfo:", paywallInfo)
+//    }
+//    handler.onPresent { paywallInfo in
+//      print("The paywall presented. PaywallInfo:", paywallInfo)
+//    }
+//    handler.onError { error in
+//      print("The paywall presentation failed with error \(error)")
+//    }
+//    handler.onSkip { reason in
+//      switch reason {
+//      case .userIsSubscribed:
+//        print("Paywall not shown because user is subscribed.")
+//      case .holdout(let experiment):
+//        print("Paywall not shown because user is in a holdout group in Experiment: \(experiment.id)")
+//      case .noRuleMatch:
+//        print("Paywall not shown because user doesn't match any rules.")
+//      case .eventNotFound:
+//        print("Paywall not shown because this event isn't part of a campaign.")
+//      }
+//    }
+//    Superwall.shared.register(event: "campaign_trigger", handler: handler) {
+//      // code in here can be remotely configured to execute. Either
+//      // (1) always after presentation or
+//      // (2) only if the user pays
+//      // code is always executed if no paywall is configured to show
+//      self.presentAlert(
+//        title: "Feature Launched",
+//        message: "Wrap your awesome features in register calls like this to remotely paywall your app. You can remotely decide whether these are paid features."
+//      )
+//    }
+    Task {
+      do {
+        let paywallVc = try await Superwall.shared.getPaywallViewController(forEvent: "campaign_trigger")
+        self.present(paywallVc, animated: true)
+      } catch {
+        print(error)
       }
-    }
-    Superwall.shared.register(event: "campaign_trigger", handler: handler) {
-      // code in here can be remotely configured to execute. Either
-      // (1) always after presentation or
-      // (2) only if the user pays
-      // code is always executed if no paywall is configured to show
-      self.presentAlert(
-        title: "Feature Launched",
-        message: "Wrap your awesome features in register calls like this to remotely paywall your app. You can remotely decide whether these are paid features."
-      )
     }
   }
 

--- a/Sources/SuperwallKit/Analytics/Internal Tracking/Trackable Events/TrackableSuperwallEvent.swift
+++ b/Sources/SuperwallKit/Analytics/Internal Tracking/Trackable Events/TrackableSuperwallEvent.swift
@@ -255,7 +255,7 @@ enum InternalSuperwallEvent {
     func getSuperwallParameters() async -> [String: Any] {
       [
         "source_event_name": eventData?.name ?? "",
-        "pipeline_type": type.rawValue,
+        "pipeline_type": type.description,
         "status": status.rawValue,
         "status_reason": statusReason?.description ?? ""
       ]

--- a/Sources/SuperwallKit/Config/ConfigManager.swift
+++ b/Sources/SuperwallKit/Config/ConfigManager.swift
@@ -268,7 +268,8 @@ class ConfigManager {
         _ = try? await paywallManager.getPaywallViewController(
           from: request,
           isPreloading: true,
-          isDebuggerLaunched: false
+          isDebuggerLaunched: false,
+          delegate: nil
         )
       }
     }

--- a/Sources/SuperwallKit/Debug/DebugViewController.swift
+++ b/Sources/SuperwallKit/Debug/DebugViewController.swift
@@ -265,7 +265,11 @@ final class DebugViewController: UIViewController {
       return
     }
 
-    let child = factory.makePaywallViewController(for: paywall, withCache: nil)
+    let child = factory.makePaywallViewController(
+      for: paywall,
+      withCache: nil,
+      delegate: nil
+    )
     addChild(child)
     previewContainerView.insertSubview(child.view, at: 0)
     previewViewContent = child.view

--- a/Sources/SuperwallKit/Delegate/Subscription Controller/PurchaseController.swift
+++ b/Sources/SuperwallKit/Delegate/Subscription Controller/PurchaseController.swift
@@ -11,8 +11,7 @@ import StoreKit
 /// The protocol that handles Superwall's subscription-related logic.
 ///
 /// By default, the Superwall SDK handles all subscription-related logic. However, if you'd like more
-/// control, you can return a ``PurchaseController`` in
-/// the delegate when configuring the SDK via
+/// control, you can return a ``PurchaseController`` when configuring the SDK via
 /// ``Superwall/configure(apiKey:purchaseController:options:completion:)-52tke``.
 ///
 /// When implementing this, you also need to set the subscription status using

--- a/Sources/SuperwallKit/Delegate/Subscription Controller/PurchaseControllerObjc.swift
+++ b/Sources/SuperwallKit/Delegate/Subscription Controller/PurchaseControllerObjc.swift
@@ -11,8 +11,7 @@ import StoreKit
 /// The Objective-C-only protocol that handles Superwall's subscription-related logic.
 ///
 /// By default, the Superwall SDK handles all subscription-related logic. However, if you'd like
-/// more control, you can return a ``PurchaseControllerObjc`` in the delegate when
-/// configuring the SDK via
+/// more control, you can return a ``PurchaseControllerObjc`` when configuring the SDK via
 /// ``Superwall/configure(apiKey:purchaseController:options:completion:)-52tke``.
 ///
 /// When implementing this, you also need to set the subscription status using

--- a/Sources/SuperwallKit/Dependencies/DependencyContainer.swift
+++ b/Sources/SuperwallKit/Dependencies/DependencyContainer.swift
@@ -164,7 +164,8 @@ extension DependencyContainer: ViewControllerFactory {
   @MainActor
   func makePaywallViewController(
     for paywall: Paywall,
-    withCache cache: PaywallViewControllerCache?
+    withCache cache: PaywallViewControllerCache?,
+    delegate: PaywallViewControllerDelegateAdapter?
   ) -> PaywallViewController {
     let messageHandler = PaywallMessageHandler(
       sessionEventsManager: sessionEventsManager,
@@ -177,7 +178,8 @@ extension DependencyContainer: ViewControllerFactory {
     )
     let paywallViewController = PaywallViewController(
       paywall: paywall,
-      delegate: Superwall.shared,
+      eventDelegate: Superwall.shared,
+      delegate: delegate,
       deviceHelper: deviceHelper,
       sessionEventsManager: sessionEventsManager,
       storage: storage,

--- a/Sources/SuperwallKit/Dependencies/FactoryProtocols.swift
+++ b/Sources/SuperwallKit/Dependencies/FactoryProtocols.swift
@@ -12,8 +12,10 @@ protocol ViewControllerFactory: AnyObject {
   @MainActor
   func makePaywallViewController(
     for paywall: Paywall,
-    withCache cache: PaywallViewControllerCache?
+    withCache cache: PaywallViewControllerCache?,
+    delegate: PaywallViewControllerDelegateAdapter?
   ) -> PaywallViewController
+
   func makeDebugViewController(withDatabaseId id: String?) -> DebugViewController
 }
 

--- a/Sources/SuperwallKit/Documentation.docc/Extensions/SuperwallExtension.md
+++ b/Sources/SuperwallKit/Documentation.docc/Extensions/SuperwallExtension.md
@@ -32,9 +32,9 @@ The ``Superwall`` class is used to access all the features of the SDK. Before us
 - ``register(event:params:handler:)``
 - ``register(event:)``
 - ``register(event:params:)``
-- ``getPaywallViewController(forEvent:params:paywallOverrides:)``
-- ``getPaywallViewController(forEvent:params:paywallOverrides:completion:)-8mxbs``
-- ``getPaywallViewController(forEvent:params:paywallOverrides:completion:)-39418``
+- ``getPaywallViewController(forEvent:params:paywallOverrides:delegate:)``
+- ``getPaywallViewController(forEvent:params:paywallOverrides:delegate:completion:)-4qzau``
+- ``getPaywallViewController(forEvent:params:paywallOverrides:delegate:completion:)-15rjy``
 - ``publisher(forEvent:params:paywallOverrides:isFeatureGatable:)``
 - ``getPresentationResult(forEvent:)``
 - ``getPresentationResult(forEvent:params:)-9ivi6``

--- a/Sources/SuperwallKit/Identity/IdentityManager.swift
+++ b/Sources/SuperwallKit/Identity/IdentityManager.swift
@@ -224,7 +224,7 @@ extension IdentityManager {
   ///
   /// - Parameters:
   ///   - duringIdentify: A boolean that indicates whether the reset
-  ///   call is happening during a call to `identify(userId:)`. If `fasle`,
+  ///   call is happening during a call to `identify(userId:)`. If `false`,
   ///   this happens
   func reset(duringIdentify: Bool) {
     identitySubject.send(false)

--- a/Sources/SuperwallKit/Paywall/Manager/PaywallManager.swift
+++ b/Sources/SuperwallKit/Paywall/Manager/PaywallManager.swift
@@ -46,7 +46,8 @@ class PaywallManager {
   func getPaywallViewController(
     from request: PaywallRequest,
     isPreloading: Bool,
-    isDebuggerLaunched: Bool
+    isDebuggerLaunched: Bool,
+    delegate: PaywallViewControllerDelegateAdapter?
   ) async throws -> PaywallViewController {
     let paywall = try await paywallRequestManager.getPaywall(from: request)
     let deviceInfo = factory.makeDeviceInfo()
@@ -57,6 +58,7 @@ class PaywallManager {
 
     if !isDebuggerLaunched,
       let viewController = self.cache.getPaywallViewController(forKey: cacheKey) {
+      viewController.delegate = delegate
       if !isPreloading {
         viewController.paywall.overrideProductsIfNeeded(from: paywall)
       }
@@ -65,7 +67,8 @@ class PaywallManager {
 
     let paywallViewController = factory.makePaywallViewController(
       for: paywall,
-      withCache: cache
+      withCache: cache,
+      delegate: delegate
     )
     cache.save(paywallViewController, forKey: cacheKey)
 

--- a/Sources/SuperwallKit/Paywall/Presentation/Get PaywallViewController/GetPaywallViewControllerResult.swift
+++ b/Sources/SuperwallKit/Paywall/Presentation/Get PaywallViewController/GetPaywallViewControllerResult.swift
@@ -7,7 +7,8 @@
 
 import Foundation
 
-/// An object that represents the result of calling ``Superwall/getPaywallViewController(forEvent:params:paywallOverrides:completion:)-39418``.
+/// An object that represents the result of calling
+/// ``Superwall/getPaywallViewController(forEvent:params:paywallOverrides:delegate:completion:)-4qzau``.
 @objc(SWKGetPaywallViewControllerResult)
 @objcMembers
 public final class GetPaywallViewControllerResult: NSObject {

--- a/Sources/SuperwallKit/Paywall/Presentation/Get PaywallViewController/InternalGetPaywallViewController.swift
+++ b/Sources/SuperwallKit/Paywall/Presentation/Get PaywallViewController/InternalGetPaywallViewController.swift
@@ -16,12 +16,10 @@ extension Superwall {
   ///
   /// - Returns: A ``PaywallViewController`` to present.
   @discardableResult
-  func getPaywallViewController(
-    _ request: PresentationRequest,
-    isObjc: Bool
-  ) -> AnyPublisher<PaywallViewController, Error> {
+  func getPaywallViewController(_ request: PresentationRequest) -> AnyPublisher<PaywallViewController, Error> {
     let paywallStatePublisher: PassthroughSubject<PaywallState, Never> = .init()
     let presentationSubject = PresentationSubject(request)
+    let hasObjcDelegate = request.flags.type.hasObjcDelegate()
 
     return presentationSubject
       .eraseToAnyPublisher()
@@ -30,12 +28,12 @@ extension Superwall {
       .evaluateRules()
       .confirmHoldoutAssignment()
       .handleTriggerResult(paywallStatePublisher)
-      .getPaywallViewController(pipelineType: .presentation(paywallStatePublisher))
+      .getPaywallViewController(paywallStatePublisher)
       .checkSubscriptionStatus(paywallStatePublisher)
       .confirmPaywallAssignment()
       .storePresentationObjects(presentationSubject, paywallStatePublisher)
       .logErrors(from: request)
       .extractPaywallViewController(paywallStatePublisher)
-      .mapErrors(isObjc: isObjc)
+      .mapErrors(toObjc: hasObjcDelegate)
   }
 }

--- a/Sources/SuperwallKit/Paywall/Presentation/Get PaywallViewController/Operators/ExtractPaywallViewControllerOperator.swift
+++ b/Sources/SuperwallKit/Paywall/Presentation/Get PaywallViewController/Operators/ExtractPaywallViewControllerOperator.swift
@@ -23,7 +23,6 @@ extension AnyPublisher where Output == PresentablePipelineOutput, Failure == Err
         let paywallViewController = input.paywallViewController
         paywallViewController.set(
           eventData: input.request.presentationInfo.eventData,
-          presentationStyleOverride: input.request.paywallOverrides?.presentationStyle,
           paywallStatePublisher: paywallStatePublisher
         )
         return input.paywallViewController

--- a/Sources/SuperwallKit/Paywall/Presentation/Get PaywallViewController/Operators/MapErrorsOperator.swift
+++ b/Sources/SuperwallKit/Paywall/Presentation/Get PaywallViewController/Operators/MapErrorsOperator.swift
@@ -9,30 +9,30 @@ import Foundation
 import Combine
 
 extension AnyPublisher where Output == PaywallViewController, Failure == Error {
-  func mapErrors(isObjc: Bool) -> AnyPublisher<PaywallViewController, Error> {
+  func mapErrors(toObjc: Bool) -> AnyPublisher<PaywallViewController, Error> {
     mapError { error -> Error in
       if let error = error as? PresentationPipelineError {
         switch error {
         case .holdout(let experiment):
-          if isObjc {
+          if toObjc {
             return PaywallSkippedReasonObjc.holdout
           } else {
             return PaywallSkippedReason.holdout(experiment)
           }
         case .noRuleMatch:
-          if isObjc {
+          if toObjc {
             return PaywallSkippedReasonObjc.noRuleMatch
           } else {
             return PaywallSkippedReason.noRuleMatch
           }
         case .eventNotFound:
-          if isObjc {
+          if toObjc {
             return PaywallSkippedReasonObjc.eventNotFound
           } else {
             return PaywallSkippedReason.eventNotFound
           }
         case .userIsSubscribed:
-          if isObjc {
+          if toObjc {
             return PaywallSkippedReasonObjc.userIsSubscribed
           } else {
             return PaywallSkippedReason.userIsSubscribed

--- a/Sources/SuperwallKit/Paywall/Presentation/Get Presentation Result/InternalGetPresentationResult.swift
+++ b/Sources/SuperwallKit/Paywall/Presentation/Get Presentation Result/InternalGetPresentationResult.swift
@@ -35,7 +35,7 @@ extension Superwall {
       .logPresentation("Called Superwall.shared.getPresentationResult")
       .evaluateRules()
       .checkForPaywallResult()
-      .getPaywallViewController(pipelineType: .getPresentationResult)
+      .getPaywallViewController()
       .checkPaywallIsPresentable()
       .convertToPresentationResult()
       .async(request: request)

--- a/Sources/SuperwallKit/Paywall/Presentation/Get Presentation Result/Operators/GetPaywallVcNoChecksOperator.swift
+++ b/Sources/SuperwallKit/Paywall/Presentation/Get Presentation Result/Operators/GetPaywallVcNoChecksOperator.swift
@@ -30,7 +30,8 @@ extension AnyPublisher where Output == TriggerResultResponsePipelineOutput, Fail
         let paywallViewController = try await dependencyContainer.paywallManager.getPaywallViewController(
           from: paywallRequest,
           isPreloading: false,
-          isDebuggerLaunched: false
+          isDebuggerLaunched: false,
+          delegate: input.request.flags.type.getPaywallVcDelegateAdapter()
         )
 
         let output = PaywallVcPipelineOutput(

--- a/Sources/SuperwallKit/Paywall/Presentation/Internal Presentation/InternalPresentation.swift
+++ b/Sources/SuperwallKit/Paywall/Presentation/Internal Presentation/InternalPresentation.swift
@@ -55,23 +55,6 @@ extension Superwall {
       .eraseToAnyPublisher()
   }
 
-  /// Presents the paywall again by sending the previous presentation request to the presentation publisher.
-  func presentAgain(cacheKey: String) {
-    guard let lastPresentationItems = presentationItems.last else {
-      return
-    }
-
-    // Remove the currently presenting paywall from cache.
-    dependencyContainer.paywallManager.removePaywallViewController(forKey: cacheKey)
-
-    // Resend the request and pass in the state publisher so it can continue
-    // to send updates.
-    internallyPresent(
-      lastPresentationItems.request,
-      lastPresentationItems.statePublisher
-    )
-  }
-
   @MainActor
   func dismiss(
     _ paywallViewController: PaywallViewController,

--- a/Sources/SuperwallKit/Paywall/Presentation/Internal Presentation/InternalPresentation.swift
+++ b/Sources/SuperwallKit/Paywall/Presentation/Internal Presentation/InternalPresentation.swift
@@ -39,7 +39,7 @@ extension Superwall {
       .checkUserSubscription(paywallStatePublisher)
       .confirmHoldoutAssignment()
       .handleTriggerResult(paywallStatePublisher)
-      .getPaywallViewController(pipelineType: .presentation(paywallStatePublisher))
+      .getPaywallViewController(paywallStatePublisher)
       .checkPaywallIsPresentable(paywallStatePublisher)
       .confirmPaywallAssignment()
       .presentPaywall(paywallStatePublisher)
@@ -59,15 +59,11 @@ extension Superwall {
   func dismiss(
     _ paywallViewController: PaywallViewController,
     result: PaywallResult,
-    shouldSendPaywallResult: Bool = true,
-    shouldCompleteStatePublisher: Bool = true,
     closeReason: PaywallCloseReason = .systemLogic,
     completion: (() -> Void)? = nil
   ) {
     paywallViewController.dismiss(
       result: result,
-      shouldSendPaywallResult: shouldSendPaywallResult,
-      shouldCompleteStatePublisher: shouldCompleteStatePublisher,
       closeReason: closeReason
     ) {
       completion?()

--- a/Sources/SuperwallKit/Paywall/Presentation/Internal Presentation/Presentation Request/PaywallOverrides.swift
+++ b/Sources/SuperwallKit/Paywall/Presentation/Internal Presentation/Presentation Request/PaywallOverrides.swift
@@ -9,7 +9,7 @@ import Foundation
 
 /// Override the default behavior and products of a paywall.
 ///
-/// Provide an instance of this to ``Superwall/getPaywallViewController(forEvent:params:paywallOverrides:)``.
+/// Provide an instance of this to ``Superwall/getPaywallViewController(forEvent:params:paywallOverrides:delegate:)``.
 @objc(SWKPaywallOverrides)
 @objcMembers
 public final class PaywallOverrides: NSObject, Sendable {
@@ -26,7 +26,7 @@ public final class PaywallOverrides: NSObject, Sendable {
 
   /// Override the default behavior and products of a paywall.
   ///
-  /// Provide an instance of this to ``Superwall/getPaywallViewController(forEvent:params:paywallOverrides:)``.
+  /// Provide an instance of this to ``Superwall/getPaywallViewController(forEvent:params:paywallOverrides:delegate:)``.
   ///
   /// - parameters:
   ///   - products: A ``PaywallProducts`` object defining the products to override on the paywall.
@@ -44,7 +44,7 @@ public final class PaywallOverrides: NSObject, Sendable {
 
   /// Override the default behavior and products of a paywall.
   ///
-  /// Provide an instance of this to ``Superwall/getPaywallViewController(forEvent:params:paywallOverrides:)``.
+  /// Provide an instance of this to ``Superwall/getPaywallViewController(forEvent:params:paywallOverrides:delegate:)``.
   ///
   /// - parameters:
   ///   - products: A ``PaywallProducts`` object defining the products to override on the paywall.
@@ -57,7 +57,7 @@ public final class PaywallOverrides: NSObject, Sendable {
 
   /// Override the default behavior and products of a paywall.
   ///
-  /// Provide an instance of this to ``Superwall/getPaywallViewController(forEvent:params:paywallOverrides:)``.
+  /// Provide an instance of this to ``Superwall/getPaywallViewController(forEvent:params:paywallOverrides:delegate:)``.
   ///
   /// - parameters:
   ///   - products: A ``PaywallProducts`` object defining the products to override on the paywall.

--- a/Sources/SuperwallKit/Paywall/Presentation/Internal Presentation/Presentation Request/PaywallOverrides.swift
+++ b/Sources/SuperwallKit/Paywall/Presentation/Internal Presentation/Presentation Request/PaywallOverrides.swift
@@ -32,7 +32,7 @@ public final class PaywallOverrides: NSObject, Sendable {
   ///   - products: A ``PaywallProducts`` object defining the products to override on the paywall.
   ///   - ignoreSubscriptionStatus: Set this to `true` to always show the paywall, regardless of whether the user has an active subscription or not.
   ///   - presentationStyleOverride: A ``PaywallPresentationStyle`` enum that specifies the presentation style for the paywall.
-  @objc public init(
+  public init(
     products: PaywallProducts? = nil,
     ignoreSubscriptionStatus: Bool = false,
     presentationStyleOverride: PaywallPresentationStyle = .none
@@ -40,5 +40,35 @@ public final class PaywallOverrides: NSObject, Sendable {
     self.products = products
     self.ignoreSubscriptionStatus = ignoreSubscriptionStatus
     self.presentationStyle = presentationStyleOverride
+  }
+
+  /// Override the default behavior and products of a paywall.
+  ///
+  /// Provide an instance of this to ``Superwall/getPaywallViewController(forEvent:params:paywallOverrides:)``.
+  ///
+  /// - parameters:
+  ///   - products: A ``PaywallProducts`` object defining the products to override on the paywall.
+  @available(swift, obsoleted: 1.0)
+  public init(products: PaywallProducts?) {
+    self.products = products
+    self.ignoreSubscriptionStatus = false
+    self.presentationStyle = .none
+  }
+
+  /// Override the default behavior and products of a paywall.
+  ///
+  /// Provide an instance of this to ``Superwall/getPaywallViewController(forEvent:params:paywallOverrides:)``.
+  ///
+  /// - parameters:
+  ///   - products: A ``PaywallProducts`` object defining the products to override on the paywall.
+  ///   - ignoreSubscriptionStatus: Set this to `true` to always show the paywall, regardless of whether the user has an active subscription or not.
+  @available(swift, obsoleted: 1.0)
+  public init(
+    products: PaywallProducts?,
+    ignoreSubscriptionStatus: Bool = false
+  ) {
+    self.products = products
+    self.ignoreSubscriptionStatus = ignoreSubscriptionStatus
+    self.presentationStyle = .none
   }
 }

--- a/Sources/SuperwallKit/Paywall/Presentation/Internal Presentation/Presentation Request/PresentationRequest.swift
+++ b/Sources/SuperwallKit/Paywall/Presentation/Internal Presentation/Presentation Request/PresentationRequest.swift
@@ -8,11 +8,55 @@
 import UIKit
 import Combine
 
-enum PresentationRequestType: String {
+enum PresentationRequestType: Equatable, CustomStringConvertible {
   case presentation
-  case getPaywallViewController
+  case getPaywallViewController(PaywallViewControllerDelegateAdapter)
   case getPresentationResult
   case getImplicitPresentationResult
+
+  var description: String {
+    switch self {
+    case .presentation:
+      return "presentation"
+    case .getPaywallViewController:
+      return "getPaywallViewController"
+    case .getPresentationResult:
+      return "getPresentationResult"
+    case .getImplicitPresentationResult:
+      return "getImplicitPresentationResult"
+    }
+  }
+
+  func getPaywallVcDelegateAdapter() -> PaywallViewControllerDelegateAdapter? {
+    switch self {
+    case .getPaywallViewController(let adapter):
+      return adapter
+    default:
+      return nil
+    }
+  }
+
+  func hasObjcDelegate() -> Bool {
+    switch self {
+    case .getPaywallViewController(let adapter):
+      return adapter.hasObjcDelegate
+    default:
+      return false
+    }
+  }
+
+  static func == (lhs: PresentationRequestType, rhs: PresentationRequestType) -> Bool {
+    switch (lhs, rhs) {
+    case (.getImplicitPresentationResult, .getImplicitPresentationResult),
+      (.getPresentationResult, .getPresentationResult),
+      (.presentation, .presentation):
+      return true
+    case let (.getPaywallViewController(type1), .getPaywallViewController(type2)):
+      return type1 === type2
+    default:
+      return false
+    }
+  }
 }
 
 /// Defines the information needed to request the presentation of a paywall.

--- a/Sources/SuperwallKit/Paywall/Presentation/Internal Presentation/Presentation State/PaywallState.swift
+++ b/Sources/SuperwallKit/Paywall/Presentation/Internal Presentation/Presentation State/PaywallState.swift
@@ -15,18 +15,18 @@ public enum PaywallResult: Equatable, Sendable {
   ///   - productId: The identifier of the product.
   case purchased(productId: String)
 
-  /// The paywall was dismissed by the user manually pressing the close button.
-  case closed
+  /// The paywall was declined by the user pressing the close button.
+  case declined
 
   /// The paywall was dismissed due to the user restoring their purchases.
   case restored
 
   func convertForObjc() -> PaywallResultObjc {
     switch self {
-    case .purchased(let productId):
+    case .purchased:
       return .purchased
-    case .closed:
-      return .closed
+    case .declined:
+      return .declined
     case .restored:
       return .restored
     }
@@ -39,8 +39,8 @@ public enum PaywallResultObjc: Int, Sendable {
   /// The paywall was dismissed because the user purchased a product
   case purchased
 
-  /// The paywall was dismissed by the user manually pressing the close button.
-  case closed
+  /// The paywall was declined by the user pressing the close button.
+  case declined
 
   /// The paywall was dismissed due to the user restoring their purchases.
   case restored

--- a/Sources/SuperwallKit/Paywall/Presentation/Internal Presentation/Presentation State/PaywallState.swift
+++ b/Sources/SuperwallKit/Paywall/Presentation/Internal Presentation/Presentation State/PaywallState.swift
@@ -20,13 +20,29 @@ public enum PaywallResult: Equatable, Sendable {
 
   /// The paywall was dismissed due to the user restoring their purchases.
   case restored
+
+  func convertForObjc() -> PaywallResultObjc {
+    switch self {
+    case .purchased(let productId):
+      return .purchased
+    case .closed:
+      return .closed
+    case .restored:
+      return .restored
+    }
+  }
 }
 
-/// Objective-C compatible enum for ``PaywallResult``
+/// Objective-C-only enum. Contains the possible reasons for the dismissal of a paywall.
 @objc(SWKPaywallResult)
 public enum PaywallResultObjc: Int, Sendable {
+  /// The paywall was dismissed because the user purchased a product
   case purchased
+
+  /// The paywall was dismissed by the user manually pressing the close button.
   case closed
+
+  /// The paywall was dismissed due to the user restoring their purchases.
   case restored
 }
 

--- a/Sources/SuperwallKit/Paywall/Presentation/PresentationItems.swift
+++ b/Sources/SuperwallKit/Paywall/Presentation/PresentationItems.swift
@@ -53,10 +53,6 @@ final class PresentationItems: @unchecked Sendable {
       self?._last = nil
       self?._paywallInfo = nil
     }
-
-    Task { @MainActor [weak self]  in
-      self?.window = nil
-    }
   }
 }
 

--- a/Sources/SuperwallKit/Paywall/Presentation/PublicPresentation.swift
+++ b/Sources/SuperwallKit/Paywall/Presentation/PublicPresentation.swift
@@ -40,7 +40,7 @@ extension Superwall {
     await withCheckedContinuation { continuation in
       dismiss(
         paywallViewController,
-        result: .closed
+        result: .declined
       ) {
         continuation.resume()
       }
@@ -56,8 +56,7 @@ extension Superwall {
     await withCheckedContinuation { continuation in
       dismiss(
         paywallViewController,
-        result: .closed,
-        shouldCompleteStatePublisher: false,
+        result: .declined,
         closeReason: .forNextPaywall
       ) {
         continuation.resume()
@@ -136,7 +135,7 @@ extension Superwall {
         case .purchased,
           .restored:
           completion?()
-        case .closed:
+        case .declined:
           let closeReason = paywallInfo.closeReason
           let featureGating = paywallInfo.featureGatingBehavior
           if closeReason != .forNextPaywall && featureGating == .nonGated {

--- a/Sources/SuperwallKit/Paywall/View Controller/Delegates/PaywallViewControllerDelegate.swift
+++ b/Sources/SuperwallKit/Paywall/View Controller/Delegates/PaywallViewControllerDelegate.swift
@@ -1,0 +1,67 @@
+//
+//  File.swift
+//  
+//
+//  Created by Yusuf Tör on 09/05/2023.
+//
+
+import Foundation
+
+/// An interface for responding to user interactions with a ``PaywallViewController`` that
+/// has been retrieved using
+/// ``Superwall/getPaywallViewController(forEvent:params:paywallOverrides:delegate:)``.
+public protocol PaywallViewControllerDelegate: AnyObject {
+  /// Tells the delegate that the user finished interacting with the paywall.
+  ///
+  /// - Parameters:
+  ///   - controller: The ``PaywallViewController`` that the user is interacting with.
+  ///   - result: A ``PaywallResult`` enum that contains the reason for the dismissal of
+  ///   the ``PaywallViewController``.
+  @MainActor
+  func paywallViewController(
+    _ controller: PaywallViewController,
+    didFinishWith result: PaywallResult
+  )
+}
+
+/// Objective-C-only interface for responding to user interactions with a ``PaywallViewController`` that
+/// has been retrieved using
+/// ``Superwall/getPaywallViewController(forEvent:params:paywallOverrides:delegate:)``.
+@objc(SWKPaywallViewControllerDelegate)
+public protocol PaywallViewControllerDelegateObjc: AnyObject {
+  /// Tells the delegate that the user finished interacting with the paywall.
+  ///
+  /// - Parameters:
+  ///   - controller: The ``PaywallViewController`` that the user is interacting with.
+  ///   - result: A ``PaywallResultObjc`` enum that contains the reason for the dismissal of
+  ///   the ``PaywallViewController``.
+  @MainActor
+  @objc func paywallViewController(
+    _ controller: PaywallViewController,
+    didFinishWith result: PaywallResultObjc
+  )
+}
+
+protocol PaywallViewControllerEventDelegate: AnyObject {
+  @MainActor func eventDidOccur(
+    _ paywallEvent: PaywallWebEvent,
+    on paywallViewController: PaywallViewController
+  ) async
+}
+
+enum PaywallLoadingState {
+  /// The initial state of the paywall
+  case unknown
+
+  /// When a purchase is loading
+  case loadingPurchase
+
+  /// When the paywall URL is loading
+  case loadingURL
+
+  /// When the user has manually shown the spinner
+  case manualLoading
+
+  /// When everything has loaded.
+  case ready
+}

--- a/Sources/SuperwallKit/Paywall/View Controller/Delegates/PaywallViewControllerDelegateAdapter.swift
+++ b/Sources/SuperwallKit/Paywall/View Controller/Delegates/PaywallViewControllerDelegateAdapter.swift
@@ -1,0 +1,45 @@
+//
+//  File.swift
+//  
+//
+//  Created by Yusuf Tör on 09/05/2023.
+//
+
+import Foundation
+
+/// An adapter between the internal SDK and the public swift/objective c ``PaywallViewController`` delegate.
+final class PaywallViewControllerDelegateAdapter {
+  weak var swiftDelegate: PaywallViewControllerDelegate?
+  weak var objcDelegate: PaywallViewControllerDelegateObjc?
+
+  var hasObjcDelegate: Bool {
+    return objcDelegate != nil
+  }
+
+  init(
+    swiftDelegate: PaywallViewControllerDelegate?,
+    objcDelegate: PaywallViewControllerDelegateObjc?
+  ) {
+    self.swiftDelegate = swiftDelegate
+    self.objcDelegate = objcDelegate
+  }
+
+  @MainActor
+  func didFinish(
+    controller: PaywallViewController,
+    swiftResult: PaywallResult,
+    objcResult: PaywallResultObjc
+  ) {
+    swiftDelegate?.paywallViewController(controller, didFinishWith: swiftResult)
+    objcDelegate?.paywallViewController(controller, didFinishWith: objcResult)
+  }
+}
+
+extension PaywallViewControllerDelegateAdapter: Stubbable {
+  static func stub() -> PaywallViewControllerDelegateAdapter {
+    return PaywallViewControllerDelegateAdapter(
+      swiftDelegate: nil,
+      objcDelegate: nil
+    )
+  }
+}

--- a/Sources/SuperwallKit/Paywall/View Controller/PaywallViewController.swift
+++ b/Sources/SuperwallKit/Paywall/View Controller/PaywallViewController.swift
@@ -242,16 +242,7 @@ public class PaywallViewController: UIViewController, SWWebViewDelegate, Loading
   }
 
   @objc private func pressedRefreshPaywall() {
-    dismiss(
-      result: .closed,
-      shouldSendPaywallResult: false,
-      shouldCompleteStatePublisher: false
-    ) { [weak self] in
-      guard let self = self else {
-        return
-      }
-      Superwall.shared.presentAgain(cacheKey: self.cacheKey)
-    }
+    webView.reload()
   }
 
   @objc private func pressedExitPaywall() {
@@ -639,10 +630,6 @@ extension PaywallViewController: PaywallMessageHandlerDelegate {
 extension PaywallViewController {
   override public func viewWillAppear(_ animated: Bool) {
     super.viewWillAppear(animated)
-    guard isActive else {
-      return
-    }
-
     cache?.activePaywallVcKey = cacheKey
 
     if isSafariVCPresented {

--- a/Sources/SuperwallKit/Superwall.swift
+++ b/Sources/SuperwallKit/Superwall.swift
@@ -444,7 +444,7 @@ public final class Superwall: NSObject, ObservableObject {
 }
 
 // MARK: - PaywallViewControllerDelegate
-extension Superwall: PaywallViewControllerDelegate {
+extension Superwall: PaywallViewControllerEventDelegate {
   @MainActor
   func eventDidOccur(
     _ paywallEvent: PaywallWebEvent,
@@ -469,7 +469,7 @@ extension Superwall: PaywallViewControllerDelegate {
       } else {
         dismiss(
           paywallViewController,
-          result: .closed
+          result: .declined
         )
       }
 

--- a/Tests/SuperwallKitTests/Analytics/Internal Tracking/TrackTests.swift
+++ b/Tests/SuperwallKitTests/Analytics/Internal Tracking/TrackTests.swift
@@ -261,7 +261,7 @@ final class TrackingTests: XCTestCase {
     let eventData: EventData = .stub()
     let event = InternalSuperwallEvent.PresentationRequest(
       eventData: eventData,
-      type: .getPaywallViewController,
+      type: .getPaywallViewController(.stub()),
       status: .noPresentation,
       statusReason: .userIsSubscribed
     )
@@ -279,7 +279,7 @@ final class TrackingTests: XCTestCase {
     let eventData: EventData = .stub()
     let event = InternalSuperwallEvent.PresentationRequest(
       eventData: eventData,
-      type: .getPaywallViewController,
+      type: .getPaywallViewController(.stub()),
       status: .noPresentation,
       statusReason: .eventNotFound
     )
@@ -297,7 +297,7 @@ final class TrackingTests: XCTestCase {
     let eventData: EventData = .stub()
     let event = InternalSuperwallEvent.PresentationRequest(
       eventData: eventData,
-      type: .getPaywallViewController,
+      type: .getPaywallViewController(.stub()),
       status: .noPresentation,
       statusReason: .noRuleMatch
     )
@@ -315,7 +315,7 @@ final class TrackingTests: XCTestCase {
     let eventData: EventData = .stub()
     let event = InternalSuperwallEvent.PresentationRequest(
       eventData: eventData,
-      type: .getPaywallViewController,
+      type: .getPaywallViewController(.stub()),
       status: .noPresentation,
       statusReason: .paywallAlreadyPresented
     )
@@ -333,7 +333,7 @@ final class TrackingTests: XCTestCase {
     let eventData: EventData = .stub()
     let event = InternalSuperwallEvent.PresentationRequest(
       eventData: eventData,
-      type: .getPaywallViewController,
+      type: .getPaywallViewController(.stub()),
       status: .noPresentation,
       statusReason: .debuggerPresented
     )
@@ -351,7 +351,7 @@ final class TrackingTests: XCTestCase {
     let eventData: EventData = .stub()
     let event = InternalSuperwallEvent.PresentationRequest(
       eventData: eventData,
-      type: .getPaywallViewController,
+      type: .getPaywallViewController(.stub()),
       status: .noPresentation,
       statusReason: .noPresenter
     )
@@ -369,7 +369,7 @@ final class TrackingTests: XCTestCase {
     let eventData: EventData = .stub()
     let event = InternalSuperwallEvent.PresentationRequest(
       eventData: eventData,
-      type: .getPaywallViewController,
+      type: .getPaywallViewController(.stub()),
       status: .noPresentation,
       statusReason: .noPaywallViewController
     )
@@ -387,7 +387,7 @@ final class TrackingTests: XCTestCase {
     let eventData: EventData = .stub()
     let event = InternalSuperwallEvent.PresentationRequest(
       eventData: eventData,
-      type: .getPaywallViewController,
+      type: .getPaywallViewController(.stub()),
       status: .noPresentation,
       statusReason: .holdout(.stub())
     )

--- a/Tests/SuperwallKitTests/Paywall/Manager/PaywallManagerMock.swift
+++ b/Tests/SuperwallKitTests/Paywall/Manager/PaywallManagerMock.swift
@@ -16,7 +16,8 @@ final class PaywallManagerMock: PaywallManager {
   override func getPaywallViewController(
     from request: PaywallRequest,
     isPreloading: Bool,
-    isDebuggerLaunched: Bool
+    isDebuggerLaunched: Bool,
+    delegate: PaywallViewControllerDelegateAdapter?
   ) async throws -> PaywallViewController {
     if let getPaywallError = getPaywallError {
       throw getPaywallError

--- a/Tests/SuperwallKitTests/Paywall/Manager/PaywallViewControllerCacheTests.swift
+++ b/Tests/SuperwallKitTests/Paywall/Manager/PaywallViewControllerCacheTests.swift
@@ -19,7 +19,7 @@ class PaywallViewControllerCacheTests: XCTestCase {
     let paywallCache = PaywallViewControllerCache(deviceLocaleString: locale)
     let id = "myid"
     let key = PaywallCacheLogic.key(identifier: id, locale: locale)
-    let paywall = dependencyContainer.makePaywallViewController(for: .stub(), withCache: paywallCache)
+    let paywall = dependencyContainer.makePaywallViewController(for: .stub(), withCache: paywallCache, delegate: nil)
     paywall.cacheKey = key
 
     // When
@@ -38,7 +38,7 @@ class PaywallViewControllerCacheTests: XCTestCase {
     let paywallCache = PaywallViewControllerCache(deviceLocaleString: locale)
     let id = "myid"
     let key = PaywallCacheLogic.key(identifier: id, locale: locale)
-    let paywall = dependencyContainer.makePaywallViewController(for: .stub(), withCache: paywallCache)
+    let paywall = dependencyContainer.makePaywallViewController(for: .stub(), withCache: paywallCache, delegate: nil)
     paywall.cacheKey = key
 
     // When
@@ -64,12 +64,12 @@ class PaywallViewControllerCacheTests: XCTestCase {
     let paywallId1 = "id1"
     let key1 = PaywallCacheLogic.key(identifier: paywallId1, locale: locale)
 
-    let paywall1 = dependencyContainer.makePaywallViewController(for: .stub(), withCache: paywallCache)
+    let paywall1 = dependencyContainer.makePaywallViewController(for: .stub(), withCache: paywallCache, delegate: nil)
     paywall1.cacheKey = key1
 
     let paywallId2 = "id2"
     let key2 = PaywallCacheLogic.key(identifier: paywallId2, locale: locale)
-    let paywall2 = dependencyContainer.makePaywallViewController(for: .stub(), withCache: paywallCache)
+    let paywall2 = dependencyContainer.makePaywallViewController(for: .stub(), withCache: paywallCache, delegate: nil)
     paywall2.cacheKey = key2
 
     // When

--- a/Tests/SuperwallKitTests/Paywall/Presentation/Get Track Result/Operators/CheckPaywallIsPresentableTests.swift
+++ b/Tests/SuperwallKitTests/Paywall/Presentation/Get Track Result/Operators/CheckPaywallIsPresentableTests.swift
@@ -24,7 +24,7 @@ final class CheckPaywallIsPresentableTests: XCTestCase {
         .setting(\.flags.subscriptionStatus, to: publisher),
       triggerResult: .paywall(.stub()),
       debugInfo: [:],
-      paywallViewController: dependencyContainer.makePaywallViewController(for: .stub(), withCache: nil),
+      paywallViewController: dependencyContainer.makePaywallViewController(for: .stub(), withCache: nil, delegate: nil),
       confirmableAssignment: nil
     )
 
@@ -69,7 +69,7 @@ final class CheckPaywallIsPresentableTests: XCTestCase {
         .setting(\.flags.subscriptionStatus, to: publisher),
       triggerResult: triggerResult,
       debugInfo: [:],
-      paywallViewController: dependencyContainer.makePaywallViewController(for: .stub(), withCache: nil),
+      paywallViewController: dependencyContainer.makePaywallViewController(for: .stub(), withCache: nil, delegate: nil),
       confirmableAssignment: nil
     )
 

--- a/Tests/SuperwallKitTests/Paywall/Presentation/Get Track Result/Operators/GetPaywallViewControllerNoChecksTests.swift
+++ b/Tests/SuperwallKitTests/Paywall/Presentation/Get Track Result/Operators/GetPaywallViewControllerNoChecksTests.swift
@@ -66,7 +66,7 @@ final class GetPaywallVcNoChecksOperatorTests: XCTestCase {
       factory: dependencyContainer,
       paywallRequestManager: dependencyContainer.paywallRequestManager
     )
-    paywallManager.getPaywallVc = dependencyContainer.makePaywallViewController(for: .stub(), withCache: nil)
+    paywallManager.getPaywallVc = dependencyContainer.makePaywallViewController(for: .stub(), withCache: nil, delegate: nil)
 
     let publisher = CurrentValueSubject<SubscriptionStatus, Never>(SubscriptionStatus.inactive)
       .eraseToAnyPublisher()

--- a/Tests/SuperwallKitTests/Paywall/Presentation/Internal Presentation/Operators/CheckPaywallPresentableOperatorTests.swift
+++ b/Tests/SuperwallKitTests/Paywall/Presentation/Internal Presentation/Operators/CheckPaywallPresentableOperatorTests.swift
@@ -45,7 +45,7 @@ final class CheckPaywallPresentableOperatorTests: XCTestCase {
       request: request,
       triggerResult: .paywall(experiment),
       debugInfo: [:],
-      paywallViewController: dependencyContainer.makePaywallViewController(for: .stub(), withCache: nil),
+      paywallViewController: dependencyContainer.makePaywallViewController(for: .stub(), withCache: nil, delegate: nil),
       confirmableAssignment: nil
     )
 
@@ -108,7 +108,7 @@ final class CheckPaywallPresentableOperatorTests: XCTestCase {
       isDebuggerLaunched: false,
       subscriptionStatus: inactiveSubscriptionPublisher,
       isPaywallPresented: false,
-      type: .getPaywallViewController
+      type: .getPaywallViewController(.stub())
     )
     .setting(\.presenter, to: nil)
     
@@ -116,7 +116,7 @@ final class CheckPaywallPresentableOperatorTests: XCTestCase {
       request: request,
       triggerResult: .paywall(experiment),
       debugInfo: [:],
-      paywallViewController: dependencyContainer.makePaywallViewController(for: .stub(), withCache: nil),
+      paywallViewController: dependencyContainer.makePaywallViewController(for: .stub(), withCache: nil, delegate: nil),
       confirmableAssignment: nil
     )
 
@@ -170,7 +170,7 @@ final class CheckPaywallPresentableOperatorTests: XCTestCase {
       request: request,
       triggerResult: .paywall(experiment),
       debugInfo: [:],
-      paywallViewController: dependencyContainer.makePaywallViewController(for: .stub(), withCache: nil),
+      paywallViewController: dependencyContainer.makePaywallViewController(for: .stub(), withCache: nil, delegate: nil),
       confirmableAssignment: nil
     )
 

--- a/Tests/SuperwallKitTests/Paywall/Presentation/Internal Presentation/Operators/CheckUserSubscriptionOperatorTests.swift
+++ b/Tests/SuperwallKitTests/Paywall/Presentation/Internal Presentation/Operators/CheckUserSubscriptionOperatorTests.swift
@@ -22,7 +22,7 @@ final class CheckUserSubscriptionOperatorTests: XCTestCase {
       isDebuggerLaunched: false,
       subscriptionStatus: publisher,
       isPaywallPresented: false,
-      type: .getPaywallViewController
+      type: .getPaywallViewController(.stub())
     )
 
     let input = AssignmentPipelineOutput(
@@ -84,7 +84,7 @@ final class CheckUserSubscriptionOperatorTests: XCTestCase {
       isDebuggerLaunched: false,
       subscriptionStatus: publisher,
       isPaywallPresented: false,
-      type: .getPaywallViewController
+      type: .getPaywallViewController(.stub())
     )
 
     let input = AssignmentPipelineOutput(
@@ -131,7 +131,7 @@ final class CheckUserSubscriptionOperatorTests: XCTestCase {
       isDebuggerLaunched: false,
       subscriptionStatus: publisher,
       isPaywallPresented: false,
-      type: .getPaywallViewController
+      type: .getPaywallViewController(.stub())
     )
 
     let input = AssignmentPipelineOutput(

--- a/Tests/SuperwallKitTests/Paywall/Presentation/Internal Presentation/Operators/ConfirmHoldoutAssignmentTests.swift
+++ b/Tests/SuperwallKitTests/Paywall/Presentation/Internal Presentation/Operators/ConfirmHoldoutAssignmentTests.swift
@@ -35,7 +35,7 @@ final class ConfirmHoldoutAssignmentOperatorTests: XCTestCase {
       isDebuggerLaunched: false,
       subscriptionStatus: inactiveSubscriptionPublisher,
       isPaywallPresented: false,
-      type: .getPaywallViewController
+      type: .getPaywallViewController(.stub())
     )
     let input = AssignmentPipelineOutput(
       request: request,
@@ -83,7 +83,7 @@ final class ConfirmHoldoutAssignmentOperatorTests: XCTestCase {
       isDebuggerLaunched: false,
       subscriptionStatus: inactiveSubscriptionPublisher,
       isPaywallPresented: false,
-      type: .getPaywallViewController
+      type: .getPaywallViewController(.stub())
     )
 
     let input = AssignmentPipelineOutput(
@@ -132,7 +132,7 @@ final class ConfirmHoldoutAssignmentOperatorTests: XCTestCase {
       isDebuggerLaunched: false,
       subscriptionStatus: inactiveSubscriptionPublisher,
       isPaywallPresented: false,
-      type: .getPaywallViewController
+      type: .getPaywallViewController(.stub())
     )
     let input = AssignmentPipelineOutput(
       request: request,

--- a/Tests/SuperwallKitTests/Paywall/Presentation/Internal Presentation/Operators/ConfirmPaywallAssignmentOperatorTests.swift
+++ b/Tests/SuperwallKitTests/Paywall/Presentation/Internal Presentation/Operators/ConfirmPaywallAssignmentOperatorTests.swift
@@ -31,7 +31,7 @@ final class ConfirmPaywallAssignmentOperatorTests: XCTestCase {
     let input = PresentablePipelineOutput(
       request: request,
       debugInfo: [:],
-      paywallViewController: dependencyContainer.makePaywallViewController(for: .stub(), withCache: nil),
+      paywallViewController: dependencyContainer.makePaywallViewController(for: .stub(), withCache: nil, delegate: nil),
       presenter: UIViewController(),
       confirmableAssignment: ConfirmableAssignment(experimentId: "", variant: .init(id: "", type: .treatment, paywallId: ""))
     )
@@ -74,7 +74,7 @@ final class ConfirmPaywallAssignmentOperatorTests: XCTestCase {
     let input = PresentablePipelineOutput(
       request: request,
       debugInfo: [:],
-      paywallViewController: dependencyContainer.makePaywallViewController(for: .stub(), withCache: nil),
+      paywallViewController: dependencyContainer.makePaywallViewController(for: .stub(), withCache: nil, delegate: nil),
       presenter: UIViewController(),
       confirmableAssignment: nil
     )
@@ -115,13 +115,13 @@ final class ConfirmPaywallAssignmentOperatorTests: XCTestCase {
       .explicitTrigger(.stub()),
       isDebuggerLaunched: false,
       isPaywallPresented: false,
-      type: .getPaywallViewController
+      type: .getPaywallViewController(.stub())
     )
 
     let input = PresentablePipelineOutput(
       request: request,
       debugInfo: [:],
-      paywallViewController: dependencyContainer.makePaywallViewController(for: .stub(), withCache: nil),
+      paywallViewController: dependencyContainer.makePaywallViewController(for: .stub(), withCache: nil, delegate: nil),
       presenter: UIViewController(),
       confirmableAssignment: ConfirmableAssignment(experimentId: "", variant: .init(id: "", type: .treatment, paywallId: ""))
     )

--- a/Tests/SuperwallKitTests/Paywall/Presentation/Internal Presentation/Operators/EvaluateRulesOperatorTests.swift
+++ b/Tests/SuperwallKitTests/Paywall/Presentation/Internal Presentation/Operators/EvaluateRulesOperatorTests.swift
@@ -23,7 +23,7 @@ final class EvaluateRulesOperatorTests: XCTestCase {
       isDebuggerLaunched: true,
       subscriptionStatus: inactiveSubscriptionPublisher,
       isPaywallPresented: false,
-      type: .getPaywallViewController
+      type: .getPaywallViewController(.stub())
     )
 
     let debugInfo: [String: Any] = [:]
@@ -67,7 +67,7 @@ final class EvaluateRulesOperatorTests: XCTestCase {
       isDebuggerLaunched: false,
       subscriptionStatus: inactiveSubscriptionPublisher,
       isPaywallPresented: false,
-      type: .getPaywallViewController
+      type: .getPaywallViewController(.stub())
     )
 
     let debugInfo: [String: Any] = [:]

--- a/Tests/SuperwallKitTests/Paywall/Presentation/Internal Presentation/Operators/GetPaywallVcOperatorTests.swift
+++ b/Tests/SuperwallKitTests/Paywall/Presentation/Internal Presentation/Operators/GetPaywallVcOperatorTests.swift
@@ -65,7 +65,7 @@ final class GetPaywallVcOperatorTests: XCTestCase {
     CurrentValueSubject(input)
       .setFailureType(to: Error.self)
       .eraseToAnyPublisher()
-      .getPaywallViewController(pipelineType: .presentation(statePublisher))
+      .getPaywallViewController(statePublisher)
       .eraseToAnyPublisher()
       .sink(
         receiveCompletion: { completion in
@@ -81,8 +81,6 @@ final class GetPaywallVcOperatorTests: XCTestCase {
         }
       )
       .store(in: &cancellables)
-
-    try? await Task.sleep(nanoseconds: 1_000_000)
 
     await fulfillment(of: [expectation, stateExpectation], timeout: 0.1)
   }
@@ -135,7 +133,7 @@ final class GetPaywallVcOperatorTests: XCTestCase {
     CurrentValueSubject(input)
       .setFailureType(to: Error.self)
       .eraseToAnyPublisher()
-      .getPaywallViewController(pipelineType: .presentation(statePublisher))
+      .getPaywallViewController(statePublisher)
       .eraseToAnyPublisher()
       .sink(
         receiveCompletion: { completion in
@@ -173,7 +171,7 @@ final class GetPaywallVcOperatorTests: XCTestCase {
       factory: dependencyContainer,
       paywallRequestManager: dependencyContainer.paywallRequestManager
     )
-    paywallManager.getPaywallVc = dependencyContainer.makePaywallViewController(for: .stub(), withCache: nil)
+    paywallManager.getPaywallVc = dependencyContainer.makePaywallViewController(for: .stub(), withCache: nil, delegate: nil)
 
     let request = PresentationRequest.stub()
       .setting(\.dependencyContainer.paywallManager, to: paywallManager)
@@ -191,7 +189,7 @@ final class GetPaywallVcOperatorTests: XCTestCase {
     CurrentValueSubject(input)
       .setFailureType(to: Error.self)
       .eraseToAnyPublisher()
-      .getPaywallViewController(pipelineType: .presentation(statePublisher))
+      .getPaywallViewController(statePublisher)
       .eraseToAnyPublisher()
       .sink(
         receiveCompletion: { completion in

--- a/Tests/SuperwallKitTests/Paywall/Presentation/Internal Presentation/Operators/StorePresentationObjectsOperatorTests.swift
+++ b/Tests/SuperwallKitTests/Paywall/Presentation/Internal Presentation/Operators/StorePresentationObjectsOperatorTests.swift
@@ -20,7 +20,7 @@ final class StorePresentationObjectsOperatorTests: XCTestCase {
     let input = PresentablePipelineOutput(
       request: request,
       debugInfo: [:],
-      paywallViewController: dependencyContainer.makePaywallViewController(for: .stub(), withCache: nil),
+      paywallViewController: dependencyContainer.makePaywallViewController(for: .stub(), withCache: nil, delegate: nil),
       presenter: UIViewController(),
       confirmableAssignment: nil
     )

--- a/Tests/SuperwallKitTests/Paywall/Presentation/Internal Presentation/Operators/WaitToPresentOperatorTests.swift
+++ b/Tests/SuperwallKitTests/Paywall/Presentation/Internal Presentation/Operators/WaitToPresentOperatorTests.swift
@@ -110,7 +110,7 @@ final class WaitToPresentTests: XCTestCase {
       paywallOverrides: nil,
       isDebuggerLaunched: false,
       isPaywallPresented: false,
-      type: .getPaywallViewController
+      type: .getPaywallViewController(.stub())
     )
     .setting(\.dependencyContainer.identityManager, to: identityManager)
     .setting(\.flags.subscriptionStatus, to: unknownSubscriptionPublisher)


### PR DESCRIPTION
## Changes in this pull request

- Adds a `PaywallViewControllerDelegate` to the `getPaywallViewController` functions. This is mandatory and is how you control what happens after a paywall is dismissed.
- Renamed the `PaywallResult` case `closed` to `declined`.

### Enhancements

- Adds Objective-C convenience methods to `PaywallOverrides`.
- Adds a `device.isFirstSession` property that you can use in paywall rules. This is `true` for the very first time a user opens the app. When the user closes and reopens the app, this will be `false`.
- Removes the need to tell us when you're going to present/have presented a `PaywallViewController` that has been retrieved using `getPaywallViewController(...)`.

### Fixes

- Fixes a crash when calling `reset()` when a paywall is displayed.

### Checklist

- [x] All tests pass. Demo project builds and runs.
- [ ] I added tests, an experiment, or detailed why my change isn't tested.
- [x] I added an entry to the `CHANGELOG.md` for any breaking changes, enhancements, or bug fixes.
- [x] I have run `swiftlint` in the main directory and fixed any issues.
- [ ] I have updated the SDK documentation as well as the online docs.
- [x] I have reviewed the [contributing guide](https://github.com/superwall-me/paywall-ios/tree/master/.github/CONTRIBUTING.md)
