### PR TITLE
Feature/notification system

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,11 @@
 
 The changelog for `SuperwallKit`. Also see the [releases](https://github.com/superwall-me/Superwall-iOS/releases) on GitHub.
 
-## 3.0.4
+## 3.1.0
+
+### Enhancements
+
+- Adds support for paywalls that include a free trial notification. After starting a free trial, the app checks whether the paywall should notify the user when their trial is about to end. If so, the user will be asked to enable notifications (if they haven't already) before scheduling a local notification. You can add a free trial notification to your paywall from the paywall editor.
 
 ### Fixes
 

--- a/Sources/SuperwallKit/Misc/Constants.swift
+++ b/Sources/SuperwallKit/Misc/Constants.swift
@@ -18,5 +18,5 @@ let sdkVersion = """
 */
 
 let sdkVersion = """
-3.0.4
+3.1.0
 """

--- a/Sources/SuperwallKit/Misc/ThrowableDecodable.swift
+++ b/Sources/SuperwallKit/Misc/ThrowableDecodable.swift
@@ -1,0 +1,16 @@
+//
+//  File.swift
+//  
+//
+//  Created by Yusuf Tör on 28/06/2023.
+//
+
+import Foundation
+
+struct Throwable<T: Decodable>: Decodable {
+  let result: Result<T, Error>
+
+  init(from decoder: Decoder) throws {
+    result = Result { try T(from: decoder) }
+  }
+}

--- a/Sources/SuperwallKit/Models/Paywall/LocalNotification.swift
+++ b/Sources/SuperwallKit/Models/Paywall/LocalNotification.swift
@@ -48,19 +48,5 @@ public final class LocalNotification: NSObject, Decodable {
 @objc(SWKLocalNotificationType)
 public enum LocalNotificationType: Int, Decodable {
   /// The notification will fire after a transaction.
-  case postTransaction
-
-  enum CodingKeys: String {
-    case postTransaction
-  }
-
-  public init(from decoder: Decoder) throws {
-    let container = try decoder.singleValueContainer()
-    let rawValue = try container.decode(String.self)
-    let notificationType = CodingKeys(rawValue: rawValue) ?? .postTransaction
-    switch notificationType {
-    case .postTransaction:
-      self = .postTransaction
-    }
-  }
+  case trialStarted
 }

--- a/Sources/SuperwallKit/Models/Paywall/LocalNotification.swift
+++ b/Sources/SuperwallKit/Models/Paywall/LocalNotification.swift
@@ -26,7 +26,7 @@ public final class LocalNotification: NSObject, Decodable {
   /// The delay to the notification in minutes.
   public let delay: Int
 
-  enum CodingKeys: String, CodingKey  {
+  enum CodingKeys: String, CodingKey {
     case type = "notificationType"
     case title = "title"
     case subtitle = "subtitle"

--- a/Sources/SuperwallKit/Models/Paywall/LocalNotification.swift
+++ b/Sources/SuperwallKit/Models/Paywall/LocalNotification.swift
@@ -28,10 +28,10 @@ public final class LocalNotification: NSObject, Decodable {
 
   enum CodingKeys: String, CodingKey {
     case type = "notificationType"
-    case title = "title"
-    case subtitle = "subtitle"
-    case body = "body"
-    case delay = "delay"
+    case title
+    case subtitle
+    case body
+    case delay
   }
 
   public init(from decoder: Decoder) throws {
@@ -49,4 +49,26 @@ public final class LocalNotification: NSObject, Decodable {
 public enum LocalNotificationType: Int, Decodable {
   /// The notification will fire after a transaction.
   case trialStarted
+
+  enum CodingKeys: String, CodingKey {
+    case trialStarted = "TRIAL_STARTED"
+  }
+
+  public init(from decoder: Decoder) throws {
+    let container = try decoder.singleValueContainer()
+    let rawValue = try container.decode(String.self)
+    let type = CodingKeys(rawValue: rawValue)
+    switch type {
+    case .trialStarted:
+      self = .trialStarted
+    case .none:
+      throw DecodingError.valueNotFound(
+        String.self,
+        .init(
+          codingPath: [],
+          debugDescription: "Unsupported notification type."
+        )
+      )
+    }
+  }
 }

--- a/Sources/SuperwallKit/Models/Paywall/LocalNotification.swift
+++ b/Sources/SuperwallKit/Models/Paywall/LocalNotification.swift
@@ -7,28 +7,60 @@
 
 import Foundation
 
-struct LocalNotification: Decodable {
-  let type: LocalNotificationType
-  let title: String
-  let subtitle: String?
-  let body: String
-  let delay: Milliseconds
+/// A local notification.
+@objc(SWKLocalNotification)
+@objcMembers
+public final class LocalNotification: NSObject, Decodable {
+  /// The type of the notification.
+  public let type: LocalNotificationType
+
+  /// The title text of the notification.
+  public let title: String
+
+  /// The subtitle text of the notification.
+  public let subtitle: String?
+
+  /// The body text of the notification.
+  public let body: String
+
+  /// The delay to the notification in minutes.
+  public let delay: Int
+
+  enum CodingKeys: String, CodingKey  {
+    case type = "notificationType"
+    case title = "title"
+    case subtitle = "subtitle"
+    case body = "body"
+    case delay = "delay"
+  }
+
+  public init(from decoder: Decoder) throws {
+    let values = try decoder.container(keyedBy: CodingKeys.self)
+    type = try values.decode(LocalNotificationType.self, forKey: .type)
+    title = try values.decode(String.self, forKey: .title)
+    subtitle = try values.decodeIfPresent(String.self, forKey: .subtitle)
+    body = try values.decode(String.self, forKey: .body)
+    delay = try values.decode(Int.self, forKey: .delay)
+  }
 }
 
-enum LocalNotificationType: Decodable {
-  case freeTrial
-//
-//  enum CodingKeys: String {
-//    case freeTrial
-//  }
-//
-//  public init(from decoder: Decoder) throws {
-//    let container = try decoder.singleValueContainer()
-//    let rawValue = try container.decode(String.self)
-//    let notificationType = CodingKeys(rawValue: rawValue) ?? .freeTrial
-//    switch notificationType {
-//    case .freeTrial:
-//      self = .freeTrial
-//    }
-//  }
+/// The type of notification.
+@objc(SWKLocalNotificationType)
+public enum LocalNotificationType: Int, Decodable {
+  /// The notification will fire after a transaction.
+  case postTransaction
+
+  enum CodingKeys: String {
+    case postTransaction
+  }
+
+  public init(from decoder: Decoder) throws {
+    let container = try decoder.singleValueContainer()
+    let rawValue = try container.decode(String.self)
+    let notificationType = CodingKeys(rawValue: rawValue) ?? .postTransaction
+    switch notificationType {
+    case .postTransaction:
+      self = .postTransaction
+    }
+  }
 }

--- a/Sources/SuperwallKit/Models/Paywall/LocalNotification.swift
+++ b/Sources/SuperwallKit/Models/Paywall/LocalNotification.swift
@@ -1,0 +1,34 @@
+//
+//  File.swift
+//  
+//
+//  Created by Yusuf Tör on 19/06/2023.
+//
+
+import Foundation
+
+struct LocalNotification: Decodable {
+  let type: LocalNotificationType
+  let title: String
+  let subtitle: String?
+  let body: String
+  let delay: Milliseconds
+}
+
+enum LocalNotificationType: Decodable {
+  case freeTrial
+//
+//  enum CodingKeys: String {
+//    case freeTrial
+//  }
+//
+//  public init(from decoder: Decoder) throws {
+//    let container = try decoder.singleValueContainer()
+//    let rawValue = try container.decode(String.self)
+//    let notificationType = CodingKeys(rawValue: rawValue) ?? .freeTrial
+//    switch notificationType {
+//    case .freeTrial:
+//      self = .freeTrial
+//    }
+//  }
+}

--- a/Sources/SuperwallKit/Models/Paywall/Paywall.swift
+++ b/Sources/SuperwallKit/Models/Paywall/Paywall.swift
@@ -177,7 +177,12 @@ struct Paywall: Decodable {
 
     featureGating = try values.decodeIfPresent(FeatureGatingBehavior.self, forKey: .featureGating) ?? .nonGated
     onDeviceCache = try values.decodeIfPresent(OnDeviceCaching.self, forKey: .onDeviceCache) ?? .disabled
-    localNotifications = try values.decodeIfPresent([LocalNotification].self, forKey: .localNotifications) ?? []
+
+    let throwableNotifications = try values.decodeIfPresent(
+      [Throwable<LocalNotification>].self,
+      forKey: .localNotifications
+    ) ?? []
+    localNotifications = throwableNotifications.compactMap { try? $0.result.get() }
   }
 
   init(

--- a/Sources/SuperwallKit/Models/Paywall/Paywall.swift
+++ b/Sources/SuperwallKit/Models/Paywall/Paywall.swift
@@ -95,6 +95,9 @@ struct Paywall: Decodable {
   /// user does not purchase.
   var featureGating: FeatureGatingBehavior
 
+  /// The local notifications for the paywall, e.g. to notify the user of free trial expiry.
+  var localNotifications: [LocalNotification]
+
   enum CodingKeys: String, CodingKey {
     case id
     case identifier
@@ -107,6 +110,7 @@ struct Paywall: Decodable {
     case products
     case featureGating
     case onDeviceCache
+    case localNotifications
 
     case responseLoadStartTime
     case responseLoadCompleteTime
@@ -173,6 +177,7 @@ struct Paywall: Decodable {
 
     featureGating = try values.decodeIfPresent(FeatureGatingBehavior.self, forKey: .featureGating) ?? .nonGated
     onDeviceCache = try values.decodeIfPresent(OnDeviceCaching.self, forKey: .onDeviceCache) ?? .disabled
+    localNotifications = try values.decodeIfPresent([LocalNotification].self, forKey: .localNotifications) ?? []
   }
 
   init(
@@ -196,7 +201,8 @@ struct Paywall: Decodable {
     swTemplateProductVariables: [ProductVariable]? = [],
     isFreeTrialAvailable: Bool = false,
     featureGating: FeatureGatingBehavior = .nonGated,
-    onDeviceCache: OnDeviceCaching = .disabled
+    onDeviceCache: OnDeviceCaching = .disabled,
+    localNotifications: [LocalNotification] = []
   ) {
     self.databaseId = databaseId
     self.identifier = identifier
@@ -219,6 +225,7 @@ struct Paywall: Decodable {
     self.isFreeTrialAvailable = isFreeTrialAvailable
     self.featureGating = featureGating
     self.onDeviceCache = onDeviceCache
+    self.localNotifications = localNotifications
   }
 
   func getInfo(

--- a/Sources/SuperwallKit/Paywall/Presentation/PaywallInfo.swift
+++ b/Sources/SuperwallKit/Paywall/Presentation/PaywallInfo.swift
@@ -98,6 +98,8 @@ public final class PaywallInfo: NSObject {
   /// An enum describing why this paywall was last closed. `none` if not yet closed.
   public let closeReason: PaywallCloseReason
 
+  public let localNotifications: [LocalNotification]
+
   private unowned let factory: TriggerSessionManagerFactory
 
   init(
@@ -121,7 +123,8 @@ public final class PaywallInfo: NSObject {
     isFreeTrialAvailable: Bool,
     factory: TriggerSessionManagerFactory,
     featureGatingBehavior: FeatureGatingBehavior = .nonGated,
-    closeReason: PaywallCloseReason = .none
+    closeReason: PaywallCloseReason = .none,
+    localNotifications: [LocalNotification] = []
   ) {
     self.databaseId = databaseId
     self.identifier = identifier
@@ -136,6 +139,7 @@ public final class PaywallInfo: NSObject {
     self.productIds = products.map { $0.id }
     self.isFreeTrialAvailable = isFreeTrialAvailable
     self.featureGatingBehavior = featureGatingBehavior
+    self.localNotifications = localNotifications
 
     if eventData != nil {
       self.presentedBy = "event"

--- a/Sources/SuperwallKit/StoreKit/Transactions/NotificationScheduler.swift
+++ b/Sources/SuperwallKit/StoreKit/Transactions/NotificationScheduler.swift
@@ -1,0 +1,60 @@
+//
+//  File.swift
+//  
+//
+//  Created by Yusuf Tör on 19/06/2023.
+//
+
+import Foundation
+import UserNotifications
+
+enum NotificationScheduler {
+  static func scheduleNotification(_ notification: LocalNotification) async {
+    guard await checkIsAuthorized() else {
+      return
+    }
+
+    let content = UNMutableNotificationContent()
+    content.title = notification.title
+    content.subtitle = notification.subtitle ?? ""
+
+    // Show this notification X seconds from now.
+    let trigger = UNTimeIntervalNotificationTrigger(
+      timeInterval: notification.delay * 1000,
+      repeats: false
+    )
+
+    // Choose a random identifier
+    let request = UNNotificationRequest(
+      identifier: UUID().uuidString,
+      content: content,
+      trigger: trigger
+    )
+
+    // Add our notification request
+    do {
+      try await UNUserNotificationCenter.current().add(request)
+    } catch {
+      Logger.debug(
+        logLevel: .warn,
+        scope: .paywallViewController,
+        message: "Could not schedule notification with title \(notification.title)"
+      )
+    }
+  }
+
+  static func checkIsAuthorized() async -> Bool {
+    return await withCheckedContinuation { continuation in
+      UNUserNotificationCenter.current().getNotificationSettings { settings in
+        switch settings.authorizationStatus {
+        case .authorized,
+          .ephemeral,
+          .provisional:
+          continuation.resume(returning: true)
+        default:
+          continuation.resume(returning: false)
+        }
+      }
+    }
+  }
+}

--- a/Sources/SuperwallKit/StoreKit/Transactions/NotificationScheduler.swift
+++ b/Sources/SuperwallKit/StoreKit/Transactions/NotificationScheduler.swift
@@ -17,13 +17,12 @@ enum NotificationScheduler {
     let center = UNUserNotificationCenter.current()
 
     return await withCheckedContinuation { continuation in
-      center.requestAuthorization(options: [.alert, .sound, .badge]) { _, error in
-        if error == nil {
+      center.requestAuthorization(options: [.alert, .sound, .badge]) { isAuthorized, _ in
+        if isAuthorized {
           return continuation.resume(returning: true)
         } else {
           return continuation.resume(returning: false)
         }
-        // Enable or disable features based on the authorization.
       }
     }
   }
@@ -49,6 +48,7 @@ enum NotificationScheduler {
     let content = UNMutableNotificationContent()
     content.title = notification.title
     content.subtitle = notification.subtitle ?? ""
+    content.body = notification.body
 
     // Show this notification X seconds from now.
     let trigger = UNTimeIntervalNotificationTrigger(

--- a/Sources/SuperwallKit/StoreKit/Transactions/NotificationScheduler.swift
+++ b/Sources/SuperwallKit/StoreKit/Transactions/NotificationScheduler.swift
@@ -17,12 +17,12 @@ enum NotificationScheduler {
     let center = UNUserNotificationCenter.current()
 
     return await withCheckedContinuation { continuation in
-      center.requestAuthorization(options: [.alert, .sound, .badge]) { granted, error in
-        if let error = error {
-          // Handle the error here.
+      center.requestAuthorization(options: [.alert, .sound, .badge]) { _, error in
+        if error == nil {
+          return continuation.resume(returning: true)
+        } else {
           return continuation.resume(returning: false)
         }
-        continuation.resume(returning: true)
         // Enable or disable features based on the authorization.
       }
     }

--- a/Sources/SuperwallKit/StoreKit/Transactions/NotificationScheduler.swift
+++ b/Sources/SuperwallKit/StoreKit/Transactions/NotificationScheduler.swift
@@ -9,18 +9,47 @@ import Foundation
 import UserNotifications
 
 enum NotificationScheduler {
-  static func scheduleNotification(_ notification: LocalNotification) async {
-    guard await checkIsAuthorized() else {
+  private static func askForPermissionsIfNecessary() async -> Bool {
+    if await checkIsAuthorized() {
+      return true
+    }
+
+    let center = UNUserNotificationCenter.current()
+
+    return await withCheckedContinuation { continuation in
+      center.requestAuthorization(options: [.alert, .sound, .badge]) { granted, error in
+        if let error = error {
+          // Handle the error here.
+          return continuation.resume(returning: false)
+        }
+        continuation.resume(returning: true)
+        // Enable or disable features based on the authorization.
+      }
+    }
+  }
+
+  static func scheduleNotifications(_ notifications: [LocalNotification]) async {
+    guard await NotificationScheduler.askForPermissionsIfNecessary() else {
       return
     }
 
+    await withTaskGroup(of: Void.self) { taskGroup in
+      for notification in notifications {
+        taskGroup.addTask {
+          await scheduleNotification(notification)
+        }
+      }
+    }
+  }
+
+  private static func scheduleNotification(_ notification: LocalNotification) async {
     let content = UNMutableNotificationContent()
     content.title = notification.title
     content.subtitle = notification.subtitle ?? ""
 
     // Show this notification X seconds from now.
     let trigger = UNTimeIntervalNotificationTrigger(
-      timeInterval: notification.delay * 1000,
+      timeInterval: TimeInterval(notification.delay * 60),
       repeats: false
     )
 
@@ -43,7 +72,7 @@ enum NotificationScheduler {
     }
   }
 
-  static func checkIsAuthorized() async -> Bool {
+  private static func checkIsAuthorized() async -> Bool {
     return await withCheckedContinuation { continuation in
       UNUserNotificationCenter.current().getNotificationSettings { settings in
         switch settings.authorizationStatus {

--- a/Sources/SuperwallKit/StoreKit/Transactions/NotificationScheduler.swift
+++ b/Sources/SuperwallKit/StoreKit/Transactions/NotificationScheduler.swift
@@ -29,6 +29,9 @@ enum NotificationScheduler {
   }
 
   static func scheduleNotifications(_ notifications: [LocalNotification]) async {
+    if notifications.isEmpty {
+      return
+    }
     guard await NotificationScheduler.askForPermissionsIfNecessary() else {
       return
     }

--- a/Sources/SuperwallKit/StoreKit/Transactions/TransactionManager.swift
+++ b/Sources/SuperwallKit/StoreKit/Transactions/TransactionManager.swift
@@ -286,7 +286,6 @@ final class TransactionManager {
         product: product
       )
       await Superwall.shared.track(trackedEvent)
-
     } else {
       let trackedEvent = InternalSuperwallEvent.SubscriptionStart(
         paywallInfo: paywallInfo,

--- a/Sources/SuperwallKit/StoreKit/Transactions/TransactionManager.swift
+++ b/Sources/SuperwallKit/StoreKit/Transactions/TransactionManager.swift
@@ -286,6 +286,19 @@ final class TransactionManager {
         product: product
       )
       await Superwall.shared.track(trackedEvent)
+
+      // TODO: Maybe move to paywallInfo
+      let paywall = await paywallViewController.paywall
+
+      let notifications = paywall.localNotifications.filter { $0.type == .freeTrial }
+
+      await withTaskGroup(of: Void.self) { taskGroup in
+        for notification in notifications {
+          taskGroup.addTask {
+            await NotificationScheduler.scheduleNotification(notification)
+          }
+        }
+      }
     } else {
       let trackedEvent = InternalSuperwallEvent.SubscriptionStart(
         paywallInfo: paywallInfo,

--- a/Sources/SuperwallKit/StoreKit/Transactions/TransactionManager.swift
+++ b/Sources/SuperwallKit/StoreKit/Transactions/TransactionManager.swift
@@ -286,6 +286,12 @@ final class TransactionManager {
         product: product
       )
       await Superwall.shared.track(trackedEvent)
+
+      let notifications = paywallInfo.localNotifications.filter {
+        $0.type == .trialStarted
+      }
+
+      await NotificationScheduler.scheduleNotifications(notifications)
     } else {
       let trackedEvent = InternalSuperwallEvent.SubscriptionStart(
         paywallInfo: paywallInfo,
@@ -293,12 +299,6 @@ final class TransactionManager {
       )
       await Superwall.shared.track(trackedEvent)
     }
-
-    let notifications = paywallInfo.localNotifications.filter {
-      $0.type == .postTransaction
-    }
-
-    await NotificationScheduler.scheduleNotifications(notifications)
 
     lastPaywallViewController = nil
   }

--- a/Sources/SuperwallKit/StoreKit/Transactions/TransactionManager.swift
+++ b/Sources/SuperwallKit/StoreKit/Transactions/TransactionManager.swift
@@ -287,18 +287,6 @@ final class TransactionManager {
       )
       await Superwall.shared.track(trackedEvent)
 
-      // TODO: Maybe move to paywallInfo
-      let paywall = await paywallViewController.paywall
-
-      let notifications = paywall.localNotifications.filter { $0.type == .freeTrial }
-
-      await withTaskGroup(of: Void.self) { taskGroup in
-        for notification in notifications {
-          taskGroup.addTask {
-            await NotificationScheduler.scheduleNotification(notification)
-          }
-        }
-      }
     } else {
       let trackedEvent = InternalSuperwallEvent.SubscriptionStart(
         paywallInfo: paywallInfo,
@@ -306,6 +294,12 @@ final class TransactionManager {
       )
       await Superwall.shared.track(trackedEvent)
     }
+
+    let notifications = paywallInfo.localNotifications.filter {
+      $0.type == .postTransaction
+    }
+
+    await NotificationScheduler.scheduleNotifications(notifications)
 
     lastPaywallViewController = nil
   }

--- a/SuperwallKit.podspec
+++ b/SuperwallKit.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
 
 	s.name         = "SuperwallKit"
-    s.version      = "3.0.4"
+    s.version      = "3.1.0"
 	s.summary      = "Superwall: In-App Paywalls Made Easy"
 	s.description  = "Paywall infrastructure for mobile apps :) we make things like editing your paywall and running price tests as easy as clicking a few buttons. superwall.com"
 

--- a/Tests/SuperwallKitTests/Models/Config/ConfigResponseTests.swift
+++ b/Tests/SuperwallKitTests/Models/Config/ConfigResponseTests.swift
@@ -66,6 +66,18 @@ let response = #"""
     "identifier": "example-paywall-4de1-2022-03-15"
   }],
   "paywall_responses": [{
+    "local_notifications": [{
+      "notification_type": "SOMETHING",
+      "title": "test",
+      "body": "body",
+      "delay": 5000
+    },
+    {
+      "notification_type": "TRIAL_STARTED",
+      "title": "test",
+      "body": "body",
+      "delay": 5000
+    }],
     "id": "571",
     "url": "https://www.fitnessai.com/superwall-video?sw_cache_key=1659989801716",
     "name": "Example Paywall",


### PR DESCRIPTION
## Changes in this pull request

- Adds support for paywalls that include a free trial notification. After starting a free trial, the app checks whether the paywall should notify the user when their trial is about to end. If so, the user will be asked to enable notifications (if they haven't already) before scheduling a local notification. You can add a free trial notification to your paywall from the paywall editor.

### Checklist

- [x] All tests pass. Demo project builds and runs.
- [x] I added tests, an experiment, or detailed why my change isn't tested.
- [x] I added an entry to the `CHANGELOG.md` for any breaking changes, enhancements, or bug fixes.
- [x] I have run `swiftlint` in the main directory and fixed any issues.
- [ ] I have updated the SDK documentation as well as the online docs.
- [x] I have reviewed the [contributing guide](https://github.com/superwall-me/paywall-ios/tree/master/.github/CONTRIBUTING.md)
