### PR TITLE
v3.0.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The changelog for `SuperwallKit`. Also see the [releases](https://github.com/superwall-me/Superwall-iOS/releases) on GitHub.
 
+## 3.0.3
+
+### Fixes
+
+- Fixes an issue where Superwall events such as `app_launch` weren't working as paywall triggers.
+
 ## 3.0.2
 
 ### Fixes

--- a/Sources/SuperwallKit/Analytics/Internal Tracking/Tracking.swift
+++ b/Sources/SuperwallKit/Analytics/Internal Tracking/Tracking.swift
@@ -75,7 +75,9 @@ extension Superwall {
     forEvent event: Trackable,
     withData eventData: EventData
   ) async {
-    await dependencyContainer.identityManager.hasIdentity.async()
+    await dependencyContainer.configManager.configState
+      .compactMap { $0.getConfig() }
+      .async()
 
     let presentationInfo: PresentationInfo = .implicitTrigger(eventData)
 

--- a/Sources/SuperwallKit/Misc/Constants.swift
+++ b/Sources/SuperwallKit/Misc/Constants.swift
@@ -18,5 +18,5 @@ let sdkVersion = """
 */
 
 let sdkVersion = """
-3.0.2
+3.0.3
 """

--- a/SuperwallKit.podspec
+++ b/SuperwallKit.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
 
 	s.name         = "SuperwallKit"
-    s.version      = "3.0.2"
+    s.version      = "3.0.3"
 	s.summary      = "Superwall: In-App Paywalls Made Easy"
 	s.description  = "Paywall infrastructure for mobile apps :) we make things like editing your paywall and running price tests as easy as clicking a few buttons. superwall.com"
 


### PR DESCRIPTION
## Changes in this pull request

### Fixes

- Fixes an issue where internal events such as `app_launch` weren't working as paywall triggers. We need to wait for config to return before we can work out whether a implicitly tracked Superwall event should present a paywall. This wasn't happening!

### Checklist

- [x] All tests pass. Demo project builds and runs.
- [x] I added tests, an experiment, or detailed why my change isn't tested.
- [x] I added an entry to the `CHANGELOG.md` for any breaking changes, enhancements, or bug fixes.
- [x] I have run `swiftlint` in the main directory and fixed any issues.
- [ ] I have updated the SDK documentation as well as the online docs.
- [x] I have reviewed the [contributing guide](https://github.com/superwall-me/paywall-ios/tree/master/.github/CONTRIBUTING.md)
