### PR TITLE
Hotfix for SwiftUI users

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 The changelog for `SuperwallKit`. Also see the [releases](https://github.com/superwall-me/Superwall-iOS/releases) on GitHub.
 
+## 3.0.1
+
+- Fixes bug that prevented Superwall from configuring when SwiftUI users in sandbox mode used the App file's `init()` to configure Superwall.
+
 ## 3.0.0
 
 Welcome to `SuperwallKit` v3.0, the framework formally known as `Paywall`!

--- a/Sources/SuperwallKit/Config/ConfigManager.swift
+++ b/Sources/SuperwallKit/Config/ConfigManager.swift
@@ -89,11 +89,6 @@ class ConfigManager {
 
   func fetchConfiguration() async {
     do {
-      // Refresh receipt in sandbox. Can't do this in production because
-      // it'll prompt the user to enter App Store login details.
-      if factory.makeIsSandbox() {
-        await storeKitManager.refreshReceipt()
-      }
       await storeKitManager.loadPurchasedProducts()
 
       let config = try await network.getConfig { [weak self] in

--- a/Sources/SuperwallKit/Misc/Constants.swift
+++ b/Sources/SuperwallKit/Misc/Constants.swift
@@ -18,5 +18,5 @@ let sdkVersion = """
 */
 
 let sdkVersion = """
-3.0.0
+3.0.1
 """

--- a/Sources/SuperwallKit/StoreKit/Products/Receipt Manager/ReceiptManager.swift
+++ b/Sources/SuperwallKit/StoreKit/Products/Receipt Manager/ReceiptManager.swift
@@ -103,10 +103,6 @@ actor ReceiptManager: NSObject {
 
   /// Refreshes the receipt.
   func refreshReceipt() async {
-    // Wait for connected scenes to exist. Prevents bug
-    // in SwiftUI where the receipt wouldn't finish refreshing.
-    _ = await UIApplication.shared.connectedScenes
-
     Logger.debug(
       logLevel: .debug,
       scope: .receipts,

--- a/Sources/SuperwallKit/StoreKit/Products/Receipt Manager/ReceiptManager.swift
+++ b/Sources/SuperwallKit/StoreKit/Products/Receipt Manager/ReceiptManager.swift
@@ -103,6 +103,10 @@ actor ReceiptManager: NSObject {
 
   /// Refreshes the receipt.
   func refreshReceipt() async {
+    // Wait for connected scenes to exist. Prevents bug
+    // in SwiftUI where the receipt wouldn't finish refreshing.
+    _ = await UIApplication.shared.connectedScenes
+
     Logger.debug(
       logLevel: .debug,
       scope: .receipts,

--- a/SuperwallKit.podspec
+++ b/SuperwallKit.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
 
 	s.name         = "SuperwallKit"
-    s.version      = "3.0.0"
+    s.version      = "3.0.1"
 	s.summary      = "Superwall: In-App Paywalls Made Easy"
 	s.description  = "Paywall infrastructure for mobile apps :) we make things like editing your paywall and running price tests as easy as clicking a few buttons. superwall.com"
 


### PR DESCRIPTION
## Changes in this pull request

- Fixes bug that prevented Superwall from configuring when SwiftUI users in sandbox mode used the App file's `init()` to configure Superwall.

### Checklist

- [x] All tests pass. Demo project builds and runs.
- [ ] I added tests, an experiment, or detailed why my change isn't tested.
- [x] I added an entry to the `CHANGELOG.md` for any breaking changes, enhancements, or bug fixes.
- [x] I have run `swiftlint` in the main directory and fixed any issues.
- [ ] I have updated the SDK documentation as well as the online docs.
- [x] I have reviewed the [contributing guide](https://github.com/superwall-me/paywall-ios/tree/master/.github/CONTRIBUTING.md)
