### PR TITLE
v3.1.1

### DIFF
--- a/.swiftpm/xcode/xcshareddata/xcschemes/SuperwallKit.xcscheme
+++ b/.swiftpm/xcode/xcshareddata/xcschemes/SuperwallKit.xcscheme
@@ -26,7 +26,13 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES">
+      shouldUseLaunchSchemeArgsEnv = "NO">
+      <CommandLineArguments>
+         <CommandLineArgument
+            argument = "UNIT_TESTS"
+            isEnabled = "YES">
+         </CommandLineArgument>
+      </CommandLineArguments>
       <Testables>
          <TestableReference
             skipped = "NO">

--- a/.swiftpm/xcode/xcshareddata/xcschemes/SuperwallKit.xcscheme
+++ b/.swiftpm/xcode/xcshareddata/xcschemes/SuperwallKit.xcscheme
@@ -29,7 +29,7 @@
       shouldUseLaunchSchemeArgsEnv = "NO">
       <CommandLineArguments>
          <CommandLineArgument
-            argument = "UNIT_TESTS"
+            argument = "SUPERWALL_UNIT_TESTS"
             isEnabled = "YES">
          </CommandLineArgument>
       </CommandLineArguments>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The changelog for `SuperwallKit`. Also see the [releases](https://github.com/superwall-me/Superwall-iOS/releases) on GitHub.
 
+## 3.1.1
+
+### Fixes
+
+- Internal updates for unit tests.
+
 ## 3.1.0
 
 ### Enhancements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ The changelog for `SuperwallKit`. Also see the [releases](https://github.com/sup
 ### Fixes
 
 - Fixes issue where a secondary paywall wouldn't present with the `transaction_fail` trigger.
-- Fixes issue where the paywall preview wasn't obeying free trial/non-free trial overrides.
+- Fixes issue where the paywall preview wasn't obeying free trial/default paywall overrides.
 - Fixes issue where preloaded paywalls may be associated with the incorrect experiment.
 
 ## 3.1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ The changelog for `SuperwallKit`. Also see the [releases](https://github.com/sup
 
 ## 3.1.1
 
+### Enhancements
+
+- Adds `shouldShowPurchaseFailureAlert` as a `PaywallOption`. This defaults to `true`. If you're using a `PurchaseController`, set this to `false` to disable the alert that shows after the purchase fails.
+
 ### Fixes
 
 - Internal updates for unit tests.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ The changelog for `SuperwallKit`. Also see the [releases](https://github.com/sup
 ### Fixes
 
 - Fixes issue where a secondary paywall wouldn't present with the `transaction_fail` trigger.
+- Fixes issue where the paywall preview wasn't obeying free trial/non-free trial overrides.
+- Fixes issue where preloaded paywalls may be associated with the incorrect experiment.
 
 ## 3.1.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ The changelog for `SuperwallKit`. Also see the [releases](https://github.com/sup
 
 ### Fixes
 
-- Internal updates for unit tests.
+- Fixes issue where a secondary paywall wouldn't present with the `transaction_fail` trigger.
 
 ## 3.1.0
 

--- a/Sources/SuperwallKit/Config/Options/PaywallOptions.swift
+++ b/Sources/SuperwallKit/Config/Options/PaywallOptions.swift
@@ -37,6 +37,12 @@ public final class PaywallOptions: NSObject {
   /// Defines the messaging of the alert presented to the user when restoring a transaction fails.
   public var restoreFailed = RestoreFailed()
 
+  /// Shows an alert after a purchase fails. Defaults to `true`.
+  ///
+  /// Set this to `false` if you're using a `PurchaseController` and want to show
+  /// your own alert after the purchase fails.
+  public var shouldShowPurchaseFailureAlert = true
+
   /// Pre-loads and caches trigger paywalls and products when you initialize the SDK via ``Superwall/configure(apiKey:purchaseController:options:completion:)-52tke``. Defaults to `true`.
   ///
   /// Set this to `false` to load and cache paywalls and products in a just-in-time fashion.

--- a/Sources/SuperwallKit/Dependencies/DependencyContainer.swift
+++ b/Sources/SuperwallKit/Dependencies/DependencyContainer.swift
@@ -430,3 +430,10 @@ extension DependencyContainer: PurchaseManagerFactory {
     )
   }
 }
+
+// MARK: - Options Factory
+extension DependencyContainer: OptionsFactory {
+  func makeSuperwallOptions() -> SuperwallOptions {
+    return configManager.options
+  }
+}

--- a/Sources/SuperwallKit/Dependencies/DependencyContainer.swift
+++ b/Sources/SuperwallKit/Dependencies/DependencyContainer.swift
@@ -437,3 +437,10 @@ extension DependencyContainer: OptionsFactory {
     return configManager.options
   }
 }
+
+// MARK: - Triggers Factory
+extension DependencyContainer: TriggerFactory {
+  func makeTriggers() -> Set<String> {
+    return Set(configManager.triggersByEventName.keys)
+  }
+}

--- a/Sources/SuperwallKit/Dependencies/FactoryProtocols.swift
+++ b/Sources/SuperwallKit/Dependencies/FactoryProtocols.swift
@@ -123,3 +123,7 @@ protocol PurchaseManagerFactory: AnyObject {
 protocol OptionsFactory: AnyObject {
   func makeSuperwallOptions() -> SuperwallOptions
 }
+
+protocol TriggerFactory: AnyObject {
+  func makeTriggers() -> Set<String>
+}

--- a/Sources/SuperwallKit/Dependencies/FactoryProtocols.swift
+++ b/Sources/SuperwallKit/Dependencies/FactoryProtocols.swift
@@ -119,3 +119,7 @@ protocol StoreTransactionFactory: AnyObject {
 protocol PurchaseManagerFactory: AnyObject {
   func makePurchaseManager() -> PurchaseManager
 }
+
+protocol OptionsFactory: AnyObject {
+  func makeSuperwallOptions() -> SuperwallOptions
+}

--- a/Sources/SuperwallKit/Misc/Constants.swift
+++ b/Sources/SuperwallKit/Misc/Constants.swift
@@ -18,5 +18,5 @@ let sdkVersion = """
 */
 
 let sdkVersion = """
-3.1.0
+3.1.1
 """

--- a/Sources/SuperwallKit/Paywall/Request/PaywallRequestManager.swift
+++ b/Sources/SuperwallKit/Paywall/Request/PaywallRequestManager.swift
@@ -58,9 +58,7 @@ actor PaywallRequestManager {
 
     let task = Task<Paywall, Error> {
       do {
-        let rawPaywall = try await getRawPaywall(
-          from: request
-        )
+        let rawPaywall = try await getRawPaywall(from: request)
         let paywallWithProducts = try await addProducts(to: rawPaywall, request: request)
 
         saveRequestHash(

--- a/Sources/SuperwallKit/Paywall/Request/PaywallRequestManager.swift
+++ b/Sources/SuperwallKit/Paywall/Request/PaywallRequestManager.swift
@@ -47,7 +47,7 @@ actor PaywallRequestManager {
     )
 
     if var paywall = paywallsByHash[requestHash],
-      request.isDebuggerLaunched {
+      !request.isDebuggerLaunched {
       paywall.experiment = request.responseIdentifiers.experiment
       return paywall
     }
@@ -86,10 +86,9 @@ actor PaywallRequestManager {
     paywall: Paywall,
     isDebuggerLaunched: Bool
   ) {
-    if isDebuggerLaunched {
-      return
-    }
-    paywallsByHash[requestHash] = paywall
     activeTasks[requestHash] = nil
+    if !isDebuggerLaunched {
+      paywallsByHash[requestHash] = paywall
+    }
   }
 }

--- a/Sources/SuperwallKit/Paywall/View Controller/PaywallViewController.swift
+++ b/Sources/SuperwallKit/Paywall/View Controller/PaywallViewController.swift
@@ -282,7 +282,7 @@ public class PaywallViewController: UIViewController, LoadingDelegate {
   /// - Parameter isHidden: A `Bool` indicating whether to show or hide the spinner.
   public func togglePaywallSpinner(isHidden: Bool) {
     if isHidden {
-      if loadingState == .manualLoading {
+      if loadingState == .manualLoading || loadingState == .loadingPurchase {
         loadingState = .ready
       }
     } else {

--- a/Sources/SuperwallKit/StoreKit/Transactions/TransactionErrorLogic.swift
+++ b/Sources/SuperwallKit/StoreKit/Transactions/TransactionErrorLogic.swift
@@ -21,6 +21,7 @@ enum TransactionErrorLogic {
 
   static func handle(
     _ error: Error,
+    triggers: Set<String>,
     shouldShowPurchaseFailureAlert: Bool
   ) -> ErrorOutcome? {
     if #available(iOS 15.0, *),
@@ -52,7 +53,10 @@ enum TransactionErrorLogic {
       }
     }
 
-    if shouldShowPurchaseFailureAlert {
+    let transactionFailExists = triggers.contains(SuperwallEventObjc.transactionFail.description)
+
+    if shouldShowPurchaseFailureAlert,
+      !transactionFailExists {
       return .presentAlert
     } else {
       return nil

--- a/Sources/SuperwallKit/StoreKit/Transactions/TransactionErrorLogic.swift
+++ b/Sources/SuperwallKit/StoreKit/Transactions/TransactionErrorLogic.swift
@@ -19,7 +19,10 @@ enum TransactionErrorLogic {
     case presentAlert
   }
 
-  static func handle(_ error: Error) -> ErrorOutcome {
+  static func handle(
+    _ error: Error,
+    shouldShowPurchaseFailureAlert: Bool
+  ) -> ErrorOutcome? {
     if #available(iOS 15.0, *),
       let error = error as? StoreKitError {
       switch error {
@@ -49,6 +52,10 @@ enum TransactionErrorLogic {
       }
     }
 
-    return .presentAlert
+    if shouldShowPurchaseFailureAlert {
+      return .presentAlert
+    } else {
+      return nil
+    }
   }
 }

--- a/Sources/SuperwallKit/Superwall.swift
+++ b/Sources/SuperwallKit/Superwall.swift
@@ -128,7 +128,7 @@ public final class Superwall: NSObject, ObservableObject {
       // Code only executes when tests are running in a debug environment.
       // This avoids lots of irrelevent error messages printed to console about Superwall not
       // being configured, which slows down the tests.
-      if ProcessInfo.processInfo.environment["XCTestConfigurationFilePath"] != nil {
+      if ProcessInfo.processInfo.arguments.contains("UNIT_TESTS") {
         let superwall = Superwall()
         self.superwall = superwall
         return superwall

--- a/Sources/SuperwallKit/Superwall.swift
+++ b/Sources/SuperwallKit/Superwall.swift
@@ -128,7 +128,7 @@ public final class Superwall: NSObject, ObservableObject {
       // Code only executes when tests are running in a debug environment.
       // This avoids lots of irrelevent error messages printed to console about Superwall not
       // being configured, which slows down the tests.
-      if ProcessInfo.processInfo.arguments.contains("UNIT_TESTS") {
+      if ProcessInfo.processInfo.arguments.contains("SUPERWALL_UNIT_TESTS") {
         let superwall = Superwall()
         self.superwall = superwall
         return superwall

--- a/SuperwallKit.podspec
+++ b/SuperwallKit.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
 
 	s.name         = "SuperwallKit"
-    s.version      = "3.1.0"
+    s.version      = "3.1.1"
 	s.summary      = "Superwall: In-App Paywalls Made Easy"
 	s.description  = "Paywall infrastructure for mobile apps :) we make things like editing your paywall and running price tests as easy as clicking a few buttons. superwall.com"
 

--- a/SuperwallKit.xcodeproj/project.pbxproj
+++ b/SuperwallKit.xcodeproj/project.pbxproj
@@ -7,287 +7,379 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		0023A25E51427F3BFB0429D2 /* SwiftUIGraveyard.swift in Sources */ = {isa = PBXBuildFile; fileRef = E603038126BB50A2AAE1C4D0 /* SwiftUIGraveyard.swift */; };
-		019397BB0BFA469A1F87C911 /* SWDebugManagerLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 173CADA540CA40A87FAA054C /* SWDebugManagerLogicTests.swift */; };
+		00A15C51FC3B450A7B0F8806 /* PaywallViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7569A0893012A88442B7ED36 /* PaywallViewController.swift */; };
+		01F3133229388B9E69B10E4A /* ASN1Decoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = F49804DCB74FEEFA0D3438A9 /* ASN1Decoder.swift */; };
 		020D985745B77C21039115AC /* UIApplication+ActiveWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74DFC04FC0F3498D1EBE4B6A /* UIApplication+ActiveWindow.swift */; };
-		027D79A608E75E7634525785 /* AppSessionManagerMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = F07DED9EBBD92558DD3ABAD9 /* AppSessionManagerMock.swift */; };
-		0401304BA8F70FBAA1B57C0B /* RawResponseOperator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 719BEEC0C3F6E63F9542A153 /* RawResponseOperator.swift */; };
-		04184388675F18A1DDDE5EAD /* Trackable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7AD581390E2944BCA2603D5B /* Trackable.swift */; };
-		05469D2D28CC098F8497FFCF /* IdentityError.swift in Sources */ = {isa = PBXBuildFile; fileRef = A981B0C90E5F0E40187C0310 /* IdentityError.swift */; };
-		06BD78BAAA64F0EDAE5C944E /* AppSessionManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0570862FCFAF7FB6B125F7E4 /* AppSessionManagerTests.swift */; };
-		06D0B71C6119B03B7CD25A1B /* MockReceiptData.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE253DB1E7B6723EC24216CE /* MockReceiptData.swift */; };
-		070509A5AA94C84993728566 /* SWDebugViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F5EF184B150FC221A8B7CCA /* SWDebugViewController.swift */; };
+		02AA9A72A7FF3EE5773A0235 /* PublicGetPaywall.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5110E43405C69969E9DA67B /* PublicGetPaywall.swift */; };
+		070DFAAB357CE1D547E946E1 /* PurchaseManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73BE8AD685B39ACAB331109C /* PurchaseManager.swift */; };
 		07862D18809FA5DEA95AE440 /* NSManagedObjectContext+mergeChanges.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4B35EF62D8C986B504B052C /* NSManagedObjectContext+mergeChanges.swift */; };
-		0836FF2D327E428E25B5A995 /* ReceiptManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D78D73D3C35F8A910272BD4A /* ReceiptManagerTests.swift */; };
-		08D6A2B29A2969975A569083 /* TransactionProduct.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1269B5184768FDA6BE892B20 /* TransactionProduct.swift */; };
+		07A6A1A089289D8C618F9DCD /* PaywallState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6397684C0676181147C32AFB /* PaywallState.swift */; };
 		0911B1213899E3C4E1620119 /* Dictionary+Keys.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8E9E1A8F57B5DCA4CD16296F /* Dictionary+Keys.swift */; };
-		09E8E3EFFFD8A14688EE323A /* PushTransitionLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14926B3770019BAF544EE626 /* PushTransitionLogic.swift */; };
+		09AA071B4A67A6256D00BDD6 /* PaywallManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 187934D3C89220C605299A17 /* PaywallManager.swift */; };
+		09DB853E1423A0EFE653B0E9 /* StoreProduct.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD8751EBBA905FB4F7E3C0BC /* StoreProduct.swift */; };
+		0A1366F15DD3C1761C095DF5 /* SuperwallOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = CFDA311A030FDFC45AEE248A /* SuperwallOptions.swift */; };
+		0A5EFFC920E6BB29814BD66B /* Foundation+ASN1Coder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80281364A23252E30DEEA1AA /* Foundation+ASN1Coder.swift */; };
+		0AB9CCC164DD87C81318AAB0 /* PublicIdentity.swift in Sources */ = {isa = PBXBuildFile; fileRef = A4493EE88B00CADF85EF1196 /* PublicIdentity.swift */; };
 		0CA13E721ADB243882536D4A /* DeviceHelperMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35F538F901BAF97DDCA86F84 /* DeviceHelperMock.swift */; };
 		0CC202CBE097714F963E0E3B /* Typealiases.swift in Sources */ = {isa = PBXBuildFile; fileRef = 848592ACE8760E53F2163F01 /* Typealiases.swift */; };
-		0CC2CEBF869822B7014B204F /* SuperwallLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 756A55836F8968D362303C55 /* SuperwallLogicTests.swift */; };
-		0F540F0364F986E183B1B3A8 /* IdentityLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1BCAA3FE5110CCAADEA9CC0E /* IdentityLogicTests.swift */; };
-		0FAA671AB9474D156FF539C2 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 56778050EC54F641333F5CDB /* Assets.xcassets */; };
-		0FDB9DD5D456AC7EE1A721D4 /* ShimmerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E709EA62F0785E7025CC3C05 /* ShimmerView.swift */; };
-		110F2CF8CFEAF85C4E99FD74 /* SuperwallOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB338C3E2FCD47EA52FD133E /* SuperwallOptions.swift */; };
-		1115A2ED3A878282F00EEF29 /* PaywallCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = F678F0A727A6D50A073DE6FE /* PaywallCache.swift */; };
+		0DAFB898EE23890CBCEFAF41 /* SubscriptionStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD69396B509844FFA8452452 /* SubscriptionStatus.swift */; };
+		0DE74AADE698D455BDE2F36E /* PushTransitionDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 440ABDF6DAE2C15579B93DF1 /* PushTransitionDelegate.swift */; };
+		0E90E90DE890CC9B5B9AC02B /* ASN1Coder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F72210F85864F3000F13646 /* ASN1Coder.swift */; };
+		101F81081753F2A151386EFA /* CheckSubscriptionStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6E787EFC5201B68C3631FE8 /* CheckSubscriptionStatus.swift */; };
+		113402664781E7374E583FAA /* CheckPaywallPresentableOperatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 079455F8D3D241361EF5F0AA /* CheckPaywallPresentableOperatorTests.swift */; };
 		11477D1EB60D1FDA32F5099A /* Endpoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = 258FC2DB67022EF3D9B1FB67 /* Endpoint.swift */; };
-		117DA7A3104B6B72E57AB526 /* PresentationInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9DE5293C9C76FBE2A418AE67 /* PresentationInfo.swift */; };
 		11C591E04AF6C3814A986463 /* CacheMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54F3977B4B42057743A41FE0 /* CacheMock.swift */; };
+		11FF1373BAAE0B019CE6AE21 /* DebugViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F9098101E599AEB01521FE89 /* DebugViewController.swift */; };
+		1225B991B40D16B7FB4EF1A5 /* EvaluateRulesOperatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16AC8D761A7F5A7F012EA39B /* EvaluateRulesOperatorTests.swift */; };
+		12D25E5674DF81B033C9659E /* FreeTrialTemplate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7553D295A9E169B45FAC1477 /* FreeTrialTemplate.swift */; };
 		1386E66C93D643CAB36FA920 /* Product.swift in Sources */ = {isa = PBXBuildFile; fileRef = D38D3A69A26709BFB52C6A3A /* Product.swift */; };
 		14D4EA6EAA43647D24A9716A /* AlertControllerFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEE0510BC2F7917AA57B896D /* AlertControllerFactory.swift */; };
-		15548573BCFA8370D2A305F4 /* TriggerSessionManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAA2D928566A5D0A3D436865 /* TriggerSessionManager.swift */; };
-		167F63E5A828953F4B43720B /* ExpressionEvaluatorLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE6B12B5C4B4EAC0CD08F50F /* ExpressionEvaluatorLogicTests.swift */; };
-		18754C1CF4D038E4B6961FFB /* PaywallOverrides.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F25D59E046C6483853DDE7D /* PaywallOverrides.swift */; };
-		1AA67756CFB437CDDA2090A5 /* SuperwallDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0897A9C4AC47DEE2F0FB20D4 /* SuperwallDelegate.swift */; };
-		1AF6D0FF3CD50E391BC1E9AC /* SKProduct+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = FCFEE6F37BE497DF44642308 /* SKProduct+Helpers.swift */; };
+		14D8827BA663A0EFD64DEC2C /* TemplateLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65EDE0BAE33F351217CC8E2D /* TemplateLogicTests.swift */; };
+		1753820CBFBDD8FF70455D71 /* ScaleAnimation.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1DF64C51FA26B40D8D7B880 /* ScaleAnimation.swift */; };
+		17C0F1960CD89B6BFA8B2FBB /* SuperwallDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7318EF33D7374DC5C8B4549D /* SuperwallDelegate.swift */; };
+		188B39AA333F5C12E73C75AB /* TriggerSessionProducts.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4D74B23A58D934512BE8470 /* TriggerSessionProducts.swift */; };
+		191AA8FBBF617251EF6F8628 /* DeviceInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E1EFE389B54C304F2B01620 /* DeviceInfo.swift */; };
 		1BDB91B70EAEC10097941381 /* SWBounceButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 299F91895EE88281B5ED8320 /* SWBounceButton.swift */; };
-		1C566DE7B035A21A76A23077 /* TriggerSessionExperiment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C69250C9C29C6062BD58A0C /* TriggerSessionExperiment.swift */; };
-		1D6788C9CE2B4B4BC68EC359 /* PaywallOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10EFDC8DEA3944B23AE6511D /* PaywallOptions.swift */; };
-		1E94FABF1ED17AC6BCB133EE /* PaywallDismissedResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = A584F8FE6F1C4B3ACC0AFACC /* PaywallDismissedResult.swift */; };
-		20E7F1EE5D48B95F3C35D0C0 /* PaywallCacheLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8CE2D05376A82D2185955AFE /* PaywallCacheLogicTests.swift */; };
+		1E7EBE0C39AC302D9B5BFF27 /* PublicGameController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 010F0F8FCE0A86D8F2823A47 /* PublicGameController.swift */; };
+		1E81A71ADE8A5EAD9E609E1D /* AppSessionManagerMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B78FB9232236AF44369EA92 /* AppSessionManagerMock.swift */; };
+		1F20D775BC035F8A75B79323 /* PaywallMessageHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF61DCA9CF170E0AFC507BAE /* PaywallMessageHandler.swift */; };
+		20DD915D754F7819C44A677F /* PaywallInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 299441C3A6D3948BC5E0C741 /* PaywallInfo.swift */; };
 		211B94C3D7CEE3DEF10E5C79 /* EventsQueue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6AFEF7CB116568A60805DF6F /* EventsQueue.swift */; };
 		213E7FC262106BFBC44462AC /* SWLocalizationViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FBE7D1E1AF61D199E17B5C05 /* SWLocalizationViewController.swift */; };
-		2140649137BB5DE1EACC1B74 /* ExpressionEvaluator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4341A45FFB9258457E962532 /* ExpressionEvaluator.swift */; };
-		21A354D6BC2136451BCCA38B /* TriggerOutcomeOperator.swift in Sources */ = {isa = PBXBuildFile; fileRef = A511EA01417DE3299BCD363B /* TriggerOutcomeOperator.swift */; };
+		21F8518DE2D08B40125A79DA /* ProductPurchaserSK1.swift in Sources */ = {isa = PBXBuildFile; fileRef = B14E186AB8E440B5F4E8FE86 /* ProductPurchaserSK1.swift */; };
+		2205A0CC8F059B3D6231C603 /* PaywallLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A7140A8B0B006F2080D8915 /* PaywallLogicTests.swift */; };
+		22B3763157DF592D4E3B27A0 /* InAppReceipt+ASN1.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E80C81546752BCF32016A27 /* InAppReceipt+ASN1.swift */; };
 		234C1753A4606242CA765CA7 /* ManagedTriggerRuleOccurrence.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCFFBE357699F5CAAB803DA7 /* ManagedTriggerRuleOccurrence.swift */; };
-		236FD721BBCC20C9CC44D391 /* Debug.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B0EE285A4202B015060049B /* Debug.swift */; };
-		23DF76717931E199DDE7375A /* ProductTrial.swift in Sources */ = {isa = PBXBuildFile; fileRef = D980856238D5C86BCA6EBBEE /* ProductTrial.swift */; };
+		23A34206DBEDD9DB79BAB702 /* PurchaseController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A96A65416DB25FF601BB68F2 /* PurchaseController.swift */; };
 		241192D89816E5EB2CF174E8 /* SWProductTemplateVariable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7647A0AE11D9C965368742C5 /* SWProductTemplateVariable.swift */; };
 		2428529A6B2B6E873DEC22E8 /* Assignment.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA9100DDAD2E8596F96A1BCB /* Assignment.swift */; };
-		25FD4EA77E9D336E82E87727 /* DeviceHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6873BA70C13AB08F307AA972 /* DeviceHelper.swift */; };
-		261FC6DA888DD3E8151A8D3B /* ConfigManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 754F0DDCB9D2D87A822F83C0 /* ConfigManagerTests.swift */; };
-		2672C5705530C6C5242EBDE3 /* FeatureFlags.swift in Sources */ = {isa = PBXBuildFile; fileRef = 424E0C25FF267517F70AFC6B /* FeatureFlags.swift */; };
+		25E2A4570B63FE36E4DD4E52 /* TemplateLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2E541F079BC78206BC44D6E /* TemplateLogic.swift */; };
+		26237FCC56AE2B7B68C9F1B1 /* SWWebView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C2580C3CD6A8BF0C5258665 /* SWWebView.swift */; };
 		2698874EEAE37BAECE7B8FD8 /* Network.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79E2143AD65D151AE7A4BF0F /* Network.swift */; };
-		271D224C45C545EAAA47D4AD /* UserAttributes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 166374D62DB0AE4E759F2CA4 /* UserAttributes.swift */; };
-		27E2E3782CCEE667F4FAFEBF /* PaywallGraveyard.swift in Sources */ = {isa = PBXBuildFile; fileRef = F551F1C92516FEB24A107A94 /* PaywallGraveyard.swift */; };
-		2A9A91EFD65458797F6B3D59 /* Tracking.swift in Sources */ = {isa = PBXBuildFile; fileRef = B81601941E6DCEEEC38A2868 /* Tracking.swift */; };
-		2BC7059002BF290E7E347B55 /* SWWebView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EFACE6CE4DAE20FB9863302E /* SWWebView.swift */; };
-		2DA159644BAD6737FD1996CE /* PaywallWebEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD7E6196C1445FABD2BA1833 /* PaywallWebEvent.swift */; };
-		2FE7B229B25CFE9A36EF7A2A /* LocalizationConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5288181962FAFEBEEF58E19C /* LocalizationConfig.swift */; };
+		269F70B96D4D04C540A32429 /* ProductPrice.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7ACA213FA146D819AAFDB787 /* ProductPrice.swift */; };
+		26E82881B51892D1CFD7390D /* StoreProductDiscount.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CB5E7278D5B95BC2EBC3474 /* StoreProductDiscount.swift */; };
+		27E396F717A62BA4E0D98086 /* PaywallCacheLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58BA95995DE57E811FD65C02 /* PaywallCacheLogicTests.swift */; };
+		28FED9AE68193B568FF887E1 /* ASN1Swift in Frameworks */ = {isa = PBXBuildFile; productRef = 5BE89F371D9B5971F3271921 /* ASN1Swift */; };
+		2A07A8F4A55E28D13777D03E /* CheckDebuggerPresentationOperatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E815C43EB5A02E48B618DD9F /* CheckDebuggerPresentationOperatorTests.swift */; };
+		2A1087A991658780B2B8036F /* PushTransition.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE1E7DA9C8816082FA05B84D /* PushTransition.swift */; };
+		2A6FD8DA68D888B413621772 /* LogErrors.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7974C3C7E0B54A24784E5C3 /* LogErrors.swift */; };
+		2BEA0C3FED992CB3BBD2F5CC /* SK1StoreProductDiscount.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C064AE76E6545B9595305D7 /* SK1StoreProductDiscount.swift */; };
+		2C1CC812D17087B1CE54161A /* Config.swift in Sources */ = {isa = PBXBuildFile; fileRef = F98F66F7AA2F9F3E96849D8A /* Config.swift */; };
+		2C7867867DDAD83E5856ECC9 /* ASN1Types.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8087A8CD8F4FC7C745010428 /* ASN1Types.swift */; };
+		2D751F5C2F463DEEF0A49B42 /* PaywallCloseReason.swift in Sources */ = {isa = PBXBuildFile; fileRef = C36308E59620C724F701B803 /* PaywallCloseReason.swift */; };
+		2EBE499C9918DE5823659CD0 /* InAppReceiptPayload.swift in Sources */ = {isa = PBXBuildFile; fileRef = 072886BB8C0E08DF414D9162 /* InAppReceiptPayload.swift */; };
+		2EC1D279019CD3FB64E4674A /* TriggerResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 25515131DF0AE67E26BFF462 /* TriggerResult.swift */; };
+		2F33D9FC5A40496D6922CEBB /* IARError.swift in Sources */ = {isa = PBXBuildFile; fileRef = DFE7B1045C0541E66A965FC1 /* IARError.swift */; };
 		3002A50E92B640B4E3A98662 /* SuperwallKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 04FB15C76DE3D22CB370AFDB /* SuperwallKit.framework */; };
-		30397EC05338A20D7EED99CB /* GameControllerEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68DE31534533BC89FFC85924 /* GameControllerEvent.swift */; };
-		31FA52BB6DD7DF9C3FFA13EB /* StoreKitManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D198142576890710445E657 /* StoreKitManagerTests.swift */; };
+		30113C71D033ADDF01214C75 /* PreloadingDisabled.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46D2598EB46E9A27E2BD5104 /* PreloadingDisabled.swift */; };
+		309EC3675C7EF75050B076E7 /* ComputedPropertyRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51445FD3A0C38C2B502EAF1D /* ComputedPropertyRequest.swift */; };
+		31DE588B2B4A26745C33753C /* ThrowableDecodable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62EC6A60945A85646E1230C1 /* ThrowableDecodable.swift */; };
+		32555BD6BFE2017158E48F37 /* CheckNoPaywallAlreadyPresented.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67D3D3EFDC1C529BB6306387 /* CheckNoPaywallAlreadyPresented.swift */; };
+		338A97B83D26325FF3DB568A /* RestorationManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC171FFE5F68BD457364481A /* RestorationManager.swift */; };
+		348EA1CCD6C5276745FBECBC /* SuperwallEventObjc.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFCF5B904164BFB6A8C87BAB /* SuperwallEventObjc.swift */; };
 		35597883CB038DBEE63E162B /* EventData.swift in Sources */ = {isa = PBXBuildFile; fileRef = D86D76FB5809C3B8122778A9 /* EventData.swift */; };
-		355A40470443886A8093794B /* Sk1TransactionObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B7237D632C045D7FD585EC4 /* Sk1TransactionObserver.swift */; };
-		35960B8492C96ED3FB40914B /* PurchaseResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7334CD5C8989BE285765BC3E /* PurchaseResult.swift */; };
-		35FA646E2C0A1778E586CDAE /* ScaleAnimation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D8DA08B90AA82CB3337B624 /* ScaleAnimation.swift */; };
-		36C39E98FE6528FF6B72BF6D /* Publisher+Async.swift in Sources */ = {isa = PBXBuildFile; fileRef = A42411E84D1A21D73D0BDA0E /* Publisher+Async.swift */; };
+		369677E9A6E8754CFD20714D /* TrackingParameters.swift in Sources */ = {isa = PBXBuildFile; fileRef = 764012CF0C0972240A73E3CF /* TrackingParameters.swift */; };
+		37344F5E62F926D676C51D89 /* ASN1Swift in Frameworks */ = {isa = PBXBuildFile; productRef = 36F71E474FE3523EF5DBADB3 /* ASN1Swift */; };
 		37607F7A7EC11CA52C64BB94 /* SWProductNumberGroup.swift in Sources */ = {isa = PBXBuildFile; fileRef = 13BB801E8B818F3B96AF65D6 /* SWProductNumberGroup.swift */; };
-		38291090AEFC86AAF64E74DB /* TransactionModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33BB1232A536B665B0C33E09 /* TransactionModel.swift */; };
-		389FED87EF4F78CBE68BC575 /* SuperwallDelegateObjc.swift in Sources */ = {isa = PBXBuildFile; fileRef = 120AB0D996202873DA53A667 /* SuperwallDelegateObjc.swift */; };
-		38BA1F430BC3ED6B68946DF4 /* PaywallCacheTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28A4999BBFF9057B7CE580E6 /* PaywallCacheTests.swift */; };
-		39D4243678C35F8292A900FE /* PaywallCacheLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 78868C8AC13F6AAE49391877 /* PaywallCacheLogic.swift */; };
+		38A74D299EDFCA3F0A5261B7 /* TransactionErrorLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 76A719AD2F4475F83DFC9575 /* TransactionErrorLogic.swift */; };
 		3ADCB411A734117FF37DDA39 /* ConfirmedAssignmentResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5997775A53005E224485B379 /* ConfirmedAssignmentResponse.swift */; };
-		3B3E0707096DF98E13E1D24B /* InternalPresentation.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA296F4FCD50E811939A9B9D /* InternalPresentation.swift */; };
-		3BAD4B9CF0D01385DBB61877 /* TrackingParameters.swift in Sources */ = {isa = PBXBuildFile; fileRef = B80E862E0AF5DCEC8142696A /* TrackingParameters.swift */; };
-		3BC29573FB068209175AA6F3 /* RotationAnimation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F8C5C62885BCF23722904B0 /* RotationAnimation.swift */; };
+		3B6A91035DE4D806BC420103 /* CheckUserSubscription.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B9C006C80A6104FA63FA84C /* CheckUserSubscription.swift */; };
+		3BA17B2DA6B69A7B90D39AF9 /* ReceiptManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03471273DF4C875227102BE2 /* ReceiptManagerTests.swift */; };
+		3BB870FFD27F80A82E8924F4 /* SessionEventsDelegateMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = C601D23DAA4F0CE7078FD77F /* SessionEventsDelegateMock.swift */; };
 		3BCCE08DF16DC2D16F9AB490 /* UIView+SpringAnimation.swift in Sources */ = {isa = PBXBuildFile; fileRef = F636156244B674A56ADC461C /* UIView+SpringAnimation.swift */; };
-		3D16647EEC0AA822A8624EC0 /* PaywallMessageHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = F90E6FDCEF2889C5068A80D4 /* PaywallMessageHandler.swift */; };
-		3F7E59BF0FCE58E5768C05EE /* AddProductsOperator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24743C72BA7EC046E88AF16E /* AddProductsOperator.swift */; };
-		4029E33782C1477AC3B88115 /* SessionEventsManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 692A22164EF856F75B39764C /* SessionEventsManager.swift */; };
-		40C3C10AA178ECD322ED348C /* SpringAnimation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 985210E1D07FB0EC67510B32 /* SpringAnimation.swift */; };
+		3BE562844FD54486450CE6BB /* PresentPaywallOperatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEA21AF7F6C5FB0EC83E4E1A /* PresentPaywallOperatorTests.swift */; };
+		3CB65E105ADED11AEE69DEAF /* InAppReceiptAttribute.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9553EC1E394EF7AE8788291 /* InAppReceiptAttribute.swift */; };
+		3CF2307C2CB994D00A35FADD /* LoadingModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 866F99509EDFBE8BAE10E575 /* LoadingModel.swift */; };
+		3CF6274768E338E617B58D6D /* PaywallSkippedReason.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A41E45077BFED96FCC25457 /* PaywallSkippedReason.swift */; };
+		3D3011B55A86A504B91EDA44 /* StoreKitTestCertificate.cer in Resources */ = {isa = PBXBuildFile; fileRef = 23F821BDAE724B3F3FFDA5E5 /* StoreKitTestCertificate.cer */; };
+		3DCE95BAC148CCC7E6E7F608 /* DeviceTemplate.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3E5C31CEEDC9C2853D91C50 /* DeviceTemplate.swift */; };
+		3F4BE7ECC80EEA757454F9B6 /* DependencyContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 124F219E38F8398A65A7EB32 /* DependencyContainer.swift */; };
+		412C74624BB8933162DAAC5F /* Experiment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5836EFACFA00594CE8F9F377 /* Experiment.swift */; };
 		41EAF9340665BF7459B2C29C /* CoreDataStack.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50458143450675EF205CE2C3 /* CoreDataStack.swift */; };
-		425927D107115B9222564182 /* HandleTriggerOutcomeOperator.swift in Sources */ = {isa = PBXBuildFile; fileRef = D636EDD4E9ABEE40510C1BD5 /* HandleTriggerOutcomeOperator.swift */; };
-		44DF27A05B02B5A5EBBC7774 /* SessionEventsQueue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 723B2E9D1C844BC39A9B6488 /* SessionEventsQueue.swift */; };
-		461239E670BAE84A666A4E8F /* ConfirmAssignmentOperator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2AEAF9E84CF443750C23DFCF /* ConfirmAssignmentOperator.swift */; };
+		420A0086B6063248C101ED0A /* PriceFormatterProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A541560191B2FE1CC1D970C /* PriceFormatterProvider.swift */; };
+		424F0357DA9A8BFBC6621047 /* LogScope.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7FCE6A59348C9018F40D7AC5 /* LogScope.swift */; };
+		431A9C6D8CD0BB9FBB005F4A /* ProductPeriod.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4A5468741F21E02115E2C61 /* ProductPeriod.swift */; };
+		432FB2AE172725B4ED208416 /* DebugManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5383FA48A6E9EF8F30683C9B /* DebugManager.swift */; };
+		43EF1A9F46DECE0EECFD0368 /* HiddenListener.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9B0C261DCC1ED74DD2BF3EA /* HiddenListener.swift */; };
+		443C104A8DE35D192C11560F /* MockSessionEventsQueue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21B510F7222F3E052A862A66 /* MockSessionEventsQueue.swift */; };
+		4595C5ACC78639E77D4636A4 /* SessionEventsManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3EC6869BE9279D725C1F822E /* SessionEventsManagerTests.swift */; };
 		470D3FB2F3A7B61FD7881DF2 /* UIWindow+Landscape.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D97E1615BA0B22BBBE0DAFA /* UIWindow+Landscape.swift */; };
-		471AE92D554214DD3580FFFA /* TriggerSessionManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C9C75A8DD2B4612C74C986B /* TriggerSessionManagerTests.swift */; };
-		486B2E1BA64D50869DE4D696 /* DeviceTemplate.swift in Sources */ = {isa = PBXBuildFile; fileRef = A33CBBAB5601194ABD7FB8EE /* DeviceTemplate.swift */; };
-		49589ABCD4E7BBB1D8A853A5 /* AssignmentLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B7D272921BDC60D44BA5FCB /* AssignmentLogicTests.swift */; };
+		480C37A4D7A8AB5EE0760BF1 /* PaywallLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC6C4D551369C55D8AFB7F96 /* PaywallLogic.swift */; };
+		4A0581431C658ADA17B40961 /* TriggerSessionTransaction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 775D6EC141DAE9BED8B732A7 /* TriggerSessionTransaction.swift */; };
+		4A86316A1F74FE8FC4BF889F /* RuleAttributes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1376F233A5CF79DAD2428171 /* RuleAttributes.swift */; };
+		4AA4E2CE223DC7CF1678E83C /* TrackTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65E23B703C00044332FDEBE8 /* TrackTests.swift */; };
 		4AB907436D4A84932F09D8B3 /* String+MD5.swift in Sources */ = {isa = PBXBuildFile; fileRef = D449672964023589DA5535E3 /* String+MD5.swift */; };
-		4C3C20A6359DE80DDA07EF49 /* BundleHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5765F9403E44383A8FC7D3AD /* BundleHelper.swift */; };
-		4D04FBD1B06BF7F41FBACE78 /* MockSKPaymentTransaction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91B2F0F10B6207B5092AC539 /* MockSKPaymentTransaction.swift */; };
-		4E8256BF3BEC5A3AE893AE4F /* InternalPresentationLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE90F82958684A445132862C /* InternalPresentationLogic.swift */; };
-		4E952A1C6A9D721DE835C3A1 /* RestorationHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4641647787524DB540D4969B /* RestorationHandler.swift */; };
+		4B0E203D477E48611797047C /* PaywallViewControllerCacheTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 672776875A4286319C2F2D61 /* PaywallViewControllerCacheTests.swift */; };
+		4BEB01C5B5C5183511251D43 /* LogPresentation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CCCFB974F1CAB7ABEF75AB7 /* LogPresentation.swift */; };
+		4DE01655FC4CC148DD3D161C /* LoggerMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = A00C04BE1449BE21E13B61A0 /* LoggerMock.swift */; };
+		4E5F1AB421E91E102B6D4800 /* OnDeviceCaching.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5283BA49E380740C34D78856 /* OnDeviceCaching.swift */; };
+		4E7761949715C8BF8DEEF35C /* ReceiptLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0A53CC571B7BC3F5AAD71BF /* ReceiptLogic.swift */; };
+		4EF50815E31F85400513F053 /* PresentationItems.swift in Sources */ = {isa = PBXBuildFile; fileRef = E23F2FE294EBC63F81786A85 /* PresentationItems.swift */; };
 		4EFA142D3D37B0564BDB52CB /* NetworkMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10D5ABDB23D56393EFDCF73A /* NetworkMock.swift */; };
 		4FE19D26711ECB7B2EE8806D /* TriggerRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 481D47E5121C521DDA268609 /* TriggerRule.swift */; };
 		507E017DBEC2663F1B4727E0 /* Dictionary+Merging.swift in Sources */ = {isa = PBXBuildFile; fileRef = 335888285131F832E1C91A8F /* Dictionary+Merging.swift */; };
-		51984020B969A36162E3E65E /* TransactionErrorLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4D811522FFC29BB16F367FF /* TransactionErrorLogic.swift */; };
+		51ED6FE7AC4B8EFB97D4B376 /* CoordinatorProtocols.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4268B8B324D767409873B4C /* CoordinatorProtocols.swift */; };
+		52973FEBBC4D2E753F673859 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = B23E9FB48867BAE49688784F /* Assets.xcassets */; };
 		53113582D4E7F54236FD493C /* CacheKeys.swift in Sources */ = {isa = PBXBuildFile; fileRef = 865262BC55BAEA135E51698D /* CacheKeys.swift */; };
 		53227994995EA43A8CAFB0DA /* LocalizationManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF091A5565631C9F426F304B /* LocalizationManager.swift */; };
 		534E94DCCD72F2F7D0EC1441 /* Task+Retrying.swift in Sources */ = {isa = PBXBuildFile; fileRef = 938EB5121B1D9EA6B2EAE9EC /* Task+Retrying.swift */; };
-		53567ADDA1C3FE1AC646014A /* Config.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6842E9305150D3702AB48E2E /* Config.swift */; };
-		55623881B3106928D158F31A /* GetPaywallVcOperator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A3F246F74018E6AD4B82CBF /* GetPaywallVcOperator.swift */; };
+		5566DBCF96993C1E4D217F50 /* GetPaywallResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24EA03270476CD31B906CDC8 /* GetPaywallResult.swift */; };
+		55CBCFC21A8DF3D8B14FBC19 /* RestorationResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2AFFA0F0D2BCDFEC8BEC856 /* RestorationResult.swift */; };
 		5621A2D2FEC048847E22BF6C /* KeypathWritable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2027BFC214905CBE589AF2 /* KeypathWritable.swift */; };
+		56408549E721E2ED524DEA35 /* PaddingListener.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9DC4D23D1EDDA249C928930D /* PaddingListener.swift */; };
+		57543AA59192358A909ADCCF /* RuleLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2BE63AAEDD12E85626744ED5 /* RuleLogic.swift */; };
+		5773633643CA7DF61F73098C /* SK2StoreProduct.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2CB827497BCEBDF9E1E2707 /* SK2StoreProduct.swift */; };
+		58170B6B2E4224AD27549567 /* UserInitiatedEvents.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE406AAED11F2B63E4A5A1FD /* UserInitiatedEvents.swift */; };
 		58185F7A0770111BDE259936 /* NetworkTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2A2A54314BAEAF65B46D322 /* NetworkTests.swift */; };
-		59B43621B2A93A3364C037D9 /* PresentationPipelineError.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1FFFB20CA2231FC607BE44A /* PresentationPipelineError.swift */; };
-		5DEE758BE8E42F90C7470264 /* ConfigManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4ADB18BDD8A9BF03BDE396C0 /* ConfigManager.swift */; };
-		5E00EFE0CB67691D55A151F0 /* IdentityManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8AA3BB9F834B8758CB45DD2 /* IdentityManager.swift */; };
-		5E025C05CC8F758569CB2DFF /* IdentityManagerMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 365CD0C3A1A3A605271B1DB7 /* IdentityManagerMock.swift */; };
-		5EC3EF1FE5033E365E5A0A41 /* InAppReceiptAttribute.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2FDD78DE945EE7B82EAB274 /* InAppReceiptAttribute.swift */; };
+		589DA96DCAC1A4F0B08A2501 /* TriggerSessionTrigger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 991415992A1EA3C9E6DB7D25 /* TriggerSessionTrigger.swift */; };
+		591DCE67E64C63AACFFB604B /* IdentityLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB3F04AC933701EE33F5F325 /* IdentityLogic.swift */; };
+		59685CE55D34FA6A96A8F890 /* AssignmentLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3501D12845840D6CBA1F0081 /* AssignmentLogicTests.swift */; };
+		5A6D06700C4E4E2C6C9BC1B2 /* ShimmerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D123D95036ED6CE3B097BBF0 /* ShimmerView.swift */; };
+		5C504112376B6E0798CA20CE /* Variables.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B75209DF76859131941CA0F /* Variables.swift */; };
+		5D9AC3A1B3B9DB379856E0A4 /* ExpressionEvaluatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79D581A513C692B07DE5A38C /* ExpressionEvaluatorTests.swift */; };
+		5E05FDE4F45BD5B0DF6AFB9F /* ActivityIndicatorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EBFB0A38F634286F61572C51 /* ActivityIndicatorView.swift */; };
+		5EF4EE04BAA930A2CC4379A1 /* RawWebMessageHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC91544C3B7D209A8D51397F /* RawWebMessageHandlerTests.swift */; };
+		5F1F480AA12C8D17B179D96B /* PaywallViewControllerMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = A453816DBA43C08410D12DE6 /* PaywallViewControllerMock.swift */; };
 		5FB78EB52A12BA704AD3AE31 /* EventsResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEFDA9310B29A0C918D7A292 /* EventsResponse.swift */; };
-		60C79DA10DD627D7A64FD3C2 /* AppSessionLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = C649C8B193A114A5BDAF49C0 /* AppSessionLogic.swift */; };
-		61BF8F296579B092CE533A8D /* DarkBlurredBackground.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10552F325E6976EC5825C6EA /* DarkBlurredBackground.swift */; };
-		6254D0B972C1A719FB78D1B3 /* InAppPurchase.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB04E29E0B87E29156C9C246 /* InAppPurchase.swift */; };
-		62666478F7A62BC63E4BCEE7 /* ReceiptManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BEE62C0226A4AD750011CFD /* ReceiptManager.swift */; };
+		60315CA6C1D6B9EAE7F71731 /* StoreKitCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = A829C96661335814CCF85BE3 /* StoreKitCoordinator.swift */; };
+		61EC2A032D127B323D4A8124 /* ConfirmPaywallAssignmentOperatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8FC7F8602B38644BCCDAD159 /* ConfirmPaywallAssignmentOperatorTests.swift */; };
 		62CF18234F0EC4775DA8F828 /* UIViewController+AsyncPresent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69A4D77D819DDB696834E1B7 /* UIViewController+AsyncPresent.swift */; };
-		64585F844489D8A4D68BDDC9 /* SWDebugManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4252EDEF1B7AFBCB44CD5000 /* SWDebugManager.swift */; };
-		68032B8D2E7B57996F426601 /* TriggerSessionProducts.swift in Sources */ = {isa = PBXBuildFile; fileRef = 368931F3E7FD5474629096FB /* TriggerSessionProducts.swift */; };
+		633234099D510043E2D7D7EB /* ProductsFetcherSK1.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C4CEDEB039548ABF39B528E /* ProductsFetcherSK1.swift */; };
+		63CED0C62636A9FD03B7315A /* ConfigManagerMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAAE50F011668C1D62B86751 /* ConfigManagerMock.swift */; };
+		656301FB982B22EFF291122F /* TriggerSessionManagerLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = BACAA655F72F3CE9B71C2C46 /* TriggerSessionManagerLogic.swift */; };
+		670829E4DF02F3BB60444B38 /* ConfirmHoldoutAssignment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 81CB02D2E13C410C2600B506 /* ConfirmHoldoutAssignment.swift */; };
+		67C020751429B5677D9A0727 /* IdentityManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 236900A8A8F95CE92E612458 /* IdentityManager.swift */; };
 		68AF64973AC860BE2A41B8D4 /* LoadingInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57478172574516BD5EDD254A /* LoadingInfo.swift */; };
-		6C6A7F67026F6A7CCEE45530 /* SuperwallLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1C7DF2BC047B98ABFFC3C966 /* SuperwallLogic.swift */; };
-		6D7E7DE7EE8A541CC4EA97F9 /* TriggerSessionPaywall.swift in Sources */ = {isa = PBXBuildFile; fileRef = 544F99BB5858C75E3220B4EB /* TriggerSessionPaywall.swift */; };
-		6ECE340EEAE00D5CC93838D4 /* PaywallConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FEBF2A47374CE665EC5D33D /* PaywallConfig.swift */; };
-		710357F3AD844D767E1620F6 /* OccurrenceLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31BFC6917BDCE905B903E8FE /* OccurrenceLogicTests.swift */; };
-		7146184F32B6CBB91A4474CA /* ExpressionEvaluatorParams.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B052A053B815537646DD70D /* ExpressionEvaluatorParams.swift */; };
+		68FF8D03BAD0F2BE33B9C976 /* ProductPurchaserSK1Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 618BF4D10B7D87FAF8FB48CD /* ProductPurchaserSK1Tests.swift */; };
+		6A3D32A64CC92B5AFB15621C /* SessionEventsQueue.swift in Sources */ = {isa = PBXBuildFile; fileRef = F63599D252F44CF417D79AF3 /* SessionEventsQueue.swift */; };
+		6AB737FD60B729CE6F85E0A9 /* WaitToPresentOperatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A978542D21EC187C1A3C499 /* WaitToPresentOperatorTests.swift */; };
+		6B3DA52EEC1753FC97B1BE5C /* CheckUserSubscriptionOperatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83F3F6FCA1A755FC0A6CD8EC /* CheckUserSubscriptionOperatorTests.swift */; };
+		6D41217E107DA0E6FFAD0ACB /* StoreTransaction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8FDBBFC2D8F670CE2DC91889 /* StoreTransaction.swift */; };
+		6DC998F9CB808894AD3D41E8 /* GetPresentationResultLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A2E8A96B1F4C3C78CFA696C /* GetPresentationResultLogic.swift */; };
+		6DCFC3B002082C9C2E1BBC67 /* Logger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DB09C4AF80761DF4205C4C2 /* Logger.swift */; };
+		6FE965326C139AB101BAC1CF /* Trackable.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFE42FD8C7F01915D74D0008 /* Trackable.swift */; };
+		701B1B586B6C1E3F0B3AF560 /* StoreKitManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 054FCADFEF560A1A736DEFE4 /* StoreKitManagerTests.swift */; };
 		72FAD5E490B233658EDACC98 /* PostbackRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4BBEC4952B1502826F554C83 /* PostbackRequest.swift */; };
 		7352E1493F1207737B393213 /* LocalizationLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35C534C42A8EAC1F183CC85A /* LocalizationLogic.swift */; };
 		73947C28195DF53EBD32EF45 /* Decimal+Rounding.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9A3C997FDC1550AF477CA1D /* Decimal+Rounding.swift */; };
 		744F0D34C800E17CF8462820 /* URLSessionRetryLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C054891709C534F59C93C815 /* URLSessionRetryLogicTests.swift */; };
+		7477EFEA4C42BB441B92D096 /* RawPaywallResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5637C2D7DDA38C11E48DD1C /* RawPaywallResponse.swift */; };
 		749117DF0A2364453CCED102 /* LocalizationOption.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7FFF0EDFF6DA910E4B5CCB7 /* LocalizationOption.swift */; };
-		7666A23DF5010191B52F6670 /* PushTransitionDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 806911E8F01C4115843E2019 /* PushTransitionDelegate.swift */; };
-		7676D687F1785721C6B74C0E /* SuperwallEventObjc.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5D6BFF0F26C146D7C443388F /* SuperwallEventObjc.swift */; };
+		7494124F44F712EC7138C7DF /* UserAttributes.swift in Sources */ = {isa = PBXBuildFile; fileRef = B52A0EFBBFE9D2F949EA4C28 /* UserAttributes.swift */; };
 		767974DF68CE67AE2066E3D6 /* FileManagerMigrator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DAE3B565ECB65BCCFD39A0A /* FileManagerMigrator.swift */; };
-		775B0FD111BDDC7FD76FC62F /* ProductsManagerMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = D95F38041B9935272D2D87C2 /* ProductsManagerMock.swift */; };
-		779B63AAD57260CF12FF2DFF /* PaywallState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 767385007521EEE45C1F4D76 /* PaywallState.swift */; };
+		76984544B2AEED280390BFB0 /* RotationAnimation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2BB10D9097CC124FFC34A4A0 /* RotationAnimation.swift */; };
+		76CC2455A437DC1DB0F3424E /* ConfigManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4EC3DA8E774FBFE31F811FAF /* ConfigManager.swift */; };
+		77EDD2927FF8DCF95579BE3E /* IdentityLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40AE19B5A9B237A2552D5F36 /* IdentityLogicTests.swift */; };
+		78113F737BA99A2848850904 /* TrackableSuperwallEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D8AD1A7B62E8CBBDFB65BE5 /* TrackableSuperwallEvent.swift */; };
+		78C91388B9EA991A972C9536 /* TransactionProduct.swift in Sources */ = {isa = PBXBuildFile; fileRef = A454A48473801779E36C9709 /* TransactionProduct.swift */; };
 		795E7752217DF07AD7EB8660 /* Trigger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2628BCB13E80DC539F35C7B5 /* Trigger.swift */; };
-		7E67A618C1144768C1B1D818 /* Variables.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC841969BFFEF512F254A8AB /* Variables.swift */; };
+		79FDB7149265B9F164ACEB6F /* PresentationRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7397C5FD11E7A09B6AD39165 /* PresentationRequest.swift */; };
+		7A1519F9AAF8CA9914E9C5C8 /* AppleIncRootCertificate.cer in Resources */ = {isa = PBXBuildFile; fileRef = B1A112ABEB40964EDA5B5B21 /* AppleIncRootCertificate.cer */; };
+		7AD6B818E94D31DD9E1F67BB /* InAppPurchase.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF0A461D50AF945239D3D048 /* InAppPurchase.swift */; };
+		7B36EE4BCAA74CBFD91976C4 /* SubscriptionPeriod.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D60F06C8685538A9486B97D /* SubscriptionPeriod.swift */; };
+		7DA2CF4C6FF5C8A1C44282E6 /* LoadingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A94120D51C7B36AC9EA32B8B /* LoadingView.swift */; };
+		7DCBF8A78D0B6A7A2649553D /* Validation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 498D6155C2B8B18E7F3D0E79 /* Validation.swift */; };
+		7E355FE2557391CE4593B9B0 /* SpringAnimation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D1A60826D12F97F96E671DF /* SpringAnimation.swift */; };
+		7ED33A59F30F7C9BA080CB40 /* TriggerSessionPaywall.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF3D82A1AC66E94746295419 /* TriggerSessionPaywall.swift */; };
 		7F01F765BE9EF495D1EF58A7 /* UIViewController+AsyncDismiss.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70D2B0D671B1A1E665B7CCD8 /* UIViewController+AsyncDismiss.swift */; };
 		7F94C5006D67DDEBE7BC33C7 /* SWPriceTemplateVariable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6627CEA22A8E0CFA9D0901AC /* SWPriceTemplateVariable.swift */; };
-		8113C9A88414B6CA11476CF3 /* HiddenListener.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E33BFE573CD9D7C0BA05F7B /* HiddenListener.swift */; };
-		821FBEF8A036815D6967C24B /* PaywallLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0514001D70634D4DA82B83F7 /* PaywallLogicTests.swift */; };
-		83CA7ACD6AEE4D7BF81C588C /* InAppReceiptPayload.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79144F89F4D8E24ADDC3EE92 /* InAppReceiptPayload.swift */; };
+		7FCDAF6C945FA04FC4C4E8E3 /* DeviceHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB242DC77FEC0BE10C0DDC9C /* DeviceHelper.swift */; };
+		803BFA630F96B638E3BDE715 /* GameControllerEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21C52F36F0BFF59363EBB4C7 /* GameControllerEvent.swift */; };
+		81680E02D1693BF58E015C0C /* ASN1Decoder+UnkeyedDecodingContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = D31BB6D0C57337C6E929D617 /* ASN1Decoder+UnkeyedDecodingContainer.swift */; };
+		822B2898CDD9C6E50816F62B /* API.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD9298A79020030E9A1357A6 /* API.swift */; };
+		83EE1B79C6BEB4A61929769F /* SK1StoreTransaction.swift in Sources */ = {isa = PBXBuildFile; fileRef = A50760583D3E3E87C83B75F0 /* SK1StoreTransaction.swift */; };
 		84616856D40F775122FD9BF9 /* Dictionary+Cache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 571825E7515FCC1E877D4429 /* Dictionary+Cache.swift */; };
-		8490A243F8769FA73DE6B116 /* SuperwallEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AD39245CEC3FF3EBD5EDE5C /* SuperwallEvent.swift */; };
-		850A43400768AEA8F173285C /* FreeTrialTemplate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1503802B20764509D922B1FC /* FreeTrialTemplate.swift */; };
+		848B586F9024F10C52EF3B10 /* PaywallPresentationRequestStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77444F578076D619C97EA6BB /* PaywallPresentationRequestStatus.swift */; };
+		8544DEF9914769BCAE073DD5 /* GetExperiment.swift in Sources */ = {isa = PBXBuildFile; fileRef = E35ABB03CA31D2C187A9D052 /* GetExperiment.swift */; };
 		85728EABBC5C73193AC5F876 /* CustomURLSessionMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3506FCC35155DF104A1DFCA /* CustomURLSessionMock.swift */; };
-		865D29C948809329640D2EF3 /* StoreKitManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 983AC5AC5E0DAF2B2938E45D /* StoreKitManager.swift */; };
-		86C69BB773D53978B4EC9D03 /* Publisher+HasRetrieved.swift in Sources */ = {isa = PBXBuildFile; fileRef = F982A447662FAA74CAA606A2 /* Publisher+HasRetrieved.swift */; };
-		87399276E22CF3308B7ACE88 /* TransactionPayment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B8D19C18FFC8A968902F554 /* TransactionPayment.swift */; };
-		87DAD5B313899D1FD9F73B5E /* ActivityIndicatorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69D11EF72866A27D016C9140 /* ActivityIndicatorView.swift */; };
+		86D668D3851219380D12C58D /* PaywallOverrides.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9904A3538DF80EA8EEC2687 /* PaywallOverrides.swift */; };
+		8891C9D2F74407705E38FD89 /* PurchaseControllerObjc.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47D0B3E1489C378D73F7CFD4 /* PurchaseControllerObjc.swift */; };
+		889DAC79C6434B34CE56DCF8 /* SessionEventsManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67B05942B51DA5DE06C22C1C /* SessionEventsManager.swift */; };
 		88A5CA6515126BD3D09E0563 /* LimitedQueue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B921746BEC8F63DDB65C634 /* LimitedQueue.swift */; };
 		8AEB577682D9AB9354CB8EE9 /* UIColor+Hex.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2888B05A273E9EB6E9382332 /* UIColor+Hex.swift */; };
 		8B200F99B71D706D45948339 /* Utils.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE0E783785F917188D12F4B4 /* Utils.swift */; };
-		8BB27D953027025A087227EB /* AppSessionLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2AB593578F0AB2F11158D5A /* AppSessionLogicTests.swift */; };
-		8DBFB47EABCD57AFC9C9946A /* TrackingLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF09F3137AD182B8B4AF8BFC /* TrackingLogicTests.swift */; };
+		8B58E4DC7A49D2DFB3CA1F7F /* ASN1Decoder+SingleValueContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 184CC04EBE95A64F30F83EA0 /* ASN1Decoder+SingleValueContainer.swift */; };
+		8B5AD068AF8D1CE959CC0D72 /* ExpressionEvaluator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1CC8F4AB247F86988A71BF01 /* ExpressionEvaluator.swift */; };
+		8C3A81E3D75F027539933310 /* BottomPaddingAnimation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18DB52B223C181E0A8FA1D6D /* BottomPaddingAnimation.swift */; };
+		8C75B925E7ADDCCEA7740895 /* TriggerSessionManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA46295F06642C4306BEA957 /* TriggerSessionManagerTests.swift */; };
 		8EAEFA3BFACC09BE03A8D208 /* SDKJS.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5A461C7228BE71FF8695236 /* SDKJS.swift */; };
-		8EED10CD66775D1BDC606F72 /* RawWebMessageHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20002CE824E4D422DDA12E62 /* RawWebMessageHandler.swift */; };
+		8EC4001F5273FB1260618E84 /* PaywallRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1AB5B56470F69FBE1C34EAA8 /* PaywallRequest.swift */; };
+		8F18BFB254E432BFBEAB1324 /* LogLevel.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA3A82C80F89023672D56AD7 /* LogLevel.swift */; };
+		8F24AAC773F119481E2C654F /* PublicPresentation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01E54BC1CA38F828AC77F774 /* PublicPresentation.swift */; };
+		8F7AEBBA27B4278F55516CA7 /* NotificationScheduler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 448D7B7B467CBA2A4359E3F4 /* NotificationScheduler.swift */; };
 		90E9A3B2C922288C8A86BCC9 /* Bundle+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51407421A3CBF7AF0FC76E60 /* Bundle+Helpers.swift */; };
-		9187839D25693740ACA21B27 /* TriggerSessionProduct.swift in Sources */ = {isa = PBXBuildFile; fileRef = B57F9BE50ABBC04A7E4A1B4E /* TriggerSessionProduct.swift */; };
+		90EE0190126A3BBA4661122E /* AddPaywallProducts.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83A6A722D119902A42DC2737 /* AddPaywallProducts.swift */; };
 		919A08D7F25BD2DF27A22697 /* StorageMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D1887F247BF6F770122F257 /* StorageMock.swift */; };
-		926D1D7D4C3C0B87339B3B27 /* PublicIdentity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4955958DB59356ABF25A5D4F /* PublicIdentity.swift */; };
-		92ABF4A84F053ECAE668F4B0 /* SuperwallEventInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2357B335109EA70FD685C993 /* SuperwallEventInfo.swift */; };
-		9401F2546B9758A6797C9DF8 /* AssignmentLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8258E9C6F333EB19A7695EB9 /* AssignmentLogic.swift */; };
-		947F5D924E73A70F4BACC910 /* PaywallTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3ACEB8F7B11E039CB02BCCD0 /* PaywallTests.swift */; };
+		9304297F3B76DB512F2F9D53 /* TrackingLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2300AFFC31667E749E85EAC /* TrackingLogicTests.swift */; };
+		941F2296F5250A15DE6B5B70 /* SuperwallKit_Model.xcdatamodeld in Sources */ = {isa = PBXBuildFile; fileRef = EC51351CA716C5C3B71E2FA1 /* SuperwallKit_Model.xcdatamodeld */; };
 		94908C7FD2227D917187FEEF /* CoreDataManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E3AC3B23DAAA8C1D125BDD3 /* CoreDataManager.swift */; };
-		94D8A80642BFFF0807B7DA30 /* Superwall.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22CA87F0488301B60564C72A /* Superwall.swift */; };
-		94D9448CEA20F0BE74956D7C /* LoadingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8FA16E10142CB82A233C7F2 /* LoadingViewController.swift */; };
 		9509D1E5080DBB8BD39FDF1C /* SuperwallKit.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 04FB15C76DE3D22CB370AFDB /* SuperwallKit.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
-		959E679C31B894A29D4175F0 /* TriggerSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2697574309A971468AC12635 /* TriggerSession.swift */; };
-		95EF88822DDFE3BC83306969 /* CheckPaywallPresentableOperator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 352D6CA631F149C0B0C29DAE /* CheckPaywallPresentableOperator.swift */; };
+		9552D9AC4CC00EC9630508D0 /* ExpressionEvaluatorParams.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1B7E4FC6B4AAEA58D95A052 /* ExpressionEvaluatorParams.swift */; };
 		9656724257D2DD930C70CD8E /* SWProductPeriod.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BB7B88D5D474F9F3C366D6A /* SWProductPeriod.swift */; };
-		97F9D03859ECD517B9F3B9EF /* SessionEventsDelegateMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBDE3A7712EC4EF8592A53FB /* SessionEventsDelegateMock.swift */; };
-		9ABF279F63EFC6C82DE1F26C /* TrackingResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2200BA9DBFD79CD558E7C542 /* TrackingResult.swift */; };
-		9B5E4C60905A923EFD16D740 /* Date+IsoString.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB95FC8B25A0F7F539D4AF92 /* Date+IsoString.swift */; };
-		9CD675C5051BE4389835ADBB /* MockSkProduct.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3EB9F4F9ACAEA150B071FDA5 /* MockSkProduct.swift */; };
-		9CE266719FD631DE65ED3B06 /* TransactionRecorder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A1AAD9CA30CFB266D26F7C7 /* TransactionRecorder.swift */; };
+		9867958FEB6C268B7A213591 /* CheckDebuggerPresentation.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA3C3F42E928987B92F35B96 /* CheckDebuggerPresentation.swift */; };
+		98BFA6594FE9A9097AC5F88F /* ConfigState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28A1C8B0D79B8AC70ECF0CBB /* ConfigState.swift */; };
+		995FD66283C7B03D3B33DF89 /* AppSessionLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 214622367ACC8F66EB392105 /* AppSessionLogic.swift */; };
+		999B569F8B14C4DF8FD5ACFF /* LocalNotification.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA1F5AFA28F20FAE4D0AA3B5 /* LocalNotification.swift */; };
+		9A4B85F1BC220968C8A42666 /* PresentPaywall.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98D3CEEDCBBDB85C54FDC128 /* PresentPaywall.swift */; };
+		9A802A666FD3BEE9B246EF4B /* ProductTemplate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B430DE1BA468E280567F03C /* ProductTemplate.swift */; };
+		9ABF8B3F8E320024252036F8 /* UNUserNotificationCenter+SuperwallNotifications.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE32816F1CA1637897AC87A2 /* UNUserNotificationCenter+SuperwallNotifications.swift */; };
+		9B49485A1CFAC2621A89B150 /* AppSessionLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 81BE917F0AA7A7453B7D0BB2 /* AppSessionLogicTests.swift */; };
+		9C755FBB61B4D81CAFD0C0A0 /* String+RFC339.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB518DC9EFF0FE0C3A022982 /* String+RFC339.swift */; };
+		9D2B19788936FAED6F369768 /* StoreProductDiscountType.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFA4E94285A5E9430D48CB14 /* StoreProductDiscountType.swift */; };
+		9D919E6F6A12252033CFF813 /* PresentationValueObjc.swift in Sources */ = {isa = PBXBuildFile; fileRef = 544C032167E8198513B2A860 /* PresentationValueObjc.swift */; };
+		9E0E10B5F04756D2B2DEB478 /* PaywallCacheLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63A8950F4F998DE6C9242A10 /* PaywallCacheLogic.swift */; };
 		9E21D97817B1BA97806283B3 /* CustomURLSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = B37D3D1DE18F6748B9E8963C /* CustomURLSession.swift */; };
 		9EAE577E60052F5E1C7B9657 /* EmptyResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = B88E86C67F934540D846B8BA /* EmptyResponse.swift */; };
-		A041F20F420D00BF53B5C0C9 /* PresentationRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB817B50385C1C04C49E277B /* PresentationRequest.swift */; };
-		A0DA7968E68D48AAF593A2C0 /* GameControllerManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4FF025AF2EC66D8312999A4 /* GameControllerManager.swift */; };
+		9F50FBB5826FF0A4ED075F26 /* ASN1Decoder+Extras.swift in Sources */ = {isa = PBXBuildFile; fileRef = D07ACB41E733B6CF8EA722E0 /* ASN1Decoder+Extras.swift */; };
+		A138759EEB6B669C19FB5AFF /* PaywallMessageHandlerDelegateMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = F798D9662212AD1CC75666F3 /* PaywallMessageHandlerDelegateMock.swift */; };
 		A1621A749D8F05959A486ACE /* CoreDataManagerMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB1B228FB279EA92C35C7394 /* CoreDataManagerMock.swift */; };
+		A17660D2723D600B5AA84CCA /* TriggerSessionManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 71BCCF22958A702677FB66F5 /* TriggerSessionManager.swift */; };
+		A191F045B8A9EE2D4A3B757D /* OccurrenceLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2123B84F5C786278E128152D /* OccurrenceLogicTests.swift */; };
 		A1EE1654484802E9E08CC32E /* ManagedEventData.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3F4F74393061C17CEB18F90 /* ManagedEventData.swift */; };
 		A2591FA256332165D0B0AFAF /* SWProductSubscriptionPeriod.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B40F35B536F527B029D7BDE /* SWProductSubscriptionPeriod.swift */; };
+		A29904A22F5E10DB8D2AE241 /* ASN1Decoder+KeyedDecodingContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAF94D451CB6346AE3C5863B /* ASN1Decoder+KeyedDecodingContainer.swift */; };
 		A2DC9FA3045DF056BC867D8B /* PaywallPresentationStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 153C660FB51D0D1DFE56D462 /* PaywallPresentationStyle.swift */; };
-		A30B59DD743B66099D59DAEA /* PresentPaywallOperator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 844207A4B6BC4A2A29FDCEF7 /* PresentPaywallOperator.swift */; };
-		A40A57883A6ED18619244966 /* PaywallInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = C28014EF3A8BF357F2E71FC1 /* PaywallInfo.swift */; };
-		A452C13E1F76B7DD715C7470 /* MockSessionEventsQueue.swift in Sources */ = {isa = PBXBuildFile; fileRef = E03E830ADACA9E5D41E5CFC4 /* MockSessionEventsQueue.swift */; };
-		A8CB114A06AFAAB7420D88EA /* LogPresentationOperator.swift in Sources */ = {isa = PBXBuildFile; fileRef = B979A4EBDBD32C0985FD74DC /* LogPresentationOperator.swift */; };
-		A9A569AE8B039F1BE950ADA4 /* InternalPresentationLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF78EA507375E36880AB33AB /* InternalPresentationLogicTests.swift */; };
+		A44BAE75AAE4713FAE38F992 /* ProductsFetcherSK1.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD6BA222CB2EAA4B65F362C5 /* ProductsFetcherSK1.swift */; };
+		A51060CF6339BF9383F94B51 /* MockSubscriptionPeriod.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5C4AD6349F2D432132F36D5 /* MockSubscriptionPeriod.swift */; };
+		A73497BB3DCD881318A5CD86 /* ConfigLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 97D7F499B2CBFFF0A61F8D72 /* ConfigLogicTests.swift */; };
+		A74BBEF8CCF5A35AB19BB70C /* ProductPurchaserLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A413B6FF46B130D90A428B4 /* ProductPurchaserLogic.swift */; };
+		A78DC9BD71DD85831025D620 /* SuperwallGraveyard.swift in Sources */ = {isa = PBXBuildFile; fileRef = D36898353ABCE620BA7AEE59 /* SuperwallGraveyard.swift */; };
+		AACC7BEE37DDDD7068A1E48C /* TransactionManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 646E6799FE4934BF76A06F34 /* TransactionManager.swift */; };
 		ABC17AE96AD396607E3CAB17 /* CoreDataStackMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E828EBAB18CCC0B236EF71D /* CoreDataStackMock.swift */; };
 		AC7D527612F631AAADC7D225 /* FileManagerMigratorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FB3F2FC9FCCD4B912E61A1F /* FileManagerMigratorTests.swift */; };
+		AC821D5E03C0C97DEE9BA7BD /* StoreKitCoordinatorFactoryMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 07B04D40ECF8BAFFC0CA9F26 /* StoreKitCoordinatorFactoryMock.swift */; };
 		AD5EBB6DBA919E3CBC5B85B7 /* SessionEventsRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = B40D6FA6547CB5B9520B0B64 /* SessionEventsRequest.swift */; };
-		ADEDCF9F58A0742F3FE81D1B /* LoadingModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57BBC30EF2E06EBADE774802 /* LoadingModel.swift */; };
+		AD699B03E565AD6034AEC527 /* PurchaseResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2165AB24A77F58698AAFC04A /* PurchaseResult.swift */; };
+		ADA31CB0D14CEE6B4784039A /* TriggerSessionProduct.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0F2070ACE29ED3EA357228DC /* TriggerSessionProduct.swift */; };
+		AE0555AA0B433427E5D17309 /* InternalGetPresentationResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = F57F454704875FFFC5CE1827 /* InternalGetPresentationResult.swift */; };
+		AE1D15070BC159212967CAD4 /* ConfirmHoldoutAssignmentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 018F5856F39FC33AFE9740D4 /* ConfirmHoldoutAssignmentTests.swift */; };
+		AE9F583082A5CDCE595BDA2D /* AppSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8165DD71323903F7CF426D2C /* AppSession.swift */; };
 		AEAB0C0C168B0B3D864109EA /* CoreDataManagerFakeDataMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = E74C7DE0FAFE0C01F374DDF0 /* CoreDataManagerFakeDataMock.swift */; };
 		AEB9D461AF5103FB7257AD25 /* SwiftyJSON.swift in Sources */ = {isa = PBXBuildFile; fileRef = 19F010DC597017F5BEAEDE86 /* SwiftyJSON.swift */; };
-		AED0F0AA92480E68279450A5 /* TransactionRecorderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82D71435A6AFB8E6599B1B20 /* TransactionRecorderTests.swift */; };
 		AEDE34B9767E378C0A4D2E08 /* SWProductNumber.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B17DA82A4CD5ADCB98C423A /* SWProductNumber.swift */; };
-		AFB9D5B24A0437C3A0A5F576 /* PaddingListener.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04E8EB76AB037B3586240A4B /* PaddingListener.swift */; };
-		AFD7BDBF3518B2CB67B75C39 /* TrackingLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42F51ED1275B5BBD0893B067 /* TrackingLogic.swift */; };
-		AFE36A8062A6BAC8F2F1612E /* MockSubscriptionPeriod.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D32BFD05F5B55287EFB19FD /* MockSubscriptionPeriod.swift */; };
+		AF4AD928FACF9056E00D5920 /* HandleTriggerResultOperatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B27F0D55EF3480E2B65C8DFD /* HandleTriggerResultOperatorTests.swift */; };
 		B0B0AD9409CEFE7CA8225146 /* Array+SafeRemove.swift in Sources */ = {isa = PBXBuildFile; fileRef = C855DE8F5341D67C614E3AF5 /* Array+SafeRemove.swift */; };
-		B2082DF2D5D0069EA2757A4F /* ConvenienceFunctions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9152116E6A842164DB3339DE /* ConvenienceFunctions.swift */; };
+		B10030CC414C2C341487F4B8 /* PaywallViewControllerDelegateAdapter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 990461F7A9B2F3ED62B3A628 /* PaywallViewControllerDelegateAdapter.swift */; };
+		B1F2B0B6FF29C03A4C90636B /* GetPaywallVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFEECDF884EDFE6FF1D0E0C3 /* GetPaywallVC.swift */; };
+		B238354BF9B5605366D0408E /* GetPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1D09FBCB364D8316C4A8C69 /* GetPresenter.swift */; };
+		B2842C329F0F9AAFC2040C35 /* EvaluateRules.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55DDD2F24335874B99E71B44 /* EvaluateRules.swift */; };
+		B2AB1E9283FDE2D544C8BCA8 /* MockReceiptData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39B81D88316F06C0C2757F10 /* MockReceiptData.swift */; };
 		B2B5684F46FB49AB9E3C1BE0 /* Cache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03E47DA89C9F4FBD7FA038F5 /* Cache.swift */; };
-		B3357D8577BA7CDA91A702B3 /* TrackableSuperwallEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8121467D535878BE104DF9AF /* TrackableSuperwallEvent.swift */; };
-		B40F1FB68BB0FB6A1B46D17D /* InAppReceiptPayloadContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2B726AD765B53DCC82C1E65 /* InAppReceiptPayloadContainer.swift */; };
+		B3E6E82C0240EE6048360C9B /* RawWebMessageHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C39015ED9E8F5D9F0F78F1E /* RawWebMessageHandler.swift */; };
 		B456ED8E41AD35A0EF5C295F /* ProductVariable.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC8730F0D05BFDFA12AA6309 /* ProductVariable.swift */; };
-		B58139A668F6E6A5B9546EB3 /* ProductTemplate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42FFDB546C618BDAE779B3DA /* ProductTemplate.swift */; };
+		B49D61F76B0A35E5B6B01B9D /* PresentationInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18A22BD77510896343D76A1C /* PresentationInfo.swift */; };
+		B4C9FECB4894151E42A34F85 /* Date+TimeIntervalMilliseconds.swift in Sources */ = {isa = PBXBuildFile; fileRef = E51D0B38180377D9CD3E65DA /* Date+TimeIntervalMilliseconds.swift */; };
+		B523BBBB01E8A3D43F881400 /* StorePresentationObjects.swift in Sources */ = {isa = PBXBuildFile; fileRef = 544D7004BC0C01A06868A252 /* StorePresentationObjects.swift */; };
+		B5AE7BCDCB6D49FC8493D55B /* DecodingError+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6EDC14C0D6958144679F149D /* DecodingError+Extensions.swift */; };
 		B5B83CE0D021A82950A51C47 /* String+CamelCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = F16AFE9C93A441CFB6A95F10 /* String+CamelCase.swift */; };
 		B60C3A3AD25CE2E2C513A2D2 /* Stubbable.swift in Sources */ = {isa = PBXBuildFile; fileRef = E3BFF03C1812D7239003448A /* Stubbable.swift */; };
-		B7E9BC212E3E3CC98BE84E99 /* TriggerInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35BA5B3787B2B3122EAA11B5 /* TriggerInfo.swift */; };
+		B7750B3709CE8073697C9A9C /* OpacityAnimation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 532AB25EB4DA9BAA5E3FA530 /* OpacityAnimation.swift */; };
 		B81474E6A0850E9951407926 /* PresentationCondition.swift in Sources */ = {isa = PBXBuildFile; fileRef = 191449E65A8E9EF341BAA900 /* PresentationCondition.swift */; };
+		B8483A96A7AE8440AF1E0C3B /* SKProductSubscriptionPeriodMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5BF66C3986E287B7B2F5E27 /* SKProductSubscriptionPeriodMock.swift */; };
 		B84CA6014D8D6EF201DB3935 /* LocalizationGrouping.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABC1253C6D5DD8D967BE05D1 /* LocalizationGrouping.swift */; };
+		BA957415E2E1A38A25550B99 /* MockIntroductoryPeriod.swift in Sources */ = {isa = PBXBuildFile; fileRef = 296A4AFE25C5E55DC5DD207D /* MockIntroductoryPeriod.swift */; };
 		BADAD7DDF7A8F0460CBFF362 /* ButtonFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 643A346628DA026FEA092C27 /* ButtonFactory.swift */; };
-		BBEF040F3E72B3F8CC88ED72 /* AppSessionManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5170FDBAB83BD12B139D7886 /* AppSessionManager.swift */; };
+		BBC0ADE1AAB3E8C2DC5E4F01 /* ASN1Decoder+Utils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37B17A8801A2A9454E66D892 /* ASN1Decoder+Utils.swift */; };
+		BBCB4880B7BF29743FEC82EC /* ExpressionEvaluatorLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95B831FECAFDDEC7B65A260D /* ExpressionEvaluatorLogicTests.swift */; };
 		BCF808C7AC319C2B1F0AD52D /* ConfigResponseLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4827295A4E093CAEE2207DDF /* ConfigResponseLogicTests.swift */; };
+		BCFF20903199DDDE379D81E0 /* InAppReceiptPayloadContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 862888AB2869D09AA55A017D /* InAppReceiptPayloadContainer.swift */; };
+		BD152F3BA0BC197A5C6C8CC1 /* InAppReceipt.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0695B39826F85AACBA833B77 /* InAppReceipt.swift */; };
+		BDBEE781EC4910025379F0B6 /* ASN1Serialization.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7588892D6DD1C4437CF507DE /* ASN1Serialization.swift */; };
+		BDCB094C8EAC080EE35DDF0A /* InternalPresentationLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F4EC7B3BCFACD602B9BFA41 /* InternalPresentationLogicTests.swift */; };
+		BDECE549960DB9A5662939BE /* Tracking.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F6AFBC7C60A5074ACE8DF88 /* Tracking.swift */; };
+		BE5BE4ECDE6505182DD92AA1 /* PaywallViewControllerDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88EBF6FC3090E004EE1377B4 /* PaywallViewControllerDelegate.swift */; };
 		BEC00305295F34E7D6B4E82A /* SWDebugManagerLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 76CE4D7606C896027C76520E /* SWDebugManagerLogic.swift */; };
-		C0A4031DC255DA772ECF6EC9 /* TriggerSessionTransaction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 06F06F088D9FA3AE24C04986 /* TriggerSessionTransaction.swift */; };
-		C1BA23CFF665B9D36AB6CC34 /* ProductPeriod.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE7292248877A0CD370259B8 /* ProductPeriod.swift */; };
-		C1F4379AB924DF559E8B1C23 /* ExpressionEvaluatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D127BF1A2362FBB81E2C7B52 /* ExpressionEvaluatorTests.swift */; };
-		C28C9580007CDFF029DD665B /* APIs.swift in Sources */ = {isa = PBXBuildFile; fileRef = F915C5C4DDA15706C36E58C4 /* APIs.swift */; };
-		C5B3004AACBE72FCD2951AD1 /* PushTransition.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83043016E578123D1E2D2C90 /* PushTransition.swift */; };
+		BF4246F1F93C56DC39998549 /* Sk1StoreProduct.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB6E84EBB6257BAA57F74229 /* Sk1StoreProduct.swift */; };
+		BF97D6AAA3FDA03FE3ECF56F /* WaitToPresent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21D68A4D5F80E09BA683386E /* WaitToPresent.swift */; };
+		BF9ADF5761C34F584EC416B1 /* PaywallWebEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 260AE52B33B132D5A5C04911 /* PaywallWebEvent.swift */; };
+		BFBE808BCA151FAE95AE3276 /* PaywallRequestManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1528915438E6714B1F7F7BD4 /* PaywallRequestManager.swift */; };
+		C053DEA1266E78107F828B19 /* StoreKitManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 910786130E2D7EDE2ED5452D /* StoreKitManager.swift */; };
+		C06AC148BC549114D020152D /* ConfirmPaywallAssignment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 073A0FCBB864ADFDDF30FED5 /* ConfirmPaywallAssignment.swift */; };
+		C09B8BBB7002DA446E9F74E1 /* FactoryProtocols.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C2E30544869C5469AA31832 /* FactoryProtocols.swift */; };
+		C37062A037D20AF1E5478AE2 /* StorePayment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F6E6855FC2A6D10054EAE33 /* StorePayment.swift */; };
+		C39E9FF31A8943B772EBDCAA /* InternalPresentation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 583DED0D7CA8A26424C8364A /* InternalPresentation.swift */; };
+		C583E63E93F418B8119FE2F1 /* PresentationErrors.swift in Sources */ = {isa = PBXBuildFile; fileRef = 852DB0D6CF864AE3433EF7F9 /* PresentationErrors.swift */; };
+		C5A1C6E1DB61246348A88768 /* PaywallManagerMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C57C1CCAF97244AE0DC953F /* PaywallManagerMock.swift */; };
+		C5EA22647EFADC126DC4BFE8 /* Date+IsoString.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2AF370C9EDF3C7A4605D385 /* Date+IsoString.swift */; };
 		C6747B1CFCA4C7D96D61649E /* Postback.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55AF2FFB19E23737519F408D /* Postback.swift */; };
 		C68EF5D7D3FD7E9FB2A95C47 /* Dictionary+Filter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1752442EC1C51EE4D01141AF /* Dictionary+Filter.swift */; };
-		C6D63D3FA9D015DB03AA7416 /* PaywallViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0F807DE042D48EB3DCB59F0 /* PaywallViewController.swift */; };
 		C7AB21123540550E513AD28A /* CoreDataManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0D9CC1B947A08633E1C7BAE3 /* CoreDataManagerTests.swift */; };
-		C7BDBC371E86ACD7773C1469 /* Publisher+AsyncMap.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDBE29280BE3AE1C147CD39B /* Publisher+AsyncMap.swift */; };
 		C802FBEC68BF3153CB894040 /* SWSubscriptionTemplateVariable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48E54A0E064C48DBF496B375 /* SWSubscriptionTemplateVariable.swift */; };
+		C86B9D3992BBD1E8A1105F3C /* SuperwallDelegateObjc.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33A9E0597972B90E3B9DFFE1 /* SuperwallDelegateObjc.swift */; };
+		C8BCF3C0404622139D002893 /* PushTransitionLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC74F16DC5A17489E97061EA /* PushTransitionLogic.swift */; };
+		C90E075C3BEE92968BBC4E1B /* LocalizationConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67C4FC41FEE0B47EA402D738 /* LocalizationConfig.swift */; };
 		C9BE2675C944542B6282E5B5 /* SWProductDiscount.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62AC69B94A568B7E14A391A8 /* SWProductDiscount.swift */; };
+		C9C5355AE4077E6A021F30FF /* IdentityInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C1EB433A4E4342E03BB7744 /* IdentityInfo.swift */; };
 		CB1E11FB74879A29DD1C9EB1 /* Encodable+Dictionary.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2E6016BF483A4C47FF7A7C0 /* Encodable+Dictionary.swift */; };
-		CC4E746146D0A074392B7075 /* PaywallRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DE6A6C484F28CD71BEA78B0 /* PaywallRequest.swift */; };
-		CEB30F92165CF9F526AB2E02 /* LoadingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB7DA08E93F886E54733004B /* LoadingView.swift */; };
-		CEEE66079046C63D431EAB2A /* TemplateLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 030B4D4D2CD35F6571860A93 /* TemplateLogic.swift */; };
+		CF1F5D47BA8ABF223B0B2256 /* ReceiptManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0741078E82A1B595D71D13E0 /* ReceiptManager.swift */; };
 		CF3683E2AD703237EC0CE22E /* PaywallProducts.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C95DABA23C6CBEF0AAA63C0 /* PaywallProducts.swift */; };
-		CFE9B0D5469664A8B34C1A63 /* PaywallManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1C1382B972905BF5393D30B7 /* PaywallManager.swift */; };
-		D02157DA630A977D57B55EFD /* PaywallMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 884371CD0933DF20F13D7B6B /* PaywallMessage.swift */; };
-		D10C4C038D590A13EB6C1DFD /* PaywallLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6E8278A89BA67AE4FF032DB /* PaywallLogic.swift */; };
-		D26CB433B7DCC1C59CFAFE4F /* ConfigLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 128A1A9EAD883A4065875CFD /* ConfigLogicTests.swift */; };
-		D2F18E95E1D1DCC3CFFD38F8 /* ExpressionEvaluatorLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDD938341ED4745A6206D944 /* ExpressionEvaluatorLogic.swift */; };
-		D3285BB8652564F7B7E308A0 /* Sk2TransactionObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD9DCF41F38A46DEDB3AD663 /* Sk2TransactionObserver.swift */; };
-		D40D7F7DB3CDAA1360CA3B93 /* IdentityLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60A486DE7BE9D8DAE69BFF2E /* IdentityLogic.swift */; };
+		CFEB0D797815E8EDFB059767 /* Superwall.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F7EDB6D68D0AEDD332E40BB /* Superwall.swift */; };
+		D0E19F665C7B230BF3FA122D /* TrackingResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = F85ED994DEC92BB90ACC6AC2 /* TrackingResult.swift */; };
+		D2E381B26362F434760F9AC0 /* GameControllerManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 577A16EE2161E2CDEDFA48C0 /* GameControllerManager.swift */; };
+		D330BD5F814AC52E6D04C7E7 /* InternalGetPaywall.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C9F31221C5E26E20514E0C1 /* InternalGetPaywall.swift */; };
+		D377D402D2E6126F79AED3C3 /* StoreProductType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B5C66252BBED43067E4CD87 /* StoreProductType.swift */; };
+		D443CC56731E9A20E4F43F4C /* LoadingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20365697A9C396E8EC746B77 /* LoadingViewController.swift */; };
 		D461F38D019122194A9CB38C /* PaywallRequestBody.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6F71D7A7DC8FFB72CA13296 /* PaywallRequestBody.swift */; };
-		D676B7E6D1C79278219F651C /* SuperwallGraveyard.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2A05D7D4EDEB7F2F5FD8997 /* SuperwallGraveyard.swift */; };
-		D7D93432817570E25BEE3D9A /* DebuggerCheckerOperator.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBD023FB713C2A223849B1EF /* DebuggerCheckerOperator.swift */; };
-		D87DFF2B47537836DB531474 /* ConfigLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 762D43B5A353A6871C058792 /* ConfigLogic.swift */; };
+		D4B5A9708204AB6D58904733 /* GetPaywallVcOperatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 943CA7F8AE219A07C1245232 /* GetPaywallVcOperatorTests.swift */; };
+		D4D09356A2650ED3F8D518EE /* ConfigLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = B634347011742D475E3F1A27 /* ConfigLogic.swift */; };
+		D56F32CB484F74EC7E49E581 /* PaywallViewControllerCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BAEECE2DBFEB8817E6C36DA /* PaywallViewControllerCache.swift */; };
+		D6005FE1E75CD3796B709AB4 /* ProductTrial.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61DF3B7A43B6FFAEA3DD9BE9 /* ProductTrial.swift */; };
+		D66461863D54A56BE9C29310 /* Publisher+Async.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF5A8FFFC23826AD113D525A /* Publisher+Async.swift */; };
+		D89E9C69317044050B97B573 /* IdentityManagerMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2714D9FD9F55611B4C5E4E7D /* IdentityManagerMock.swift */; };
 		D916475C6CE464EEB094F419 /* TaskRetryLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7867A3C9B173BC2D6000937 /* TaskRetryLogic.swift */; };
 		D91750797BB4947F6975B2B9 /* Date+IsoStringTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57C7673988B39FB0BDEA8BE4 /* Date+IsoStringTests.swift */; };
 		D978EAD4FA4865B5E07BF03B /* Future+Async.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8DE36D141F461F6E945823FA /* Future+Async.swift */; };
-		D9D8E02D0943EE30C516CA86 /* PublicGameController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09F317AAF18C52B7B06580E9 /* PublicGameController.swift */; };
+		DA089BB7812726DCA236A48F /* SuperwallEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 07D0428CF2880D29405900F7 /* SuperwallEvent.swift */; };
+		DA93155D0C405E32127089E2 /* TransactionVerifierSK2.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6AB850ECCAF10AF0C1AF66F9 /* TransactionVerifierSK2.swift */; };
+		DBEE8C9C68C5AE64E1A80F50 /* SK2StoreTransaction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53754B4AADE9DFF31E2F3B43 /* SK2StoreTransaction.swift */; };
 		DBF70D987418DD9EB504FBDE /* Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42956918D4FFA5FBA79F3AA5 /* Constants.swift */; };
+		DCE85B4A9DBD672B658F6EB3 /* MockSKPaymentTransaction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B1A6ADFFB9FA982BF69C134 /* MockSKPaymentTransaction.swift */; };
 		DE2F41FF9D70AB13AD246E49 /* VariantOption.swift in Sources */ = {isa = PBXBuildFile; fileRef = 194B8214C0A66407CEDCC0F4 /* VariantOption.swift */; };
-		DE46586224545C5B2AD41372 /* PaywallRequestManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3660DCD99EE318F7A12FE16F /* PaywallRequestManager.swift */; };
+		DE62F8E261EC7C60FBAAAE1D /* BundleHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = F34468E3988E779132CE101A /* BundleHelper.swift */; };
 		DEB255607E961730B4A5761B /* UIDevice+ModelName.swift in Sources */ = {isa = PBXBuildFile; fileRef = 750CC308DD48F4CE615DFC89 /* UIDevice+ModelName.swift */; };
 		E0728B4B771F020BF6CC405C /* String+RemoveChars.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E3E1BAFC4A22DC46C49F00C /* String+RemoveChars.swift */; };
+		E0DA50D9E75BADFBBABB8768 /* PaywallMessageHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B45A6006E4299E75E91CC2ED /* PaywallMessageHandlerTests.swift */; };
+		E0F3648081AB86077201EB5D /* FeatureFlags.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83416F0F1B5294C350D5CF70 /* FeatureFlags.swift */; };
 		E0F69E406F64A1160FF55BFA /* SWProduct.swift in Sources */ = {isa = PBXBuildFile; fileRef = 460B6F98BADD9EC96A978E40 /* SWProduct.swift */; };
-		E18B0385312E6FADC04D6F4B /* TriggerSessionTrigger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E2F873BF32DB7D791C152C1 /* TriggerSessionTrigger.swift */; };
-		E2C32146C9B1E9EA1E1143DC /* AppSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1AE22760FB509FAE1B9AF0C7 /* AppSession.swift */; };
+		E1A838C9CE62C9479D0C68F4 /* SWDebugManagerLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C733A9BE56EA9E10D75B073B /* SWDebugManagerLogicTests.swift */; };
+		E2E0E2A82200943E73E3A92A /* AppSessionManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59A767F107FB1FBBC2F22DB3 /* AppSessionManagerTests.swift */; };
+		E3DC0E7597234DC8CC508A33 /* MapSwiftErrors.swift in Sources */ = {isa = PBXBuildFile; fileRef = 81D80A7C5B8A17B83C218656 /* MapSwiftErrors.swift */; };
+		E3F2F347326B8D206D341FB6 /* TrackingLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95ED8690E8B88125776BC247 /* TrackingLogic.swift */; };
+		E41B3EF729D9896C7E0FD10C /* PaywallPresentationHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B9E9E16EBDA97E736968496 /* PaywallPresentationHandler.swift */; };
+		E48123B9CCCB7D02CAF15642 /* StoreTransactionType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90B1A5AC3B7C3000274C782E /* StoreTransactionType.swift */; };
+		E5678743A4C7E7917AE2E851 /* SK2StoreProductDiscount.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6CFA5F684C1732D79CBA2C49 /* SK2StoreProductDiscount.swift */; };
 		E63A7174E3B98690B073C373 /* JSONEncoder+Superwall.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD778E66506BA51BEB5EE89C /* JSONEncoder+Superwall.swift */; };
 		E63BD2E9AA7F1CCC70C889D5 /* ConfigResponseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 355B043004EA75053A0524DD /* ConfigResponseTests.swift */; };
-		E82B6B4AD270B08CA5F3244C /* MockIntroductoryPeriod.swift in Sources */ = {isa = PBXBuildFile; fileRef = F787CE1E5BC1B7FAD479F0DC /* MockIntroductoryPeriod.swift */; };
-		E8B60A6F863B0F4FD6282F45 /* BottomPaddingAnimation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B3F1C3A01E3C951974667D7 /* BottomPaddingAnimation.swift */; };
+		E7FD108C357A816AF8BFBA47 /* DarkBlurredBackground.swift in Sources */ = {isa = PBXBuildFile; fileRef = 97A579F56E5CEF54DB9E9B62 /* DarkBlurredBackground.swift */; };
 		E8C338D99A00BEFD9C908968 /* V1Migrator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4BE6E7AC2E38E0EB43C35AF5 /* V1Migrator.swift */; };
-		E937F2AB6D4C0E627F92489D /* Model.xcdatamodeld in Sources */ = {isa = PBXBuildFile; fileRef = E36770FA7C30179E09D62489 /* Model.xcdatamodeld */; };
-		EA42211867A18EC544172EC2 /* ProductPrice.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8F55CC8D621E7013FAEF4C0 /* ProductPrice.swift */; };
+		E95C8C0485512D77E37703C5 /* ASN1Templates.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45AFD6EE9BED296D075A9618 /* ASN1Templates.swift */; };
+		E986B0CF98B8C09AAA961E94 /* AppSessionManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC89718EBDD71E09AB5F41DA /* AppSessionManager.swift */; };
+		EB6540A8E1ECC3548C5E6368 /* PaywallMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC653A44D9B40812BDDD94E7 /* PaywallMessage.swift */; };
 		EB6A6ED6BD9965DC70A606DF /* TriggerRuleOccurrence.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B6C286BF417074EEE0D3D55 /* TriggerRuleOccurrence.swift */; };
-		EBD60DFCBEDFE311EDE63EA1 /* PaywallSkippedReason.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF03C89BD8E474D8F539C181 /* PaywallSkippedReason.swift */; };
-		EBF18BE21B633EDC931C10B3 /* AwaitIdentityOperator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 999EAA9CED33866246D75177 /* AwaitIdentityOperator.swift */; };
+		ED1C693657DA7FCBAE2DDDC6 /* FeatureGatingBehaviour.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24B8D7F537204EAB13BB7F10 /* FeatureGatingBehaviour.swift */; };
 		EDAEC46845C1DB11CB4C99AE /* SWConsoleViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CDFBF0FA8B313E0D84A51DB /* SWConsoleViewController.swift */; };
-		EF1E845D1542855C1BEB8591 /* ReceiptLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = EFBFA0E9940718D6F8B28EE5 /* ReceiptLogic.swift */; };
-		F0366D496C024FA8FE5F5823 /* UserInitiatedEvents.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E36C7A628CE395D4E118CDE /* UserInitiatedEvents.swift */; };
+		EF32778E182D5FF3FCC86223 /* TriggerSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E77DE2454F2F58460EF162A /* TriggerSession.swift */; };
+		F12D7D4F0F53C71B2A28445B /* SuperwallEventInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5238DE736E2EF395E44ABCE1 /* SuperwallEventInfo.swift */; };
+		F15479C499547FE1B47DEA6B /* MockSkProduct.swift in Sources */ = {isa = PBXBuildFile; fileRef = 719FE7C289CB0A621595A2A4 /* MockSkProduct.swift */; };
+		F1C87596E2893379C74907F6 /* TriggerSessionManagerLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1BC1DAA412BF11AE6B58D59D /* TriggerSessionManagerLogicTests.swift */; };
 		F297363F2C4BFEE9D051D684 /* EventsRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64293B1D6F648DE113908AE7 /* EventsRequest.swift */; };
-		F2F8B839FF59CE357067389F /* SessionEventsManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B0BE8481AD0F840392AE4BF /* SessionEventsManagerTests.swift */; };
 		F3A7AF6D766960ECFE03E4B8 /* UIViewController+TopVc.swift in Sources */ = {isa = PBXBuildFile; fileRef = 759D7C0FCB370EB4FC33F4E4 /* UIViewController+TopVc.swift */; };
-		F494571A1A71840F891183A6 /* SuperwallDelegateAdapter.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA1DF58EB09E500977460E0E /* SuperwallDelegateAdapter.swift */; };
+		F5CCDC90D8CBA5ED0C5BAD2E /* PublicGetPresentationResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4F676D3A0F5B540052D36B1 /* PublicGetPresentationResult.swift */; };
+		F5F8C2E02A057DA15C2936AB /* StorePresentationObjectsOperatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BDA9D233EACAB5090B0657D /* StorePresentationObjectsOperatorTests.swift */; };
+		F5FBA532DB79848B0537720F /* PresentationResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94125DB9AC8A2EA66F983EDA /* PresentationResult.swift */; };
 		F605AA51AB24B564D3A21B07 /* Paywall.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82E6981E6A6574EE72B65A9E /* Paywall.swift */; };
 		F63B1A0AB2214948A14C9F88 /* AssignmentPostback.swift in Sources */ = {isa = PBXBuildFile; fileRef = 890C396C6DB6F419ED621BAA /* AssignmentPostback.swift */; };
-		F67A0DA424F15D3FB83EB5C9 /* TransactionManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9269654937F069D15D5112CE /* TransactionManager.swift */; };
-		F6FE84ADA7107D9CC04639B8 /* ProductsManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9DB8450EB537722D79EB8194 /* ProductsManager.swift */; };
-		F7C9D4352AA93BC8896BD160 /* PublicPresentation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 641CDF0D4256D135D4461FE8 /* PublicPresentation.swift */; };
+		F75F5E1D503B9391ADD812EC /* PKCS7.swift in Sources */ = {isa = PBXBuildFile; fileRef = 30C2B369C690AAB9C085E2E9 /* PKCS7.swift */; };
+		F79C378E19116B9312AE5873 /* ASN1Decoder+Unboxing.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70FC86C1189200C486627EAD /* ASN1Decoder+Unboxing.swift */; };
 		F8E799A3A83A2758D6EAA385 /* Array+Guarded.swift in Sources */ = {isa = PBXBuildFile; fileRef = A40D9BA2449503F4B7F5B7A6 /* Array+Guarded.swift */; };
+		F946296C5DD154BCF5C0B958 /* InternalPresentationLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 13CD313E1E0B5EFBFA4B041F /* InternalPresentationLogic.swift */; };
 		F958219E873CEF2A14079E22 /* GCControllerElement+buttonName.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2243C6BF6BE477794F568ED /* GCControllerElement+buttonName.swift */; };
-		F96AE1AC5DA8C2F5FBF7E35D /* ConfigManagerMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CF6099237A88F3736F766A8 /* ConfigManagerMock.swift */; };
+		FA907E1BC8B68F238C791867 /* SuperwallDelegateAdapter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8E441343EAC43B2ECF35F929 /* SuperwallDelegateAdapter.swift */; };
 		FC051A3A8D640AF49D798B25 /* RawExperiment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7611B89AB647CB1AB79CA912 /* RawExperiment.swift */; };
-		FDA86882DC58B8F9B831D1FE /* TriggerSessionManagerLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0240B2878A43A1164D2F2D6 /* TriggerSessionManagerLogic.swift */; };
-		FE6C2F5C3BED509814DE2E58 /* TriggerSessionManagerLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C1998A6FF59883ECD906E84 /* TriggerSessionManagerLogicTests.swift */; };
+		FCC6EF5807B709E920901174 /* PaywallConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECEF5CE080936CBEDE201F13 /* PaywallConfig.swift */; };
+		FCD7C16E35F139DCC2386B91 /* ConfigManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92A6B82F855E19B9C180C659 /* ConfigManagerTests.swift */; };
+		FCEF5A897E34F9B7AB691C56 /* PaywallOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1A64CCBCB23CC1715DF79AC /* PaywallOptions.swift */; };
+		FCF498808FF38EEC5E9895DB /* IdentityOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 320AA5349848F696950F441A /* IdentityOptions.swift */; };
 		FFC1A413FF8B96275C4C1649 /* Storage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1C16CBCBF2093DD9C5F3E105 /* Storage.swift */; };
 /* End PBXBuildFile section */
 
@@ -316,289 +408,379 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
-		030B4D4D2CD35F6571860A93 /* TemplateLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TemplateLogic.swift; sourceTree = "<group>"; };
+		010F0F8FCE0A86D8F2823A47 /* PublicGameController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PublicGameController.swift; sourceTree = "<group>"; };
+		018F5856F39FC33AFE9740D4 /* ConfirmHoldoutAssignmentTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConfirmHoldoutAssignmentTests.swift; sourceTree = "<group>"; };
+		01E54BC1CA38F828AC77F774 /* PublicPresentation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PublicPresentation.swift; sourceTree = "<group>"; };
+		03471273DF4C875227102BE2 /* ReceiptManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReceiptManagerTests.swift; sourceTree = "<group>"; };
 		03E47DA89C9F4FBD7FA038F5 /* Cache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Cache.swift; sourceTree = "<group>"; };
-		04E8EB76AB037B3586240A4B /* PaddingListener.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaddingListener.swift; sourceTree = "<group>"; };
 		04FB15C76DE3D22CB370AFDB /* SuperwallKit.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = SuperwallKit.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		0514001D70634D4DA82B83F7 /* PaywallLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaywallLogicTests.swift; sourceTree = "<group>"; };
-		0570862FCFAF7FB6B125F7E4 /* AppSessionManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppSessionManagerTests.swift; sourceTree = "<group>"; };
-		06F06F088D9FA3AE24C04986 /* TriggerSessionTransaction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TriggerSessionTransaction.swift; sourceTree = "<group>"; };
-		0897A9C4AC47DEE2F0FB20D4 /* SuperwallDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SuperwallDelegate.swift; sourceTree = "<group>"; };
-		09F317AAF18C52B7B06580E9 /* PublicGameController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PublicGameController.swift; sourceTree = "<group>"; };
-		0B0EE285A4202B015060049B /* Debug.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Debug.swift; sourceTree = "<group>"; };
+		054FCADFEF560A1A736DEFE4 /* StoreKitManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreKitManagerTests.swift; sourceTree = "<group>"; };
+		0695B39826F85AACBA833B77 /* InAppReceipt.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InAppReceipt.swift; sourceTree = "<group>"; };
+		072886BB8C0E08DF414D9162 /* InAppReceiptPayload.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InAppReceiptPayload.swift; sourceTree = "<group>"; };
+		073A0FCBB864ADFDDF30FED5 /* ConfirmPaywallAssignment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConfirmPaywallAssignment.swift; sourceTree = "<group>"; };
+		0741078E82A1B595D71D13E0 /* ReceiptManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReceiptManager.swift; sourceTree = "<group>"; };
+		079455F8D3D241361EF5F0AA /* CheckPaywallPresentableOperatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CheckPaywallPresentableOperatorTests.swift; sourceTree = "<group>"; };
+		07B04D40ECF8BAFFC0CA9F26 /* StoreKitCoordinatorFactoryMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreKitCoordinatorFactoryMock.swift; sourceTree = "<group>"; };
+		07D0428CF2880D29405900F7 /* SuperwallEvent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SuperwallEvent.swift; sourceTree = "<group>"; };
+		0B5C66252BBED43067E4CD87 /* StoreProductType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreProductType.swift; sourceTree = "<group>"; };
+		0C39015ED9E8F5D9F0F78F1E /* RawWebMessageHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RawWebMessageHandler.swift; sourceTree = "<group>"; };
+		0C4CEDEB039548ABF39B528E /* ProductsFetcherSK1.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductsFetcherSK1.swift; sourceTree = "<group>"; };
 		0C95DABA23C6CBEF0AAA63C0 /* PaywallProducts.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaywallProducts.swift; sourceTree = "<group>"; };
+		0CCCFB974F1CAB7ABEF75AB7 /* LogPresentation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LogPresentation.swift; sourceTree = "<group>"; };
 		0D9CC1B947A08633E1C7BAE3 /* CoreDataManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoreDataManagerTests.swift; sourceTree = "<group>"; };
 		0E3AC3B23DAAA8C1D125BDD3 /* CoreDataManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoreDataManager.swift; sourceTree = "<group>"; };
-		10552F325E6976EC5825C6EA /* DarkBlurredBackground.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DarkBlurredBackground.swift; sourceTree = "<group>"; };
+		0F2070ACE29ED3EA357228DC /* TriggerSessionProduct.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TriggerSessionProduct.swift; sourceTree = "<group>"; };
 		10D5ABDB23D56393EFDCF73A /* NetworkMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkMock.swift; sourceTree = "<group>"; };
-		10EFDC8DEA3944B23AE6511D /* PaywallOptions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaywallOptions.swift; sourceTree = "<group>"; };
-		120AB0D996202873DA53A667 /* SuperwallDelegateObjc.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SuperwallDelegateObjc.swift; sourceTree = "<group>"; };
-		1269B5184768FDA6BE892B20 /* TransactionProduct.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransactionProduct.swift; sourceTree = "<group>"; };
-		128A1A9EAD883A4065875CFD /* ConfigLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConfigLogicTests.swift; sourceTree = "<group>"; };
+		124F219E38F8398A65A7EB32 /* DependencyContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DependencyContainer.swift; sourceTree = "<group>"; };
+		1376F233A5CF79DAD2428171 /* RuleAttributes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RuleAttributes.swift; sourceTree = "<group>"; };
 		13BB801E8B818F3B96AF65D6 /* SWProductNumberGroup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SWProductNumberGroup.swift; sourceTree = "<group>"; };
-		14926B3770019BAF544EE626 /* PushTransitionLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PushTransitionLogic.swift; sourceTree = "<group>"; };
-		1503802B20764509D922B1FC /* FreeTrialTemplate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FreeTrialTemplate.swift; sourceTree = "<group>"; };
+		13CD313E1E0B5EFBFA4B041F /* InternalPresentationLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InternalPresentationLogic.swift; sourceTree = "<group>"; };
+		1528915438E6714B1F7F7BD4 /* PaywallRequestManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaywallRequestManager.swift; sourceTree = "<group>"; };
 		153C660FB51D0D1DFE56D462 /* PaywallPresentationStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaywallPresentationStyle.swift; sourceTree = "<group>"; };
-		166374D62DB0AE4E759F2CA4 /* UserAttributes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserAttributes.swift; sourceTree = "<group>"; };
-		173CADA540CA40A87FAA054C /* SWDebugManagerLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SWDebugManagerLogicTests.swift; sourceTree = "<group>"; };
+		16AC8D761A7F5A7F012EA39B /* EvaluateRulesOperatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EvaluateRulesOperatorTests.swift; sourceTree = "<group>"; };
 		1752442EC1C51EE4D01141AF /* Dictionary+Filter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Dictionary+Filter.swift"; sourceTree = "<group>"; };
+		184CC04EBE95A64F30F83EA0 /* ASN1Decoder+SingleValueContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ASN1Decoder+SingleValueContainer.swift"; sourceTree = "<group>"; };
+		187934D3C89220C605299A17 /* PaywallManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaywallManager.swift; sourceTree = "<group>"; };
+		18A22BD77510896343D76A1C /* PresentationInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PresentationInfo.swift; sourceTree = "<group>"; };
+		18DB52B223C181E0A8FA1D6D /* BottomPaddingAnimation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BottomPaddingAnimation.swift; sourceTree = "<group>"; };
 		191449E65A8E9EF341BAA900 /* PresentationCondition.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PresentationCondition.swift; sourceTree = "<group>"; };
 		194B8214C0A66407CEDCC0F4 /* VariantOption.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VariantOption.swift; sourceTree = "<group>"; };
 		19F010DC597017F5BEAEDE86 /* SwiftyJSON.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwiftyJSON.swift; sourceTree = "<group>"; };
-		1AE22760FB509FAE1B9AF0C7 /* AppSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppSession.swift; sourceTree = "<group>"; };
-		1BCAA3FE5110CCAADEA9CC0E /* IdentityLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IdentityLogicTests.swift; sourceTree = "<group>"; };
-		1C1382B972905BF5393D30B7 /* PaywallManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaywallManager.swift; sourceTree = "<group>"; };
+		1A2E8A96B1F4C3C78CFA696C /* GetPresentationResultLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetPresentationResultLogic.swift; sourceTree = "<group>"; };
+		1AB5B56470F69FBE1C34EAA8 /* PaywallRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaywallRequest.swift; sourceTree = "<group>"; };
+		1B1A6ADFFB9FA982BF69C134 /* MockSKPaymentTransaction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockSKPaymentTransaction.swift; sourceTree = "<group>"; };
+		1B78FB9232236AF44369EA92 /* AppSessionManagerMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppSessionManagerMock.swift; sourceTree = "<group>"; };
+		1B9C006C80A6104FA63FA84C /* CheckUserSubscription.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CheckUserSubscription.swift; sourceTree = "<group>"; };
+		1BC1DAA412BF11AE6B58D59D /* TriggerSessionManagerLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TriggerSessionManagerLogicTests.swift; sourceTree = "<group>"; };
 		1C16CBCBF2093DD9C5F3E105 /* Storage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Storage.swift; sourceTree = "<group>"; };
-		1C7DF2BC047B98ABFFC3C966 /* SuperwallLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SuperwallLogic.swift; sourceTree = "<group>"; };
-		1D8DA08B90AA82CB3337B624 /* ScaleAnimation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScaleAnimation.swift; sourceTree = "<group>"; };
-		1DE6A6C484F28CD71BEA78B0 /* PaywallRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaywallRequest.swift; sourceTree = "<group>"; };
-		1F5EF184B150FC221A8B7CCA /* SWDebugViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SWDebugViewController.swift; sourceTree = "<group>"; };
-		1F8C5C62885BCF23722904B0 /* RotationAnimation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RotationAnimation.swift; sourceTree = "<group>"; };
-		20002CE824E4D422DDA12E62 /* RawWebMessageHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RawWebMessageHandler.swift; sourceTree = "<group>"; };
-		2200BA9DBFD79CD558E7C542 /* TrackingResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrackingResult.swift; sourceTree = "<group>"; };
-		22CA87F0488301B60564C72A /* Superwall.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Superwall.swift; sourceTree = "<group>"; };
-		2357B335109EA70FD685C993 /* SuperwallEventInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SuperwallEventInfo.swift; sourceTree = "<group>"; };
-		24743C72BA7EC046E88AF16E /* AddProductsOperator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddProductsOperator.swift; sourceTree = "<group>"; };
+		1CC8F4AB247F86988A71BF01 /* ExpressionEvaluator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExpressionEvaluator.swift; sourceTree = "<group>"; };
+		20365697A9C396E8EC746B77 /* LoadingViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoadingViewController.swift; sourceTree = "<group>"; };
+		2123B84F5C786278E128152D /* OccurrenceLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OccurrenceLogicTests.swift; sourceTree = "<group>"; };
+		214622367ACC8F66EB392105 /* AppSessionLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppSessionLogic.swift; sourceTree = "<group>"; };
+		2165AB24A77F58698AAFC04A /* PurchaseResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PurchaseResult.swift; sourceTree = "<group>"; };
+		21B510F7222F3E052A862A66 /* MockSessionEventsQueue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockSessionEventsQueue.swift; sourceTree = "<group>"; };
+		21C52F36F0BFF59363EBB4C7 /* GameControllerEvent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GameControllerEvent.swift; sourceTree = "<group>"; };
+		21D68A4D5F80E09BA683386E /* WaitToPresent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WaitToPresent.swift; sourceTree = "<group>"; };
+		236900A8A8F95CE92E612458 /* IdentityManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IdentityManager.swift; sourceTree = "<group>"; };
+		23F821BDAE724B3F3FFDA5E5 /* StoreKitTestCertificate.cer */ = {isa = PBXFileReference; path = StoreKitTestCertificate.cer; sourceTree = "<group>"; };
+		24B8D7F537204EAB13BB7F10 /* FeatureGatingBehaviour.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeatureGatingBehaviour.swift; sourceTree = "<group>"; };
+		24EA03270476CD31B906CDC8 /* GetPaywallResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetPaywallResult.swift; sourceTree = "<group>"; };
+		25515131DF0AE67E26BFF462 /* TriggerResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TriggerResult.swift; sourceTree = "<group>"; };
 		258FC2DB67022EF3D9B1FB67 /* Endpoint.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Endpoint.swift; sourceTree = "<group>"; };
+		260AE52B33B132D5A5C04911 /* PaywallWebEvent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaywallWebEvent.swift; sourceTree = "<group>"; };
 		2628BCB13E80DC539F35C7B5 /* Trigger.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Trigger.swift; sourceTree = "<group>"; };
-		2697574309A971468AC12635 /* TriggerSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TriggerSession.swift; sourceTree = "<group>"; };
+		2714D9FD9F55611B4C5E4E7D /* IdentityManagerMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IdentityManagerMock.swift; sourceTree = "<group>"; };
+		2845A6B61C43D18F869D750E /* Model.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = Model.xcdatamodel; sourceTree = "<group>"; };
 		2888B05A273E9EB6E9382332 /* UIColor+Hex.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIColor+Hex.swift"; sourceTree = "<group>"; };
-		28A4999BBFF9057B7CE580E6 /* PaywallCacheTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaywallCacheTests.swift; sourceTree = "<group>"; };
+		28A1C8B0D79B8AC70ECF0CBB /* ConfigState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConfigState.swift; sourceTree = "<group>"; };
+		296A4AFE25C5E55DC5DD207D /* MockIntroductoryPeriod.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockIntroductoryPeriod.swift; sourceTree = "<group>"; };
+		299441C3A6D3948BC5E0C741 /* PaywallInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaywallInfo.swift; sourceTree = "<group>"; };
 		299F91895EE88281B5ED8320 /* SWBounceButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SWBounceButton.swift; sourceTree = "<group>"; };
-		2AEAF9E84CF443750C23DFCF /* ConfirmAssignmentOperator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConfirmAssignmentOperator.swift; sourceTree = "<group>"; };
-		2B0BE8481AD0F840392AE4BF /* SessionEventsManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionEventsManagerTests.swift; sourceTree = "<group>"; };
 		2B40F35B536F527B029D7BDE /* SWProductSubscriptionPeriod.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SWProductSubscriptionPeriod.swift; sourceTree = "<group>"; };
-		2C69250C9C29C6062BD58A0C /* TriggerSessionExperiment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TriggerSessionExperiment.swift; sourceTree = "<group>"; };
-		2CF6099237A88F3736F766A8 /* ConfigManagerMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConfigManagerMock.swift; sourceTree = "<group>"; };
-		2D32BFD05F5B55287EFB19FD /* MockSubscriptionPeriod.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockSubscriptionPeriod.swift; sourceTree = "<group>"; };
+		2B430DE1BA468E280567F03C /* ProductTemplate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductTemplate.swift; sourceTree = "<group>"; };
+		2BB10D9097CC124FFC34A4A0 /* RotationAnimation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RotationAnimation.swift; sourceTree = "<group>"; };
+		2BE63AAEDD12E85626744ED5 /* RuleLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RuleLogic.swift; sourceTree = "<group>"; };
+		2CB5E7278D5B95BC2EBC3474 /* StoreProductDiscount.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreProductDiscount.swift; sourceTree = "<group>"; };
+		2D1A60826D12F97F96E671DF /* SpringAnimation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpringAnimation.swift; sourceTree = "<group>"; };
 		2DAE3B565ECB65BCCFD39A0A /* FileManagerMigrator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileManagerMigrator.swift; sourceTree = "<group>"; };
 		2E2027BFC214905CBE589AF2 /* KeypathWritable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeypathWritable.swift; sourceTree = "<group>"; };
+		2E77DE2454F2F58460EF162A /* TriggerSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TriggerSession.swift; sourceTree = "<group>"; };
+		2F6AFBC7C60A5074ACE8DF88 /* Tracking.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Tracking.swift; sourceTree = "<group>"; };
+		2F7EDB6D68D0AEDD332E40BB /* Superwall.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Superwall.swift; sourceTree = "<group>"; };
 		2FB3F2FC9FCCD4B912E61A1F /* FileManagerMigratorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileManagerMigratorTests.swift; sourceTree = "<group>"; };
-		31BFC6917BDCE905B903E8FE /* OccurrenceLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OccurrenceLogicTests.swift; sourceTree = "<group>"; };
+		30C2B369C690AAB9C085E2E9 /* PKCS7.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PKCS7.swift; sourceTree = "<group>"; };
+		320AA5349848F696950F441A /* IdentityOptions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IdentityOptions.swift; sourceTree = "<group>"; };
 		335888285131F832E1C91A8F /* Dictionary+Merging.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Dictionary+Merging.swift"; sourceTree = "<group>"; };
-		33BB1232A536B665B0C33E09 /* TransactionModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransactionModel.swift; sourceTree = "<group>"; };
-		352D6CA631F149C0B0C29DAE /* CheckPaywallPresentableOperator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CheckPaywallPresentableOperator.swift; sourceTree = "<group>"; };
+		33A9E0597972B90E3B9DFFE1 /* SuperwallDelegateObjc.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SuperwallDelegateObjc.swift; sourceTree = "<group>"; };
+		3501D12845840D6CBA1F0081 /* AssignmentLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssignmentLogicTests.swift; sourceTree = "<group>"; };
 		355B043004EA75053A0524DD /* ConfigResponseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConfigResponseTests.swift; sourceTree = "<group>"; };
-		35BA5B3787B2B3122EAA11B5 /* TriggerInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TriggerInfo.swift; sourceTree = "<group>"; };
 		35C534C42A8EAC1F183CC85A /* LocalizationLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalizationLogic.swift; sourceTree = "<group>"; };
 		35F538F901BAF97DDCA86F84 /* DeviceHelperMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeviceHelperMock.swift; sourceTree = "<group>"; };
-		365CD0C3A1A3A605271B1DB7 /* IdentityManagerMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IdentityManagerMock.swift; sourceTree = "<group>"; };
-		3660DCD99EE318F7A12FE16F /* PaywallRequestManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaywallRequestManager.swift; sourceTree = "<group>"; };
-		368931F3E7FD5474629096FB /* TriggerSessionProducts.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TriggerSessionProducts.swift; sourceTree = "<group>"; };
-		3ACEB8F7B11E039CB02BCCD0 /* PaywallTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaywallTests.swift; sourceTree = "<group>"; };
-		3BEE62C0226A4AD750011CFD /* ReceiptManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReceiptManager.swift; sourceTree = "<group>"; };
-		3C1998A6FF59883ECD906E84 /* TriggerSessionManagerLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TriggerSessionManagerLogicTests.swift; sourceTree = "<group>"; };
+		37B17A8801A2A9454E66D892 /* ASN1Decoder+Utils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ASN1Decoder+Utils.swift"; sourceTree = "<group>"; };
+		39B81D88316F06C0C2757F10 /* MockReceiptData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockReceiptData.swift; sourceTree = "<group>"; };
+		3C064AE76E6545B9595305D7 /* SK1StoreProductDiscount.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SK1StoreProductDiscount.swift; sourceTree = "<group>"; };
+		3C1EB433A4E4342E03BB7744 /* IdentityInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IdentityInfo.swift; sourceTree = "<group>"; };
 		3CDFBF0FA8B313E0D84A51DB /* SWConsoleViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SWConsoleViewController.swift; sourceTree = "<group>"; };
-		3D198142576890710445E657 /* StoreKitManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreKitManagerTests.swift; sourceTree = "<group>"; };
+		3D8AD1A7B62E8CBBDFB65BE5 /* TrackableSuperwallEvent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrackableSuperwallEvent.swift; sourceTree = "<group>"; };
 		3D97E1615BA0B22BBBE0DAFA /* UIWindow+Landscape.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIWindow+Landscape.swift"; sourceTree = "<group>"; };
 		3E3E1BAFC4A22DC46C49F00C /* String+RemoveChars.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+RemoveChars.swift"; sourceTree = "<group>"; };
 		3E828EBAB18CCC0B236EF71D /* CoreDataStackMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoreDataStackMock.swift; sourceTree = "<group>"; };
-		3EB9F4F9ACAEA150B071FDA5 /* MockSkProduct.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockSkProduct.swift; sourceTree = "<group>"; };
-		424E0C25FF267517F70AFC6B /* FeatureFlags.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeatureFlags.swift; sourceTree = "<group>"; };
-		4252EDEF1B7AFBCB44CD5000 /* SWDebugManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SWDebugManager.swift; sourceTree = "<group>"; };
+		3EC6869BE9279D725C1F822E /* SessionEventsManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionEventsManagerTests.swift; sourceTree = "<group>"; };
+		40AE19B5A9B237A2552D5F36 /* IdentityLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IdentityLogicTests.swift; sourceTree = "<group>"; };
 		42956918D4FFA5FBA79F3AA5 /* Constants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Constants.swift; sourceTree = "<group>"; };
-		42F51ED1275B5BBD0893B067 /* TrackingLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrackingLogic.swift; sourceTree = "<group>"; };
-		42FFDB546C618BDAE779B3DA /* ProductTemplate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductTemplate.swift; sourceTree = "<group>"; };
-		4341A45FFB9258457E962532 /* ExpressionEvaluator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExpressionEvaluator.swift; sourceTree = "<group>"; };
+		440ABDF6DAE2C15579B93DF1 /* PushTransitionDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PushTransitionDelegate.swift; sourceTree = "<group>"; };
+		448D7B7B467CBA2A4359E3F4 /* NotificationScheduler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationScheduler.swift; sourceTree = "<group>"; };
+		45AFD6EE9BED296D075A9618 /* ASN1Templates.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ASN1Templates.swift; sourceTree = "<group>"; };
 		460B6F98BADD9EC96A978E40 /* SWProduct.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SWProduct.swift; sourceTree = "<group>"; };
-		4641647787524DB540D4969B /* RestorationHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RestorationHandler.swift; sourceTree = "<group>"; };
+		46D2598EB46E9A27E2BD5104 /* PreloadingDisabled.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreloadingDisabled.swift; sourceTree = "<group>"; };
+		47D0B3E1489C378D73F7CFD4 /* PurchaseControllerObjc.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PurchaseControllerObjc.swift; sourceTree = "<group>"; };
 		481D47E5121C521DDA268609 /* TriggerRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TriggerRule.swift; sourceTree = "<group>"; };
 		4827295A4E093CAEE2207DDF /* ConfigResponseLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConfigResponseLogicTests.swift; sourceTree = "<group>"; };
 		48E54A0E064C48DBF496B375 /* SWSubscriptionTemplateVariable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SWSubscriptionTemplateVariable.swift; sourceTree = "<group>"; };
-		4955958DB59356ABF25A5D4F /* PublicIdentity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PublicIdentity.swift; sourceTree = "<group>"; };
-		4A1AAD9CA30CFB266D26F7C7 /* TransactionRecorder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransactionRecorder.swift; sourceTree = "<group>"; };
-		4ADB18BDD8A9BF03BDE396C0 /* ConfigManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConfigManager.swift; sourceTree = "<group>"; };
+		498D6155C2B8B18E7F3D0E79 /* Validation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Validation.swift; sourceTree = "<group>"; };
+		4A41E45077BFED96FCC25457 /* PaywallSkippedReason.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaywallSkippedReason.swift; sourceTree = "<group>"; };
+		4A978542D21EC187C1A3C499 /* WaitToPresentOperatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WaitToPresentOperatorTests.swift; sourceTree = "<group>"; };
 		4B17DA82A4CD5ADCB98C423A /* SWProductNumber.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SWProductNumber.swift; sourceTree = "<group>"; };
 		4B6C286BF417074EEE0D3D55 /* TriggerRuleOccurrence.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TriggerRuleOccurrence.swift; sourceTree = "<group>"; };
 		4BBEC4952B1502826F554C83 /* PostbackRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostbackRequest.swift; sourceTree = "<group>"; };
 		4BE6E7AC2E38E0EB43C35AF5 /* V1Migrator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = V1Migrator.swift; sourceTree = "<group>"; };
-		4FEBF2A47374CE665EC5D33D /* PaywallConfig.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaywallConfig.swift; sourceTree = "<group>"; };
+		4EC3DA8E774FBFE31F811FAF /* ConfigManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConfigManager.swift; sourceTree = "<group>"; };
 		50458143450675EF205CE2C3 /* CoreDataStack.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoreDataStack.swift; sourceTree = "<group>"; };
 		51407421A3CBF7AF0FC76E60 /* Bundle+Helpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Bundle+Helpers.swift"; sourceTree = "<group>"; };
-		5170FDBAB83BD12B139D7886 /* AppSessionManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppSessionManager.swift; sourceTree = "<group>"; };
-		5288181962FAFEBEEF58E19C /* LocalizationConfig.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalizationConfig.swift; sourceTree = "<group>"; };
-		544F99BB5858C75E3220B4EB /* TriggerSessionPaywall.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TriggerSessionPaywall.swift; sourceTree = "<group>"; };
+		51445FD3A0C38C2B502EAF1D /* ComputedPropertyRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ComputedPropertyRequest.swift; sourceTree = "<group>"; };
+		5238DE736E2EF395E44ABCE1 /* SuperwallEventInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SuperwallEventInfo.swift; sourceTree = "<group>"; };
+		5283BA49E380740C34D78856 /* OnDeviceCaching.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnDeviceCaching.swift; sourceTree = "<group>"; };
+		532AB25EB4DA9BAA5E3FA530 /* OpacityAnimation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpacityAnimation.swift; sourceTree = "<group>"; };
+		53754B4AADE9DFF31E2F3B43 /* SK2StoreTransaction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SK2StoreTransaction.swift; sourceTree = "<group>"; };
+		5383FA48A6E9EF8F30683C9B /* DebugManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DebugManager.swift; sourceTree = "<group>"; };
+		544C032167E8198513B2A860 /* PresentationValueObjc.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PresentationValueObjc.swift; sourceTree = "<group>"; };
+		544D7004BC0C01A06868A252 /* StorePresentationObjects.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StorePresentationObjects.swift; sourceTree = "<group>"; };
 		54F3977B4B42057743A41FE0 /* CacheMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CacheMock.swift; sourceTree = "<group>"; };
 		55AF2FFB19E23737519F408D /* Postback.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Postback.swift; sourceTree = "<group>"; };
-		56778050EC54F641333F5CDB /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		55DDD2F24335874B99E71B44 /* EvaluateRules.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EvaluateRules.swift; sourceTree = "<group>"; };
 		571825E7515FCC1E877D4429 /* Dictionary+Cache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Dictionary+Cache.swift"; sourceTree = "<group>"; };
 		57478172574516BD5EDD254A /* LoadingInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoadingInfo.swift; sourceTree = "<group>"; };
-		5765F9403E44383A8FC7D3AD /* BundleHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BundleHelper.swift; sourceTree = "<group>"; };
-		57BBC30EF2E06EBADE774802 /* LoadingModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoadingModel.swift; sourceTree = "<group>"; };
+		577A16EE2161E2CDEDFA48C0 /* GameControllerManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GameControllerManager.swift; sourceTree = "<group>"; };
 		57C7673988B39FB0BDEA8BE4 /* Date+IsoStringTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Date+IsoStringTests.swift"; sourceTree = "<group>"; };
+		5836EFACFA00594CE8F9F377 /* Experiment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Experiment.swift; sourceTree = "<group>"; };
+		583DED0D7CA8A26424C8364A /* InternalPresentation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InternalPresentation.swift; sourceTree = "<group>"; };
+		58BA95995DE57E811FD65C02 /* PaywallCacheLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaywallCacheLogicTests.swift; sourceTree = "<group>"; };
 		5997775A53005E224485B379 /* ConfirmedAssignmentResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConfirmedAssignmentResponse.swift; sourceTree = "<group>"; };
-		5C9C75A8DD2B4612C74C986B /* TriggerSessionManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TriggerSessionManagerTests.swift; sourceTree = "<group>"; };
-		5D6BFF0F26C146D7C443388F /* SuperwallEventObjc.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SuperwallEventObjc.swift; sourceTree = "<group>"; };
-		5E2F873BF32DB7D791C152C1 /* TriggerSessionTrigger.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TriggerSessionTrigger.swift; sourceTree = "<group>"; };
-		5E36C7A628CE395D4E118CDE /* UserInitiatedEvents.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserInitiatedEvents.swift; sourceTree = "<group>"; };
-		60A486DE7BE9D8DAE69BFF2E /* IdentityLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IdentityLogic.swift; sourceTree = "<group>"; };
+		59A767F107FB1FBBC2F22DB3 /* AppSessionManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppSessionManagerTests.swift; sourceTree = "<group>"; };
+		5A413B6FF46B130D90A428B4 /* ProductPurchaserLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductPurchaserLogic.swift; sourceTree = "<group>"; };
+		5C2E30544869C5469AA31832 /* FactoryProtocols.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FactoryProtocols.swift; sourceTree = "<group>"; };
+		5C57C1CCAF97244AE0DC953F /* PaywallManagerMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaywallManagerMock.swift; sourceTree = "<group>"; };
+		618BF4D10B7D87FAF8FB48CD /* ProductPurchaserSK1Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductPurchaserSK1Tests.swift; sourceTree = "<group>"; };
+		61DF3B7A43B6FFAEA3DD9BE9 /* ProductTrial.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductTrial.swift; sourceTree = "<group>"; };
 		62AC69B94A568B7E14A391A8 /* SWProductDiscount.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SWProductDiscount.swift; sourceTree = "<group>"; };
-		641CDF0D4256D135D4461FE8 /* PublicPresentation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PublicPresentation.swift; sourceTree = "<group>"; };
+		62EC6A60945A85646E1230C1 /* ThrowableDecodable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThrowableDecodable.swift; sourceTree = "<group>"; };
+		6397684C0676181147C32AFB /* PaywallState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaywallState.swift; sourceTree = "<group>"; };
+		63A8950F4F998DE6C9242A10 /* PaywallCacheLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaywallCacheLogic.swift; sourceTree = "<group>"; };
 		64293B1D6F648DE113908AE7 /* EventsRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventsRequest.swift; sourceTree = "<group>"; };
 		643A346628DA026FEA092C27 /* ButtonFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ButtonFactory.swift; sourceTree = "<group>"; };
+		646E6799FE4934BF76A06F34 /* TransactionManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransactionManager.swift; sourceTree = "<group>"; };
+		65E23B703C00044332FDEBE8 /* TrackTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrackTests.swift; sourceTree = "<group>"; };
+		65EDE0BAE33F351217CC8E2D /* TemplateLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TemplateLogicTests.swift; sourceTree = "<group>"; };
 		6627CEA22A8E0CFA9D0901AC /* SWPriceTemplateVariable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SWPriceTemplateVariable.swift; sourceTree = "<group>"; };
-		6842E9305150D3702AB48E2E /* Config.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Config.swift; sourceTree = "<group>"; };
-		6873BA70C13AB08F307AA972 /* DeviceHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeviceHelper.swift; sourceTree = "<group>"; };
-		68DE31534533BC89FFC85924 /* GameControllerEvent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GameControllerEvent.swift; sourceTree = "<group>"; };
-		692A22164EF856F75B39764C /* SessionEventsManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionEventsManager.swift; sourceTree = "<group>"; };
+		672776875A4286319C2F2D61 /* PaywallViewControllerCacheTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaywallViewControllerCacheTests.swift; sourceTree = "<group>"; };
+		67B05942B51DA5DE06C22C1C /* SessionEventsManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionEventsManager.swift; sourceTree = "<group>"; };
+		67C4FC41FEE0B47EA402D738 /* LocalizationConfig.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalizationConfig.swift; sourceTree = "<group>"; };
+		67D3D3EFDC1C529BB6306387 /* CheckNoPaywallAlreadyPresented.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CheckNoPaywallAlreadyPresented.swift; sourceTree = "<group>"; };
 		69A4D77D819DDB696834E1B7 /* UIViewController+AsyncPresent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIViewController+AsyncPresent.swift"; sourceTree = "<group>"; };
-		69D11EF72866A27D016C9140 /* ActivityIndicatorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActivityIndicatorView.swift; sourceTree = "<group>"; };
+		6A541560191B2FE1CC1D970C /* PriceFormatterProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PriceFormatterProvider.swift; sourceTree = "<group>"; };
+		6AB850ECCAF10AF0C1AF66F9 /* TransactionVerifierSK2.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransactionVerifierSK2.swift; sourceTree = "<group>"; };
 		6AFEF7CB116568A60805DF6F /* EventsQueue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventsQueue.swift; sourceTree = "<group>"; };
-		6B052A053B815537646DD70D /* ExpressionEvaluatorParams.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExpressionEvaluatorParams.swift; sourceTree = "<group>"; };
-		6B8D19C18FFC8A968902F554 /* TransactionPayment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransactionPayment.swift; sourceTree = "<group>"; };
+		6B9E9E16EBDA97E736968496 /* PaywallPresentationHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaywallPresentationHandler.swift; sourceTree = "<group>"; };
 		6BB7B88D5D474F9F3C366D6A /* SWProductPeriod.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SWProductPeriod.swift; sourceTree = "<group>"; };
+		6C9F31221C5E26E20514E0C1 /* InternalGetPaywall.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InternalGetPaywall.swift; sourceTree = "<group>"; };
+		6CFA5F684C1732D79CBA2C49 /* SK2StoreProductDiscount.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SK2StoreProductDiscount.swift; sourceTree = "<group>"; };
 		6D1887F247BF6F770122F257 /* StorageMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StorageMock.swift; sourceTree = "<group>"; };
+		6DB09C4AF80761DF4205C4C2 /* Logger.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Logger.swift; sourceTree = "<group>"; };
+		6EDC14C0D6958144679F149D /* DecodingError+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DecodingError+Extensions.swift"; sourceTree = "<group>"; };
 		70D2B0D671B1A1E665B7CCD8 /* UIViewController+AsyncDismiss.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIViewController+AsyncDismiss.swift"; sourceTree = "<group>"; };
-		719BEEC0C3F6E63F9542A153 /* RawResponseOperator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RawResponseOperator.swift; sourceTree = "<group>"; };
-		723B2E9D1C844BC39A9B6488 /* SessionEventsQueue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionEventsQueue.swift; sourceTree = "<group>"; };
-		7334CD5C8989BE285765BC3E /* PurchaseResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PurchaseResult.swift; sourceTree = "<group>"; };
+		70FC86C1189200C486627EAD /* ASN1Decoder+Unboxing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ASN1Decoder+Unboxing.swift"; sourceTree = "<group>"; };
+		719FE7C289CB0A621595A2A4 /* MockSkProduct.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockSkProduct.swift; sourceTree = "<group>"; };
+		71BCCF22958A702677FB66F5 /* TriggerSessionManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TriggerSessionManager.swift; sourceTree = "<group>"; };
+		7318EF33D7374DC5C8B4549D /* SuperwallDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SuperwallDelegate.swift; sourceTree = "<group>"; };
+		7397C5FD11E7A09B6AD39165 /* PresentationRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PresentationRequest.swift; sourceTree = "<group>"; };
+		73BE8AD685B39ACAB331109C /* PurchaseManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PurchaseManager.swift; sourceTree = "<group>"; };
 		74DFC04FC0F3498D1EBE4B6A /* UIApplication+ActiveWindow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIApplication+ActiveWindow.swift"; sourceTree = "<group>"; };
 		750CC308DD48F4CE615DFC89 /* UIDevice+ModelName.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIDevice+ModelName.swift"; sourceTree = "<group>"; };
-		754F0DDCB9D2D87A822F83C0 /* ConfigManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConfigManagerTests.swift; sourceTree = "<group>"; };
-		756A55836F8968D362303C55 /* SuperwallLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SuperwallLogicTests.swift; sourceTree = "<group>"; };
+		7553D295A9E169B45FAC1477 /* FreeTrialTemplate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FreeTrialTemplate.swift; sourceTree = "<group>"; };
+		7569A0893012A88442B7ED36 /* PaywallViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaywallViewController.swift; sourceTree = "<group>"; };
+		7588892D6DD1C4437CF507DE /* ASN1Serialization.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ASN1Serialization.swift; sourceTree = "<group>"; };
 		759D7C0FCB370EB4FC33F4E4 /* UIViewController+TopVc.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIViewController+TopVc.swift"; sourceTree = "<group>"; };
 		7611B89AB647CB1AB79CA912 /* RawExperiment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RawExperiment.swift; sourceTree = "<group>"; };
-		762D43B5A353A6871C058792 /* ConfigLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConfigLogic.swift; sourceTree = "<group>"; };
+		764012CF0C0972240A73E3CF /* TrackingParameters.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrackingParameters.swift; sourceTree = "<group>"; };
 		7647A0AE11D9C965368742C5 /* SWProductTemplateVariable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SWProductTemplateVariable.swift; sourceTree = "<group>"; };
-		767385007521EEE45C1F4D76 /* PaywallState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaywallState.swift; sourceTree = "<group>"; };
+		76A719AD2F4475F83DFC9575 /* TransactionErrorLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransactionErrorLogic.swift; sourceTree = "<group>"; };
 		76CE4D7606C896027C76520E /* SWDebugManagerLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SWDebugManagerLogic.swift; sourceTree = "<group>"; };
-		78868C8AC13F6AAE49391877 /* PaywallCacheLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaywallCacheLogic.swift; sourceTree = "<group>"; };
-		79144F89F4D8E24ADDC3EE92 /* InAppReceiptPayload.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InAppReceiptPayload.swift; sourceTree = "<group>"; };
+		77444F578076D619C97EA6BB /* PaywallPresentationRequestStatus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaywallPresentationRequestStatus.swift; sourceTree = "<group>"; };
+		775D6EC141DAE9BED8B732A7 /* TriggerSessionTransaction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TriggerSessionTransaction.swift; sourceTree = "<group>"; };
+		79D581A513C692B07DE5A38C /* ExpressionEvaluatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExpressionEvaluatorTests.swift; sourceTree = "<group>"; };
 		79E2143AD65D151AE7A4BF0F /* Network.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Network.swift; sourceTree = "<group>"; };
-		7AD581390E2944BCA2603D5B /* Trackable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Trackable.swift; sourceTree = "<group>"; };
+		7ACA213FA146D819AAFDB787 /* ProductPrice.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductPrice.swift; sourceTree = "<group>"; };
 		7B921746BEC8F63DDB65C634 /* LimitedQueue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LimitedQueue.swift; sourceTree = "<group>"; };
-		7E33BFE573CD9D7C0BA05F7B /* HiddenListener.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HiddenListener.swift; sourceTree = "<group>"; };
-		806911E8F01C4115843E2019 /* PushTransitionDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PushTransitionDelegate.swift; sourceTree = "<group>"; };
-		8121467D535878BE104DF9AF /* TrackableSuperwallEvent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrackableSuperwallEvent.swift; sourceTree = "<group>"; };
-		8258E9C6F333EB19A7695EB9 /* AssignmentLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssignmentLogic.swift; sourceTree = "<group>"; };
-		82D71435A6AFB8E6599B1B20 /* TransactionRecorderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransactionRecorderTests.swift; sourceTree = "<group>"; };
+		7F4EC7B3BCFACD602B9BFA41 /* InternalPresentationLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InternalPresentationLogicTests.swift; sourceTree = "<group>"; };
+		7FCE6A59348C9018F40D7AC5 /* LogScope.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LogScope.swift; sourceTree = "<group>"; };
+		80281364A23252E30DEEA1AA /* Foundation+ASN1Coder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Foundation+ASN1Coder.swift"; sourceTree = "<group>"; };
+		8087A8CD8F4FC7C745010428 /* ASN1Types.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ASN1Types.swift; sourceTree = "<group>"; };
+		8165DD71323903F7CF426D2C /* AppSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppSession.swift; sourceTree = "<group>"; };
+		81BE917F0AA7A7453B7D0BB2 /* AppSessionLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppSessionLogicTests.swift; sourceTree = "<group>"; };
+		81CB02D2E13C410C2600B506 /* ConfirmHoldoutAssignment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConfirmHoldoutAssignment.swift; sourceTree = "<group>"; };
+		81D80A7C5B8A17B83C218656 /* MapSwiftErrors.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MapSwiftErrors.swift; sourceTree = "<group>"; };
 		82E6981E6A6574EE72B65A9E /* Paywall.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Paywall.swift; sourceTree = "<group>"; };
-		83043016E578123D1E2D2C90 /* PushTransition.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PushTransition.swift; sourceTree = "<group>"; };
-		844207A4B6BC4A2A29FDCEF7 /* PresentPaywallOperator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PresentPaywallOperator.swift; sourceTree = "<group>"; };
+		83416F0F1B5294C350D5CF70 /* FeatureFlags.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeatureFlags.swift; sourceTree = "<group>"; };
+		83A6A722D119902A42DC2737 /* AddPaywallProducts.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddPaywallProducts.swift; sourceTree = "<group>"; };
+		83F3F6FCA1A755FC0A6CD8EC /* CheckUserSubscriptionOperatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CheckUserSubscriptionOperatorTests.swift; sourceTree = "<group>"; };
 		848592ACE8760E53F2163F01 /* Typealiases.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Typealiases.swift; sourceTree = "<group>"; };
+		852DB0D6CF864AE3433EF7F9 /* PresentationErrors.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PresentationErrors.swift; sourceTree = "<group>"; };
+		862888AB2869D09AA55A017D /* InAppReceiptPayloadContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InAppReceiptPayloadContainer.swift; sourceTree = "<group>"; };
 		865262BC55BAEA135E51698D /* CacheKeys.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CacheKeys.swift; sourceTree = "<group>"; };
-		884371CD0933DF20F13D7B6B /* PaywallMessage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaywallMessage.swift; sourceTree = "<group>"; };
+		866F99509EDFBE8BAE10E575 /* LoadingModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoadingModel.swift; sourceTree = "<group>"; };
+		88EBF6FC3090E004EE1377B4 /* PaywallViewControllerDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaywallViewControllerDelegate.swift; sourceTree = "<group>"; };
 		890C396C6DB6F419ED621BAA /* AssignmentPostback.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssignmentPostback.swift; sourceTree = "<group>"; };
-		8A3F246F74018E6AD4B82CBF /* GetPaywallVcOperator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetPaywallVcOperator.swift; sourceTree = "<group>"; };
-		8AD39245CEC3FF3EBD5EDE5C /* SuperwallEvent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SuperwallEvent.swift; sourceTree = "<group>"; };
-		8CE2D05376A82D2185955AFE /* PaywallCacheLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaywallCacheLogicTests.swift; sourceTree = "<group>"; };
+		8A7140A8B0B006F2080D8915 /* PaywallLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaywallLogicTests.swift; sourceTree = "<group>"; };
+		8BAEECE2DBFEB8817E6C36DA /* PaywallViewControllerCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaywallViewControllerCache.swift; sourceTree = "<group>"; };
+		8BDA9D233EACAB5090B0657D /* StorePresentationObjectsOperatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StorePresentationObjectsOperatorTests.swift; sourceTree = "<group>"; };
+		8D60F06C8685538A9486B97D /* SubscriptionPeriod.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubscriptionPeriod.swift; sourceTree = "<group>"; };
 		8DE36D141F461F6E945823FA /* Future+Async.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Future+Async.swift"; sourceTree = "<group>"; };
+		8E441343EAC43B2ECF35F929 /* SuperwallDelegateAdapter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SuperwallDelegateAdapter.swift; sourceTree = "<group>"; };
 		8E9E1A8F57B5DCA4CD16296F /* Dictionary+Keys.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Dictionary+Keys.swift"; sourceTree = "<group>"; };
-		9152116E6A842164DB3339DE /* ConvenienceFunctions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConvenienceFunctions.swift; sourceTree = "<group>"; };
-		91B2F0F10B6207B5092AC539 /* MockSKPaymentTransaction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockSKPaymentTransaction.swift; sourceTree = "<group>"; };
+		8FC7F8602B38644BCCDAD159 /* ConfirmPaywallAssignmentOperatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConfirmPaywallAssignmentOperatorTests.swift; sourceTree = "<group>"; };
+		8FDBBFC2D8F670CE2DC91889 /* StoreTransaction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreTransaction.swift; sourceTree = "<group>"; };
+		90B1A5AC3B7C3000274C782E /* StoreTransactionType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreTransactionType.swift; sourceTree = "<group>"; };
+		910786130E2D7EDE2ED5452D /* StoreKitManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreKitManager.swift; sourceTree = "<group>"; };
 		92001AC11F099F7B03AF338A /* SuperwallKitTests.xctest */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.cfbundle; path = SuperwallKitTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
-		9269654937F069D15D5112CE /* TransactionManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransactionManager.swift; sourceTree = "<group>"; };
+		92A6B82F855E19B9C180C659 /* ConfigManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConfigManagerTests.swift; sourceTree = "<group>"; };
 		938EB5121B1D9EA6B2EAE9EC /* Task+Retrying.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Task+Retrying.swift"; sourceTree = "<group>"; };
-		983AC5AC5E0DAF2B2938E45D /* StoreKitManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreKitManager.swift; sourceTree = "<group>"; };
-		985210E1D07FB0EC67510B32 /* SpringAnimation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpringAnimation.swift; sourceTree = "<group>"; };
-		999EAA9CED33866246D75177 /* AwaitIdentityOperator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AwaitIdentityOperator.swift; sourceTree = "<group>"; };
-		9AD77244B0329A08D176B56B /* Model.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = Model.xcdatamodel; sourceTree = "<group>"; };
-		9B3F1C3A01E3C951974667D7 /* BottomPaddingAnimation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BottomPaddingAnimation.swift; sourceTree = "<group>"; };
-		9B7237D632C045D7FD585EC4 /* Sk1TransactionObserver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sk1TransactionObserver.swift; sourceTree = "<group>"; };
-		9B7D272921BDC60D44BA5FCB /* AssignmentLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssignmentLogicTests.swift; sourceTree = "<group>"; };
-		9DB8450EB537722D79EB8194 /* ProductsManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductsManager.swift; sourceTree = "<group>"; };
-		9DE5293C9C76FBE2A418AE67 /* PresentationInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PresentationInfo.swift; sourceTree = "<group>"; };
-		9F25D59E046C6483853DDE7D /* PaywallOverrides.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaywallOverrides.swift; sourceTree = "<group>"; };
-		A2AB593578F0AB2F11158D5A /* AppSessionLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppSessionLogicTests.swift; sourceTree = "<group>"; };
-		A2B726AD765B53DCC82C1E65 /* InAppReceiptPayloadContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InAppReceiptPayloadContainer.swift; sourceTree = "<group>"; };
-		A33CBBAB5601194ABD7FB8EE /* DeviceTemplate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeviceTemplate.swift; sourceTree = "<group>"; };
+		94125DB9AC8A2EA66F983EDA /* PresentationResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PresentationResult.swift; sourceTree = "<group>"; };
+		943CA7F8AE219A07C1245232 /* GetPaywallVcOperatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetPaywallVcOperatorTests.swift; sourceTree = "<group>"; };
+		95B831FECAFDDEC7B65A260D /* ExpressionEvaluatorLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExpressionEvaluatorLogicTests.swift; sourceTree = "<group>"; };
+		95ED8690E8B88125776BC247 /* TrackingLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrackingLogic.swift; sourceTree = "<group>"; };
+		97A579F56E5CEF54DB9E9B62 /* DarkBlurredBackground.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DarkBlurredBackground.swift; sourceTree = "<group>"; };
+		97D7F499B2CBFFF0A61F8D72 /* ConfigLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConfigLogicTests.swift; sourceTree = "<group>"; };
+		98D3CEEDCBBDB85C54FDC128 /* PresentPaywall.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PresentPaywall.swift; sourceTree = "<group>"; };
+		990461F7A9B2F3ED62B3A628 /* PaywallViewControllerDelegateAdapter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaywallViewControllerDelegateAdapter.swift; sourceTree = "<group>"; };
+		991415992A1EA3C9E6DB7D25 /* TriggerSessionTrigger.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TriggerSessionTrigger.swift; sourceTree = "<group>"; };
+		9B75209DF76859131941CA0F /* Variables.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Variables.swift; sourceTree = "<group>"; };
+		9C2580C3CD6A8BF0C5258665 /* SWWebView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SWWebView.swift; sourceTree = "<group>"; };
+		9DC4D23D1EDDA249C928930D /* PaddingListener.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaddingListener.swift; sourceTree = "<group>"; };
+		9E1EFE389B54C304F2B01620 /* DeviceInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeviceInfo.swift; sourceTree = "<group>"; };
+		9E80C81546752BCF32016A27 /* InAppReceipt+ASN1.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "InAppReceipt+ASN1.swift"; sourceTree = "<group>"; };
+		9F6E6855FC2A6D10054EAE33 /* StorePayment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StorePayment.swift; sourceTree = "<group>"; };
+		9F72210F85864F3000F13646 /* ASN1Coder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ASN1Coder.swift; sourceTree = "<group>"; };
+		A00C04BE1449BE21E13B61A0 /* LoggerMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoggerMock.swift; sourceTree = "<group>"; };
 		A3F4F74393061C17CEB18F90 /* ManagedEventData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ManagedEventData.swift; sourceTree = "<group>"; };
 		A40D9BA2449503F4B7F5B7A6 /* Array+Guarded.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Array+Guarded.swift"; sourceTree = "<group>"; };
-		A42411E84D1A21D73D0BDA0E /* Publisher+Async.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Publisher+Async.swift"; sourceTree = "<group>"; };
-		A511EA01417DE3299BCD363B /* TriggerOutcomeOperator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TriggerOutcomeOperator.swift; sourceTree = "<group>"; };
-		A584F8FE6F1C4B3ACC0AFACC /* PaywallDismissedResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaywallDismissedResult.swift; sourceTree = "<group>"; };
-		A981B0C90E5F0E40187C0310 /* IdentityError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IdentityError.swift; sourceTree = "<group>"; };
+		A4493EE88B00CADF85EF1196 /* PublicIdentity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PublicIdentity.swift; sourceTree = "<group>"; };
+		A453816DBA43C08410D12DE6 /* PaywallViewControllerMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaywallViewControllerMock.swift; sourceTree = "<group>"; };
+		A454A48473801779E36C9709 /* TransactionProduct.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransactionProduct.swift; sourceTree = "<group>"; };
+		A50760583D3E3E87C83B75F0 /* SK1StoreTransaction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SK1StoreTransaction.swift; sourceTree = "<group>"; };
+		A5110E43405C69969E9DA67B /* PublicGetPaywall.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PublicGetPaywall.swift; sourceTree = "<group>"; };
+		A5C4AD6349F2D432132F36D5 /* MockSubscriptionPeriod.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockSubscriptionPeriod.swift; sourceTree = "<group>"; };
+		A829C96661335814CCF85BE3 /* StoreKitCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreKitCoordinator.swift; sourceTree = "<group>"; };
+		A94120D51C7B36AC9EA32B8B /* LoadingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoadingView.swift; sourceTree = "<group>"; };
+		A96A65416DB25FF601BB68F2 /* PurchaseController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PurchaseController.swift; sourceTree = "<group>"; };
+		A9904A3538DF80EA8EEC2687 /* PaywallOverrides.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaywallOverrides.swift; sourceTree = "<group>"; };
 		A9A3C997FDC1550AF477CA1D /* Decimal+Rounding.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Decimal+Rounding.swift"; sourceTree = "<group>"; };
-		AB7DA08E93F886E54733004B /* LoadingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoadingView.swift; sourceTree = "<group>"; };
-		AB817B50385C1C04C49E277B /* PresentationRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PresentationRequest.swift; sourceTree = "<group>"; };
+		AA3C3F42E928987B92F35B96 /* CheckDebuggerPresentation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CheckDebuggerPresentation.swift; sourceTree = "<group>"; };
+		AB3F04AC933701EE33F5F325 /* IdentityLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IdentityLogic.swift; sourceTree = "<group>"; };
+		AB6E84EBB6257BAA57F74229 /* Sk1StoreProduct.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sk1StoreProduct.swift; sourceTree = "<group>"; };
 		ABC1253C6D5DD8D967BE05D1 /* LocalizationGrouping.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalizationGrouping.swift; sourceTree = "<group>"; };
-		AE90F82958684A445132862C /* InternalPresentationLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InternalPresentationLogic.swift; sourceTree = "<group>"; };
-		AF09F3137AD182B8B4AF8BFC /* TrackingLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrackingLogicTests.swift; sourceTree = "<group>"; };
-		B0240B2878A43A1164D2F2D6 /* TriggerSessionManagerLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TriggerSessionManagerLogic.swift; sourceTree = "<group>"; };
-		B2A05D7D4EDEB7F2F5FD8997 /* SuperwallGraveyard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SuperwallGraveyard.swift; sourceTree = "<group>"; };
+		AC74F16DC5A17489E97061EA /* PushTransitionLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PushTransitionLogic.swift; sourceTree = "<group>"; };
+		AE32816F1CA1637897AC87A2 /* UNUserNotificationCenter+SuperwallNotifications.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UNUserNotificationCenter+SuperwallNotifications.swift"; sourceTree = "<group>"; };
+		AE406AAED11F2B63E4A5A1FD /* UserInitiatedEvents.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserInitiatedEvents.swift; sourceTree = "<group>"; };
+		AF0A461D50AF945239D3D048 /* InAppPurchase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InAppPurchase.swift; sourceTree = "<group>"; };
+		AF5A8FFFC23826AD113D525A /* Publisher+Async.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Publisher+Async.swift"; sourceTree = "<group>"; };
+		AFA4E94285A5E9430D48CB14 /* StoreProductDiscountType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreProductDiscountType.swift; sourceTree = "<group>"; };
+		B14E186AB8E440B5F4E8FE86 /* ProductPurchaserSK1.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductPurchaserSK1.swift; sourceTree = "<group>"; };
+		B1A112ABEB40964EDA5B5B21 /* AppleIncRootCertificate.cer */ = {isa = PBXFileReference; path = AppleIncRootCertificate.cer; sourceTree = "<group>"; };
+		B1A64CCBCB23CC1715DF79AC /* PaywallOptions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaywallOptions.swift; sourceTree = "<group>"; };
+		B1DF64C51FA26B40D8D7B880 /* ScaleAnimation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScaleAnimation.swift; sourceTree = "<group>"; };
+		B23E9FB48867BAE49688784F /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		B27F0D55EF3480E2B65C8DFD /* HandleTriggerResultOperatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HandleTriggerResultOperatorTests.swift; sourceTree = "<group>"; };
+		B2AFFA0F0D2BCDFEC8BEC856 /* RestorationResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RestorationResult.swift; sourceTree = "<group>"; };
 		B2E6016BF483A4C47FF7A7C0 /* Encodable+Dictionary.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Encodable+Dictionary.swift"; sourceTree = "<group>"; };
 		B37D3D1DE18F6748B9E8963C /* CustomURLSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomURLSession.swift; sourceTree = "<group>"; };
 		B40D6FA6547CB5B9520B0B64 /* SessionEventsRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionEventsRequest.swift; sourceTree = "<group>"; };
-		B4FF025AF2EC66D8312999A4 /* GameControllerManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GameControllerManager.swift; sourceTree = "<group>"; };
-		B57F9BE50ABBC04A7E4A1B4E /* TriggerSessionProduct.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TriggerSessionProduct.swift; sourceTree = "<group>"; };
+		B45A6006E4299E75E91CC2ED /* PaywallMessageHandlerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaywallMessageHandlerTests.swift; sourceTree = "<group>"; };
+		B52A0EFBBFE9D2F949EA4C28 /* UserAttributes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserAttributes.swift; sourceTree = "<group>"; };
+		B5637C2D7DDA38C11E48DD1C /* RawPaywallResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RawPaywallResponse.swift; sourceTree = "<group>"; };
+		B634347011742D475E3F1A27 /* ConfigLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConfigLogic.swift; sourceTree = "<group>"; };
 		B6F71D7A7DC8FFB72CA13296 /* PaywallRequestBody.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaywallRequestBody.swift; sourceTree = "<group>"; };
-		B80E862E0AF5DCEC8142696A /* TrackingParameters.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrackingParameters.swift; sourceTree = "<group>"; };
-		B81601941E6DCEEEC38A2868 /* Tracking.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Tracking.swift; sourceTree = "<group>"; };
 		B88E86C67F934540D846B8BA /* EmptyResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmptyResponse.swift; sourceTree = "<group>"; };
-		B979A4EBDBD32C0985FD74DC /* LogPresentationOperator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LogPresentationOperator.swift; sourceTree = "<group>"; };
-		BA296F4FCD50E811939A9B9D /* InternalPresentation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InternalPresentation.swift; sourceTree = "<group>"; };
+		B9553EC1E394EF7AE8788291 /* InAppReceiptAttribute.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InAppReceiptAttribute.swift; sourceTree = "<group>"; };
+		BA46295F06642C4306BEA957 /* TriggerSessionManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TriggerSessionManagerTests.swift; sourceTree = "<group>"; };
 		BA9100DDAD2E8596F96A1BCB /* Assignment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Assignment.swift; sourceTree = "<group>"; };
-		BBD023FB713C2A223849B1EF /* DebuggerCheckerOperator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DebuggerCheckerOperator.swift; sourceTree = "<group>"; };
-		BBDE3A7712EC4EF8592A53FB /* SessionEventsDelegateMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionEventsDelegateMock.swift; sourceTree = "<group>"; };
+		BACAA655F72F3CE9B71C2C46 /* TriggerSessionManagerLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TriggerSessionManagerLogic.swift; sourceTree = "<group>"; };
+		BB242DC77FEC0BE10C0DDC9C /* DeviceHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeviceHelper.swift; sourceTree = "<group>"; };
 		BC8730F0D05BFDFA12AA6309 /* ProductVariable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductVariable.swift; sourceTree = "<group>"; };
-		BD7E6196C1445FABD2BA1833 /* PaywallWebEvent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaywallWebEvent.swift; sourceTree = "<group>"; };
-		BE7292248877A0CD370259B8 /* ProductPeriod.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductPeriod.swift; sourceTree = "<group>"; };
-		BF03C89BD8E474D8F539C181 /* PaywallSkippedReason.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaywallSkippedReason.swift; sourceTree = "<group>"; };
+		BD6BA222CB2EAA4B65F362C5 /* ProductsFetcherSK1.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductsFetcherSK1.swift; sourceTree = "<group>"; };
+		BD8751EBBA905FB4F7E3C0BC /* StoreProduct.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreProduct.swift; sourceTree = "<group>"; };
 		BF091A5565631C9F426F304B /* LocalizationManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalizationManager.swift; sourceTree = "<group>"; };
+		BF61DCA9CF170E0AFC507BAE /* PaywallMessageHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaywallMessageHandler.swift; sourceTree = "<group>"; };
+		BFE42FD8C7F01915D74D0008 /* Trackable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Trackable.swift; sourceTree = "<group>"; };
+		BFEECDF884EDFE6FF1D0E0C3 /* GetPaywallVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetPaywallVC.swift; sourceTree = "<group>"; };
 		C054891709C534F59C93C815 /* URLSessionRetryLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLSessionRetryLogicTests.swift; sourceTree = "<group>"; };
-		C0F807DE042D48EB3DCB59F0 /* PaywallViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaywallViewController.swift; sourceTree = "<group>"; };
-		C22CA9431D5F791BE7A9BE27 /* Documentation.docc */ = {isa = PBXFileReference; lastKnownFileType = folder.documentationcatalog; path = Documentation.docc; sourceTree = "<group>"; };
-		C28014EF3A8BF357F2E71FC1 /* PaywallInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaywallInfo.swift; sourceTree = "<group>"; };
-		C649C8B193A114A5BDAF49C0 /* AppSessionLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppSessionLogic.swift; sourceTree = "<group>"; };
-		C6E8278A89BA67AE4FF032DB /* PaywallLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaywallLogic.swift; sourceTree = "<group>"; };
+		C0A53CC571B7BC3F5AAD71BF /* ReceiptLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReceiptLogic.swift; sourceTree = "<group>"; };
+		C1B7E4FC6B4AAEA58D95A052 /* ExpressionEvaluatorParams.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExpressionEvaluatorParams.swift; sourceTree = "<group>"; };
+		C1D09FBCB364D8316C4A8C69 /* GetPresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetPresenter.swift; sourceTree = "<group>"; };
+		C22CA9431D5F791BE7A9BE27 /* Documentation.docc */ = {isa = PBXFileReference; path = Documentation.docc; sourceTree = "<group>"; };
+		C2300AFFC31667E749E85EAC /* TrackingLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrackingLogicTests.swift; sourceTree = "<group>"; };
+		C2AF370C9EDF3C7A4605D385 /* Date+IsoString.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Date+IsoString.swift"; sourceTree = "<group>"; };
+		C2E541F079BC78206BC44D6E /* TemplateLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TemplateLogic.swift; sourceTree = "<group>"; };
+		C36308E59620C724F701B803 /* PaywallCloseReason.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaywallCloseReason.swift; sourceTree = "<group>"; };
+		C601D23DAA4F0CE7078FD77F /* SessionEventsDelegateMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionEventsDelegateMock.swift; sourceTree = "<group>"; };
+		C733A9BE56EA9E10D75B073B /* SWDebugManagerLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SWDebugManagerLogicTests.swift; sourceTree = "<group>"; };
 		C7867A3C9B173BC2D6000937 /* TaskRetryLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaskRetryLogic.swift; sourceTree = "<group>"; };
 		C7FFF0EDFF6DA910E4B5CCB7 /* LocalizationOption.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalizationOption.swift; sourceTree = "<group>"; };
 		C855DE8F5341D67C614E3AF5 /* Array+SafeRemove.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Array+SafeRemove.swift"; sourceTree = "<group>"; };
-		C8AA3BB9F834B8758CB45DD2 /* IdentityManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IdentityManager.swift; sourceTree = "<group>"; };
-		C8F55CC8D621E7013FAEF4C0 /* ProductPrice.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductPrice.swift; sourceTree = "<group>"; };
-		CB338C3E2FCD47EA52FD133E /* SuperwallOptions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SuperwallOptions.swift; sourceTree = "<group>"; };
-		CB95FC8B25A0F7F539D4AF92 /* Date+IsoString.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Date+IsoString.swift"; sourceTree = "<group>"; };
+		C9B0C261DCC1ED74DD2BF3EA /* HiddenListener.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HiddenListener.swift; sourceTree = "<group>"; };
+		CC171FFE5F68BD457364481A /* RestorationManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RestorationManager.swift; sourceTree = "<group>"; };
+		CC653A44D9B40812BDDD94E7 /* PaywallMessage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaywallMessage.swift; sourceTree = "<group>"; };
+		CC89718EBDD71E09AB5F41DA /* AppSessionManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppSessionManager.swift; sourceTree = "<group>"; };
 		CCFFBE357699F5CAAB803DA7 /* ManagedTriggerRuleOccurrence.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ManagedTriggerRuleOccurrence.swift; sourceTree = "<group>"; };
-		CDD938341ED4745A6206D944 /* ExpressionEvaluatorLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExpressionEvaluatorLogic.swift; sourceTree = "<group>"; };
-		CE6B12B5C4B4EAC0CD08F50F /* ExpressionEvaluatorLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExpressionEvaluatorLogicTests.swift; sourceTree = "<group>"; };
-		CF78EA507375E36880AB33AB /* InternalPresentationLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InternalPresentationLogicTests.swift; sourceTree = "<group>"; };
-		D127BF1A2362FBB81E2C7B52 /* ExpressionEvaluatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExpressionEvaluatorTests.swift; sourceTree = "<group>"; };
+		CD69396B509844FFA8452452 /* SubscriptionStatus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubscriptionStatus.swift; sourceTree = "<group>"; };
+		CD9298A79020030E9A1357A6 /* API.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = API.swift; sourceTree = "<group>"; };
+		CFDA311A030FDFC45AEE248A /* SuperwallOptions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SuperwallOptions.swift; sourceTree = "<group>"; };
+		D07ACB41E733B6CF8EA722E0 /* ASN1Decoder+Extras.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ASN1Decoder+Extras.swift"; sourceTree = "<group>"; };
+		D123D95036ED6CE3B097BBF0 /* ShimmerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShimmerView.swift; sourceTree = "<group>"; };
+		D31BB6D0C57337C6E929D617 /* ASN1Decoder+UnkeyedDecodingContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ASN1Decoder+UnkeyedDecodingContainer.swift"; sourceTree = "<group>"; };
 		D3506FCC35155DF104A1DFCA /* CustomURLSessionMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomURLSessionMock.swift; sourceTree = "<group>"; };
+		D36898353ABCE620BA7AEE59 /* SuperwallGraveyard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SuperwallGraveyard.swift; sourceTree = "<group>"; };
 		D38D3A69A26709BFB52C6A3A /* Product.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Product.swift; sourceTree = "<group>"; };
+		D3E5C31CEEDC9C2853D91C50 /* DeviceTemplate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeviceTemplate.swift; sourceTree = "<group>"; };
+		D4268B8B324D767409873B4C /* CoordinatorProtocols.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoordinatorProtocols.swift; sourceTree = "<group>"; };
 		D449672964023589DA5535E3 /* String+MD5.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+MD5.swift"; sourceTree = "<group>"; };
-		D4D811522FFC29BB16F367FF /* TransactionErrorLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransactionErrorLogic.swift; sourceTree = "<group>"; };
-		D636EDD4E9ABEE40510C1BD5 /* HandleTriggerOutcomeOperator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HandleTriggerOutcomeOperator.swift; sourceTree = "<group>"; };
-		D78D73D3C35F8A910272BD4A /* ReceiptManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReceiptManagerTests.swift; sourceTree = "<group>"; };
+		D4F676D3A0F5B540052D36B1 /* PublicGetPresentationResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PublicGetPresentationResult.swift; sourceTree = "<group>"; };
+		D5BF66C3986E287B7B2F5E27 /* SKProductSubscriptionPeriodMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SKProductSubscriptionPeriodMock.swift; sourceTree = "<group>"; };
+		D6E787EFC5201B68C3631FE8 /* CheckSubscriptionStatus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CheckSubscriptionStatus.swift; sourceTree = "<group>"; };
+		D7974C3C7E0B54A24784E5C3 /* LogErrors.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LogErrors.swift; sourceTree = "<group>"; };
 		D86D76FB5809C3B8122778A9 /* EventData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventData.swift; sourceTree = "<group>"; };
-		D95F38041B9935272D2D87C2 /* ProductsManagerMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductsManagerMock.swift; sourceTree = "<group>"; };
-		D980856238D5C86BCA6EBBEE /* ProductTrial.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductTrial.swift; sourceTree = "<group>"; };
+		DA1F5AFA28F20FAE4D0AA3B5 /* LocalNotification.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalNotification.swift; sourceTree = "<group>"; };
+		DAAE50F011668C1D62B86751 /* ConfigManagerMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConfigManagerMock.swift; sourceTree = "<group>"; };
+		DAF94D451CB6346AE3C5863B /* ASN1Decoder+KeyedDecodingContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ASN1Decoder+KeyedDecodingContainer.swift"; sourceTree = "<group>"; };
+		DB518DC9EFF0FE0C3A022982 /* String+RFC339.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+RFC339.swift"; sourceTree = "<group>"; };
 		DEFDA9310B29A0C918D7A292 /* EventsResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventsResponse.swift; sourceTree = "<group>"; };
-		E03E830ADACA9E5D41E5CFC4 /* MockSessionEventsQueue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockSessionEventsQueue.swift; sourceTree = "<group>"; };
-		E1FFFB20CA2231FC607BE44A /* PresentationPipelineError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PresentationPipelineError.swift; sourceTree = "<group>"; };
+		DFE7B1045C0541E66A965FC1 /* IARError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IARError.swift; sourceTree = "<group>"; };
 		E2243C6BF6BE477794F568ED /* GCControllerElement+buttonName.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "GCControllerElement+buttonName.swift"; sourceTree = "<group>"; };
+		E23F2FE294EBC63F81786A85 /* PresentationItems.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PresentationItems.swift; sourceTree = "<group>"; };
+		E2CB827497BCEBDF9E1E2707 /* SK2StoreProduct.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SK2StoreProduct.swift; sourceTree = "<group>"; };
+		E35ABB03CA31D2C187A9D052 /* GetExperiment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetExperiment.swift; sourceTree = "<group>"; };
 		E3BFF03C1812D7239003448A /* Stubbable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Stubbable.swift; sourceTree = "<group>"; };
+		E4A5468741F21E02115E2C61 /* ProductPeriod.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductPeriod.swift; sourceTree = "<group>"; };
+		E51D0B38180377D9CD3E65DA /* Date+TimeIntervalMilliseconds.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Date+TimeIntervalMilliseconds.swift"; sourceTree = "<group>"; };
 		E5A461C7228BE71FF8695236 /* SDKJS.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SDKJS.swift; sourceTree = "<group>"; };
-		E603038126BB50A2AAE1C4D0 /* SwiftUIGraveyard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwiftUIGraveyard.swift; sourceTree = "<group>"; };
-		E709EA62F0785E7025CC3C05 /* ShimmerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShimmerView.swift; sourceTree = "<group>"; };
 		E74C7DE0FAFE0C01F374DDF0 /* CoreDataManagerFakeDataMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoreDataManagerFakeDataMock.swift; sourceTree = "<group>"; };
-		EA1DF58EB09E500977460E0E /* SuperwallDelegateAdapter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SuperwallDelegateAdapter.swift; sourceTree = "<group>"; };
-		EB04E29E0B87E29156C9C246 /* InAppPurchase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InAppPurchase.swift; sourceTree = "<group>"; };
+		E815C43EB5A02E48B618DD9F /* CheckDebuggerPresentationOperatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CheckDebuggerPresentationOperatorTests.swift; sourceTree = "<group>"; };
 		EB1B228FB279EA92C35C7394 /* CoreDataManagerMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoreDataManagerMock.swift; sourceTree = "<group>"; };
-		EC841969BFFEF512F254A8AB /* Variables.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Variables.swift; sourceTree = "<group>"; };
-		EE253DB1E7B6723EC24216CE /* MockReceiptData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockReceiptData.swift; sourceTree = "<group>"; };
+		EBFB0A38F634286F61572C51 /* ActivityIndicatorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActivityIndicatorView.swift; sourceTree = "<group>"; };
+		EC91544C3B7D209A8D51397F /* RawWebMessageHandlerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RawWebMessageHandlerTests.swift; sourceTree = "<group>"; };
+		ECEF5CE080936CBEDE201F13 /* PaywallConfig.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaywallConfig.swift; sourceTree = "<group>"; };
+		EE1E7DA9C8816082FA05B84D /* PushTransition.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PushTransition.swift; sourceTree = "<group>"; };
+		EEA21AF7F6C5FB0EC83E4E1A /* PresentPaywallOperatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PresentPaywallOperatorTests.swift; sourceTree = "<group>"; };
 		EEE0510BC2F7917AA57B896D /* AlertControllerFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlertControllerFactory.swift; sourceTree = "<group>"; };
-		EFACE6CE4DAE20FB9863302E /* SWWebView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SWWebView.swift; sourceTree = "<group>"; };
-		EFBFA0E9940718D6F8B28EE5 /* ReceiptLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReceiptLogic.swift; sourceTree = "<group>"; };
-		F07DED9EBBD92558DD3ABAD9 /* AppSessionManagerMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppSessionManagerMock.swift; sourceTree = "<group>"; };
+		EF3D82A1AC66E94746295419 /* TriggerSessionPaywall.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TriggerSessionPaywall.swift; sourceTree = "<group>"; };
 		F16AFE9C93A441CFB6A95F10 /* String+CamelCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+CamelCase.swift"; sourceTree = "<group>"; };
 		F2A2A54314BAEAF65B46D322 /* NetworkTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkTests.swift; sourceTree = "<group>"; };
-		F2FDD78DE945EE7B82EAB274 /* InAppReceiptAttribute.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InAppReceiptAttribute.swift; sourceTree = "<group>"; };
+		F34468E3988E779132CE101A /* BundleHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BundleHelper.swift; sourceTree = "<group>"; };
+		F49804DCB74FEEFA0D3438A9 /* ASN1Decoder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ASN1Decoder.swift; sourceTree = "<group>"; };
 		F4B35EF62D8C986B504B052C /* NSManagedObjectContext+mergeChanges.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSManagedObjectContext+mergeChanges.swift"; sourceTree = "<group>"; };
-		F551F1C92516FEB24A107A94 /* PaywallGraveyard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaywallGraveyard.swift; sourceTree = "<group>"; };
+		F4D74B23A58D934512BE8470 /* TriggerSessionProducts.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TriggerSessionProducts.swift; sourceTree = "<group>"; };
+		F57F454704875FFFC5CE1827 /* InternalGetPresentationResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InternalGetPresentationResult.swift; sourceTree = "<group>"; };
+		F63599D252F44CF417D79AF3 /* SessionEventsQueue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionEventsQueue.swift; sourceTree = "<group>"; };
 		F636156244B674A56ADC461C /* UIView+SpringAnimation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIView+SpringAnimation.swift"; sourceTree = "<group>"; };
-		F678F0A727A6D50A073DE6FE /* PaywallCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaywallCache.swift; sourceTree = "<group>"; };
-		F787CE1E5BC1B7FAD479F0DC /* MockIntroductoryPeriod.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockIntroductoryPeriod.swift; sourceTree = "<group>"; };
-		F8FA16E10142CB82A233C7F2 /* LoadingViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoadingViewController.swift; sourceTree = "<group>"; };
-		F90E6FDCEF2889C5068A80D4 /* PaywallMessageHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaywallMessageHandler.swift; sourceTree = "<group>"; };
-		F915C5C4DDA15706C36E58C4 /* APIs.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIs.swift; sourceTree = "<group>"; };
-		F982A447662FAA74CAA606A2 /* Publisher+HasRetrieved.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Publisher+HasRetrieved.swift"; sourceTree = "<group>"; };
-		FAA2D928566A5D0A3D436865 /* TriggerSessionManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TriggerSessionManager.swift; sourceTree = "<group>"; };
+		F798D9662212AD1CC75666F3 /* PaywallMessageHandlerDelegateMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaywallMessageHandlerDelegateMock.swift; sourceTree = "<group>"; };
+		F85ED994DEC92BB90ACC6AC2 /* TrackingResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrackingResult.swift; sourceTree = "<group>"; };
+		F9098101E599AEB01521FE89 /* DebugViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DebugViewController.swift; sourceTree = "<group>"; };
+		F98F66F7AA2F9F3E96849D8A /* Config.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Config.swift; sourceTree = "<group>"; };
+		FA3A82C80F89023672D56AD7 /* LogLevel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LogLevel.swift; sourceTree = "<group>"; };
 		FBE7D1E1AF61D199E17B5C05 /* SWLocalizationViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SWLocalizationViewController.swift; sourceTree = "<group>"; };
-		FCFEE6F37BE497DF44642308 /* SKProduct+Helpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SKProduct+Helpers.swift"; sourceTree = "<group>"; };
+		FC6C4D551369C55D8AFB7F96 /* PaywallLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaywallLogic.swift; sourceTree = "<group>"; };
 		FD778E66506BA51BEB5EE89C /* JSONEncoder+Superwall.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "JSONEncoder+Superwall.swift"; sourceTree = "<group>"; };
-		FD9DCF41F38A46DEDB3AD663 /* Sk2TransactionObserver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sk2TransactionObserver.swift; sourceTree = "<group>"; };
-		FDBE29280BE3AE1C147CD39B /* Publisher+AsyncMap.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Publisher+AsyncMap.swift"; sourceTree = "<group>"; };
 		FE0E783785F917188D12F4B4 /* Utils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Utils.swift; sourceTree = "<group>"; };
+		FFCF5B904164BFB6A8C87BAB /* SuperwallEventObjc.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SuperwallEventObjc.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -606,6 +788,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				28FED9AE68193B568FF887E1 /* ASN1Swift in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -614,25 +797,26 @@
 			buildActionMask = 2147483647;
 			files = (
 				3002A50E92B640B4E3A98662 /* SuperwallKit.framework in Frameworks */,
+				37344F5E62F926D676C51D89 /* ASN1Swift in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
-		05146FC7F9E6578390A94CEA /* Graveyard */ = {
+		052F4F31AEADDB2A94B69EE4 /* Abstractions */ = {
 			isa = PBXGroup;
 			children = (
-				F551F1C92516FEB24A107A94 /* PaywallGraveyard.swift */,
-				B2A05D7D4EDEB7F2F5FD8997 /* SuperwallGraveyard.swift */,
-				E603038126BB50A2AAE1C4D0 /* SwiftUIGraveyard.swift */,
+				A442CC58DCB40217A6761E25 /* StoreProduct */,
+				1AB11D29B8854084126B7CBC /* StoreTransaction */,
 			);
-			path = Graveyard;
+			path = Abstractions;
 			sourceTree = "<group>";
 		};
 		068A223BBB54F9127201504F /* Paywall */ = {
 			isa = PBXGroup;
 			children = (
+				DA1F5AFA28F20FAE4D0AA3B5 /* LocalNotification.swift */,
 				82E6981E6A6574EE72B65A9E /* Paywall.swift */,
 				153C660FB51D0D1DFE56D462 /* PaywallPresentationStyle.swift */,
 				0C95DABA23C6CBEF0AAA63C0 /* PaywallProducts.swift */,
@@ -660,29 +844,43 @@
 			path = "Custom URL Session";
 			sourceTree = "<group>";
 		};
-		08CABCF338B020423646F640 /* Debug */ = {
+		0E9A13ACB22951C865722510 /* Receipt Manager */ = {
 			isa = PBXGroup;
 			children = (
-				173CADA540CA40A87FAA054C /* SWDebugManagerLogicTests.swift */,
+				39B81D88316F06C0C2757F10 /* MockReceiptData.swift */,
+				03471273DF4C875227102BE2 /* ReceiptManagerTests.swift */,
 			);
-			path = Debug;
+			path = "Receipt Manager";
 			sourceTree = "<group>";
 		};
-		09A2371C68A9C9222BF77BFE /* Paywall Response */ = {
+		0F66E51FB152C87F796F9466 /* Expression Evaluator */ = {
 			isa = PBXGroup;
 			children = (
-				0514001D70634D4DA82B83F7 /* PaywallLogicTests.swift */,
-				96E795B4136F24FB368B5914 /* Mocks */,
+				95B831FECAFDDEC7B65A260D /* ExpressionEvaluatorLogicTests.swift */,
+				79D581A513C692B07DE5A38C /* ExpressionEvaluatorTests.swift */,
 			);
-			path = "Paywall Response";
+			path = "Expression Evaluator";
 			sourceTree = "<group>";
 		};
-		0E727785AE8CA0D9DF5ECF55 /* Events */ = {
+		0FCC395C1553C4B0C3A69E1A /* StoreKit */ = {
 			isa = PBXGroup;
 			children = (
-				CAD5EB9046BC41F6685C38A1 /* Internal Tracking */,
+				054FCADFEF560A1A736DEFE4 /* StoreKitManagerTests.swift */,
+				C0D3F44546D33F8AA71A79B9 /* Mocks */,
+				2C05828E18C52F510F7CDFA2 /* Products */,
+				357496424A62506BB5B92AB9 /* Transactions */,
 			);
-			path = Events;
+			path = StoreKit;
+			sourceTree = "<group>";
+		};
+		118B5EF9AC7A21C2AFA1DED1 /* Purchasing */ = {
+			isa = PBXGroup;
+			children = (
+				5A413B6FF46B130D90A428B4 /* ProductPurchaserLogic.swift */,
+				B14E186AB8E440B5F4E8FE86 /* ProductPurchaserSK1.swift */,
+				73BE8AD685B39ACAB331109C /* PurchaseManager.swift */,
+			);
+			path = Purchasing;
 			sourceTree = "<group>";
 		};
 		14F8842196EB2B1F82B3E024 /* Network */ = {
@@ -696,6 +894,26 @@
 			path = Network;
 			sourceTree = "<group>";
 		};
+		167BF9144FB641160A5BAAF8 /* App Session */ = {
+			isa = PBXGroup;
+			children = (
+				8165DD71323903F7CF426D2C /* AppSession.swift */,
+				214622367ACC8F66EB392105 /* AppSessionLogic.swift */,
+				CC89718EBDD71E09AB5F41DA /* AppSessionManager.swift */,
+			);
+			path = "App Session";
+			sourceTree = "<group>";
+		};
+		16BDE72FF436AB5439DCB69E /* Internal Tracking */ = {
+			isa = PBXGroup;
+			children = (
+				2123B84F5C786278E128152D /* OccurrenceLogicTests.swift */,
+				C2300AFFC31667E749E85EAC /* TrackingLogicTests.swift */,
+				65E23B703C00044332FDEBE8 /* TrackTests.swift */,
+			);
+			path = "Internal Tracking";
+			sourceTree = "<group>";
+		};
 		18D7774F30D977FAAE3FDAB4 /* Tests */ = {
 			isa = PBXGroup;
 			children = (
@@ -704,56 +922,109 @@
 			path = Tests;
 			sourceTree = "<group>";
 		};
-		1DD90B7ABCBFF411CEBAC413 /* Receipt Payload Models */ = {
+		1AB11D29B8854084126B7CBC /* StoreTransaction */ = {
 			isa = PBXGroup;
 			children = (
-				EB04E29E0B87E29156C9C246 /* InAppPurchase.swift */,
-				F2FDD78DE945EE7B82EAB274 /* InAppReceiptAttribute.swift */,
-				79144F89F4D8E24ADDC3EE92 /* InAppReceiptPayload.swift */,
-				A2B726AD765B53DCC82C1E65 /* InAppReceiptPayloadContainer.swift */,
+				A50760583D3E3E87C83B75F0 /* SK1StoreTransaction.swift */,
+				53754B4AADE9DFF31E2F3B43 /* SK2StoreTransaction.swift */,
+				9F6E6855FC2A6D10054EAE33 /* StorePayment.swift */,
+				8FDBBFC2D8F670CE2DC91889 /* StoreTransaction.swift */,
+				90B1A5AC3B7C3000274C782E /* StoreTransactionType.swift */,
 			);
-			path = "Receipt Payload Models";
+			path = StoreTransaction;
 			sourceTree = "<group>";
 		};
-		222E437CCBEF49AA7E645170 /* Models */ = {
+		1C2D445F729CF0EC69FB1B5A /* Logger */ = {
 			isa = PBXGroup;
 			children = (
-				A33CBBAB5601194ABD7FB8EE /* DeviceTemplate.swift */,
-				1503802B20764509D922B1FC /* FreeTrialTemplate.swift */,
-				42FFDB546C618BDAE779B3DA /* ProductTemplate.swift */,
-				EC841969BFFEF512F254A8AB /* Variables.swift */,
+				6DB09C4AF80761DF4205C4C2 /* Logger.swift */,
+				FA3A82C80F89023672D56AD7 /* LogLevel.swift */,
+				7FCE6A59348C9018F40D7AC5 /* LogScope.swift */,
 			);
-			path = Models;
+			path = Logger;
 			sourceTree = "<group>";
 		};
-		23C4C11FF1FB634090CB9972 /* Superwall */ = {
+		1D2BA24E8A9E66C614578E97 /* Purchasing */ = {
 			isa = PBXGroup;
 			children = (
-				22CA87F0488301B60564C72A /* Superwall.swift */,
-				1C7DF2BC047B98ABFFC3C966 /* SuperwallLogic.swift */,
-				E349A6D46ADF5C503E47C0F6 /* Analytics */,
-				C14C7F1DC0E6201AE8E7D3AB /* Config */,
-				C95694BAD44C0A2088F0A187 /* Delegate */,
-				41FCFE3AAC3F61216F102CF5 /* Game Controller */,
-				05146FC7F9E6578390A94CEA /* Graveyard */,
-				E03A29FB5FB7F20FF55015BD /* Identity */,
-				DAC8B81E81A101792B00B1E1 /* Paywall Cache Manager */,
-				7F308839A545612C4BD35C1B /* Paywall Presentation */,
-				FAF32EA90EE4CADC39AED611 /* Paywall Request */,
-				9C609BF15902C7D620E4AB61 /* Paywall View Controller */,
-				ADFF20387DA4BCA7FE575231 /* Transactions */,
+				1B1A6ADFFB9FA982BF69C134 /* MockSKPaymentTransaction.swift */,
+				618BF4D10B7D87FAF8FB48CD /* ProductPurchaserSK1Tests.swift */,
 			);
-			path = Superwall;
+			path = Purchasing;
 			sourceTree = "<group>";
 		};
-		29A3D0295F9B89FE1A5E89CE /* Products */ = {
+		1DE8CF6D5ACEFA6B6349B142 /* Loading */ = {
 			isa = PBXGroup;
 			children = (
-				D95F38041B9935272D2D87C2 /* ProductsManagerMock.swift */,
-				3D198142576890710445E657 /* StoreKitManagerTests.swift */,
-				697DB2F7B09A1976AA897A2C /* Receipt Manager */,
+				EBFB0A38F634286F61572C51 /* ActivityIndicatorView.swift */,
+				97A579F56E5CEF54DB9E9B62 /* DarkBlurredBackground.swift */,
+				866F99509EDFBE8BAE10E575 /* LoadingModel.swift */,
+				A94120D51C7B36AC9EA32B8B /* LoadingView.swift */,
+				20365697A9C396E8EC746B77 /* LoadingViewController.swift */,
+				D123D95036ED6CE3B097BBF0 /* ShimmerView.swift */,
+				325FFE8F1FC6854FA48D5D7B /* Animations */,
+				8DF7C2D420C3EE8CFB96C80E /* Listeners */,
 			);
-			path = Products;
+			path = Loading;
+			sourceTree = "<group>";
+		};
+		1F29B244553BD815519B80A9 /* Device Helper */ = {
+			isa = PBXGroup;
+			children = (
+				BB242DC77FEC0BE10C0DDC9C /* DeviceHelper.swift */,
+				9E1EFE389B54C304F2B01620 /* DeviceInfo.swift */,
+			);
+			path = "Device Helper";
+			sourceTree = "<group>";
+		};
+		1F332568DE1FCDA60C979098 /* Model */ = {
+			isa = PBXGroup;
+			children = (
+				2E77DE2454F2F58460EF162A /* TriggerSession.swift */,
+				EF3D82A1AC66E94746295419 /* TriggerSessionPaywall.swift */,
+				F4D74B23A58D934512BE8470 /* TriggerSessionProducts.swift */,
+				991415992A1EA3C9E6DB7D25 /* TriggerSessionTrigger.swift */,
+				22016FCBC368D8FA0FE407D7 /* Transaction */,
+			);
+			path = Model;
+			sourceTree = "<group>";
+		};
+		22016FCBC368D8FA0FE407D7 /* Transaction */ = {
+			isa = PBXGroup;
+			children = (
+				775D6EC141DAE9BED8B732A7 /* TriggerSessionTransaction.swift */,
+				9C22A9DDC2F2A72B0BBDC757 /* Product */,
+			);
+			path = Transaction;
+			sourceTree = "<group>";
+		};
+		235D83B13EFD27C91FDBCA6F /* Operators */ = {
+			isa = PBXGroup;
+			children = (
+				D6E787EFC5201B68C3631FE8 /* CheckSubscriptionStatus.swift */,
+				81D80A7C5B8A17B83C218656 /* MapSwiftErrors.swift */,
+			);
+			path = Operators;
+			sourceTree = "<group>";
+		};
+		29AF8407DB4560B41050C02F /* Web View */ = {
+			isa = PBXGroup;
+			children = (
+				9C2580C3CD6A8BF0C5258665 /* SWWebView.swift */,
+				F4AE7105F72063122615EFF1 /* Message Handling */,
+				E4C1D2384C6CAD193D3CE652 /* Templating */,
+			);
+			path = "Web View";
+			sourceTree = "<group>";
+		};
+		29EFE2945707407DD1377584 /* App Session */ = {
+			isa = PBXGroup;
+			children = (
+				81BE917F0AA7A7453B7D0BB2 /* AppSessionLogicTests.swift */,
+				1B78FB9232236AF44369EA92 /* AppSessionManagerMock.swift */,
+				59A767F107FB1FBBC2F22DB3 /* AppSessionManagerTests.swift */,
+			);
+			path = "App Session";
 			sourceTree = "<group>";
 		};
 		2AF21BD63950D63A4F96F6C6 /* Models */ = {
@@ -776,6 +1047,15 @@
 			path = Storage;
 			sourceTree = "<group>";
 		};
+		2C05828E18C52F510F7CDFA2 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				BD6BA222CB2EAA4B65F362C5 /* ProductsFetcherSK1.swift */,
+				0E9A13ACB22951C865722510 /* Receipt Manager */,
+			);
+			path = Products;
+			sourceTree = "<group>";
+		};
 		2DAF3427CF469F5373C2BFD7 /* Managed Models */ = {
 			isa = PBXGroup;
 			children = (
@@ -795,68 +1075,133 @@
 			path = "SW Template Variables";
 			sourceTree = "<group>";
 		};
+		325FFE8F1FC6854FA48D5D7B /* Animations */ = {
+			isa = PBXGroup;
+			children = (
+				18DB52B223C181E0A8FA1D6D /* BottomPaddingAnimation.swift */,
+				532AB25EB4DA9BAA5E3FA530 /* OpacityAnimation.swift */,
+				2BB10D9097CC124FFC34A4A0 /* RotationAnimation.swift */,
+				B1DF64C51FA26B40D8D7B880 /* ScaleAnimation.swift */,
+				2D1A60826D12F97F96E671DF /* SpringAnimation.swift */,
+			);
+			path = Animations;
+			sourceTree = "<group>";
+		};
+		33C89C06ECF942287FA14087 /* Analytics */ = {
+			isa = PBXGroup;
+			children = (
+				67B05942B51DA5DE06C22C1C /* SessionEventsManager.swift */,
+				F63599D252F44CF417D79AF3 /* SessionEventsQueue.swift */,
+				167BF9144FB641160A5BAAF8 /* App Session */,
+				D13E0D5732177680FB43AA9F /* Internal Tracking */,
+				96C4C79D11E09021AA993793 /* Superwall Event */,
+				394CC2D15ADB73F8C59ADF6B /* Trigger Session Manager */,
+			);
+			path = Analytics;
+			sourceTree = "<group>";
+		};
+		350D807108D945732F8F0614 /* Operators */ = {
+			isa = PBXGroup;
+			children = (
+				AA3C3F42E928987B92F35B96 /* CheckDebuggerPresentation.swift */,
+				67D3D3EFDC1C529BB6306387 /* CheckNoPaywallAlreadyPresented.swift */,
+				1B9C006C80A6104FA63FA84C /* CheckUserSubscription.swift */,
+				81CB02D2E13C410C2600B506 /* ConfirmHoldoutAssignment.swift */,
+				073A0FCBB864ADFDDF30FED5 /* ConfirmPaywallAssignment.swift */,
+				55DDD2F24335874B99E71B44 /* EvaluateRules.swift */,
+				E35ABB03CA31D2C187A9D052 /* GetExperiment.swift */,
+				BFEECDF884EDFE6FF1D0E0C3 /* GetPaywallVC.swift */,
+				C1D09FBCB364D8316C4A8C69 /* GetPresenter.swift */,
+				D7974C3C7E0B54A24784E5C3 /* LogErrors.swift */,
+				0CCCFB974F1CAB7ABEF75AB7 /* LogPresentation.swift */,
+				98D3CEEDCBBDB85C54FDC128 /* PresentPaywall.swift */,
+				544D7004BC0C01A06868A252 /* StorePresentationObjects.swift */,
+				21D68A4D5F80E09BA683386E /* WaitToPresent.swift */,
+			);
+			path = Operators;
+			sourceTree = "<group>";
+		};
 		3547E09D300E2C1E5D42FD60 /* Extensions */ = {
 			isa = PBXGroup;
 			children = (
 				51407421A3CBF7AF0FC76E60 /* Bundle+Helpers.swift */,
-				CB95FC8B25A0F7F539D4AF92 /* Date+IsoString.swift */,
 				A9A3C997FDC1550AF477CA1D /* Decimal+Rounding.swift */,
 				B2E6016BF483A4C47FF7A7C0 /* Encodable+Dictionary.swift */,
 				8DE36D141F461F6E945823FA /* Future+Async.swift */,
 				E2243C6BF6BE477794F568ED /* GCControllerElement+buttonName.swift */,
 				FD778E66506BA51BEB5EE89C /* JSONEncoder+Superwall.swift */,
 				F4B35EF62D8C986B504B052C /* NSManagedObjectContext+mergeChanges.swift */,
-				FCFEE6F37BE497DF44642308 /* SKProduct+Helpers.swift */,
+				AF5A8FFFC23826AD113D525A /* Publisher+Async.swift */,
 				938EB5121B1D9EA6B2EAE9EC /* Task+Retrying.swift */,
 				74DFC04FC0F3498D1EBE4B6A /* UIApplication+ActiveWindow.swift */,
 				2888B05A273E9EB6E9382332 /* UIColor+Hex.swift */,
 				750CC308DD48F4CE615DFC89 /* UIDevice+ModelName.swift */,
 				F636156244B674A56ADC461C /* UIView+SpringAnimation.swift */,
 				3D97E1615BA0B22BBBE0DAFA /* UIWindow+Landscape.swift */,
+				AE32816F1CA1637897AC87A2 /* UNUserNotificationCenter+SuperwallNotifications.swift */,
 				C0D5D5E0E82C83BF2BF1654D /* Array */,
+				73CC4161577DC2E4D1B3DE07 /* Date */,
 				8FD54E5602DD1F46F33D2F43 /* Dictionary */,
-				9AE664477D2B01CF2F72E04C /* Publishers */,
 				795C742F8CF4BEDF36234CA5 /* String */,
 				C9D58EBCE1AAA5A622269EB8 /* UIViewController */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
 		};
-		36A306E145BB08C9FAD644AB /* Trigger Logic */ = {
+		357496424A62506BB5B92AB9 /* Transactions */ = {
 			isa = PBXGroup;
 			children = (
-				CE6B12B5C4B4EAC0CD08F50F /* ExpressionEvaluatorLogicTests.swift */,
-				D127BF1A2362FBB81E2C7B52 /* ExpressionEvaluatorTests.swift */,
+				1D2BA24E8A9E66C614578E97 /* Purchasing */,
 			);
-			path = "Trigger Logic";
+			path = Transactions;
 			sourceTree = "<group>";
 		};
-		4068ACB30D8EB4121CD1EDBD /* Paywall Manager */ = {
+		35F2394099558A2416E3AC55 /* View Controller */ = {
 			isa = PBXGroup;
 			children = (
-				8CE2D05376A82D2185955AFE /* PaywallCacheLogicTests.swift */,
-				28A4999BBFF9057B7CE580E6 /* PaywallCacheTests.swift */,
+				7569A0893012A88442B7ED36 /* PaywallViewController.swift */,
+				6F9276EC956CE4A6C09949CE /* Delegates */,
+				1DE8CF6D5ACEFA6B6349B142 /* Loading */,
+				489B51B9B3F61FEE0BC1CECB /* Push Transition */,
+				29AF8407DB4560B41050C02F /* Web View */,
 			);
-			path = "Paywall Manager";
+			path = "View Controller";
 			sourceTree = "<group>";
 		};
-		40BEEC55601E9330E4BA0207 /* Templating */ = {
+		373AFF230833A951B6E5DF36 /* Identity */ = {
 			isa = PBXGroup;
 			children = (
-				030B4D4D2CD35F6571860A93 /* TemplateLogic.swift */,
-				222E437CCBEF49AA7E645170 /* Models */,
+				40AE19B5A9B237A2552D5F36 /* IdentityLogicTests.swift */,
+				2714D9FD9F55611B4C5E4E7D /* IdentityManagerMock.swift */,
 			);
-			path = Templating;
+			path = Identity;
 			sourceTree = "<group>";
 		};
-		41FCFE3AAC3F61216F102CF5 /* Game Controller */ = {
+		38C02C19ED9C9958A7A61FB1 /* Debug */ = {
 			isa = PBXGroup;
 			children = (
-				68DE31534533BC89FFC85924 /* GameControllerEvent.swift */,
-				B4FF025AF2EC66D8312999A4 /* GameControllerManager.swift */,
-				09F317AAF18C52B7B06580E9 /* PublicGameController.swift */,
+				C733A9BE56EA9E10D75B073B /* SWDebugManagerLogicTests.swift */,
 			);
-			path = "Game Controller";
+			path = Debug;
+			sourceTree = "<group>";
+		};
+		394CC2D15ADB73F8C59ADF6B /* Trigger Session Manager */ = {
+			isa = PBXGroup;
+			children = (
+				71BCCF22958A702677FB66F5 /* TriggerSessionManager.swift */,
+				BACAA655F72F3CE9B71C2C46 /* TriggerSessionManagerLogic.swift */,
+				1F332568DE1FCDA60C979098 /* Model */,
+			);
+			path = "Trigger Session Manager";
+			sourceTree = "<group>";
+		};
+		3BE2C31A01D986D7FED5C4F4 /* Web View */ = {
+			isa = PBXGroup;
+			children = (
+				FD8F67EFF69ECDBE85EB24F5 /* Message Handling */,
+				79E3E1B6A224AE8B4085CF9B /* Templating */,
+			);
+			path = "Web View";
 			sourceTree = "<group>";
 		};
 		421AC40BEB48DF2CF56AC3A3 /* SW Product */ = {
@@ -872,6 +1217,15 @@
 			path = "SW Product";
 			sourceTree = "<group>";
 		};
+		42AAF2ACFDE72A9C5EA013BF /* Certificates */ = {
+			isa = PBXGroup;
+			children = (
+				B1A112ABEB40964EDA5B5B21 /* AppleIncRootCertificate.cer */,
+				23F821BDAE724B3F3FFDA5E5 /* StoreKitTestCertificate.cer */,
+			);
+			path = Certificates;
+			sourceTree = "<group>";
+		};
 		46CEF77B52399F8A27F8452F /* Events */ = {
 			isa = PBXGroup;
 			children = (
@@ -882,13 +1236,33 @@
 			path = Events;
 			sourceTree = "<group>";
 		};
-		4B9961AAC21F8B221FEA42BA /* Options */ = {
+		47BB9A3687BE8520EE4410AF /* Subscription Controller */ = {
 			isa = PBXGroup;
 			children = (
-				10EFDC8DEA3944B23AE6511D /* PaywallOptions.swift */,
-				CB338C3E2FCD47EA52FD133E /* SuperwallOptions.swift */,
+				A96A65416DB25FF601BB68F2 /* PurchaseController.swift */,
+				47D0B3E1489C378D73F7CFD4 /* PurchaseControllerObjc.swift */,
 			);
-			path = Options;
+			path = "Subscription Controller";
+			sourceTree = "<group>";
+		};
+		47CAC36D95CB240FF1B2A9CD /* Manager */ = {
+			isa = PBXGroup;
+			children = (
+				63A8950F4F998DE6C9242A10 /* PaywallCacheLogic.swift */,
+				187934D3C89220C605299A17 /* PaywallManager.swift */,
+				8BAEECE2DBFEB8817E6C36DA /* PaywallViewControllerCache.swift */,
+			);
+			path = Manager;
+			sourceTree = "<group>";
+		};
+		489B51B9B3F61FEE0BC1CECB /* Push Transition */ = {
+			isa = PBXGroup;
+			children = (
+				EE1E7DA9C8816082FA05B84D /* PushTransition.swift */,
+				440ABDF6DAE2C15579B93DF1 /* PushTransitionDelegate.swift */,
+				AC74F16DC5A17489E97061EA /* PushTransitionLogic.swift */,
+			);
+			path = "Push Transition";
 			sourceTree = "<group>";
 		};
 		4D7656D6A565958F58A644AF /* Misc */ = {
@@ -897,67 +1271,6 @@
 				F2F75130AF54DFC4C7FA839A /* Extensions */,
 			);
 			path = Misc;
-			sourceTree = "<group>";
-		};
-		4DD18814E637A4001354FDAD /* Message Handling */ = {
-			isa = PBXGroup;
-			children = (
-				884371CD0933DF20F13D7B6B /* PaywallMessage.swift */,
-				F90E6FDCEF2889C5068A80D4 /* PaywallMessageHandler.swift */,
-				BD7E6196C1445FABD2BA1833 /* PaywallWebEvent.swift */,
-				20002CE824E4D422DDA12E62 /* RawWebMessageHandler.swift */,
-			);
-			path = "Message Handling";
-			sourceTree = "<group>";
-		};
-		4E3F82D0E4031D991CE33A8C /* App Session */ = {
-			isa = PBXGroup;
-			children = (
-				1AE22760FB509FAE1B9AF0C7 /* AppSession.swift */,
-				C649C8B193A114A5BDAF49C0 /* AppSessionLogic.swift */,
-				5170FDBAB83BD12B139D7886 /* AppSessionManager.swift */,
-			);
-			path = "App Session";
-			sourceTree = "<group>";
-		};
-		51896B21B1D98B714DB4E4B6 /* Product */ = {
-			isa = PBXGroup;
-			children = (
-				BE7292248877A0CD370259B8 /* ProductPeriod.swift */,
-				C8F55CC8D621E7013FAEF4C0 /* ProductPrice.swift */,
-				D980856238D5C86BCA6EBBEE /* ProductTrial.swift */,
-				B57F9BE50ABBC04A7E4A1B4E /* TriggerSessionProduct.swift */,
-			);
-			path = Product;
-			sourceTree = "<group>";
-		};
-		52E46A3CB182D81370F207E4 /* Superwall */ = {
-			isa = PBXGroup;
-			children = (
-				3ACEB8F7B11E039CB02BCCD0 /* PaywallTests.swift */,
-				756A55836F8968D362303C55 /* SuperwallLogicTests.swift */,
-				A5CB7B5466A834AD98F25968 /* Config */,
-				08CABCF338B020423646F640 /* Debug */,
-				0E727785AE8CA0D9DF5ECF55 /* Events */,
-				8315DDA74AE879DECB3CB2A5 /* Identity */,
-				4068ACB30D8EB4121CD1EDBD /* Paywall Manager */,
-				ABD3E9ED02195BE3960B7A33 /* Paywall Presentation */,
-				09A2371C68A9C9222BF77BFE /* Paywall Response */,
-				29A3D0295F9B89FE1A5E89CE /* Products */,
-				A751B18D14C5704E8E2482E2 /* Session Events */,
-				EB16FEB8B0FE549F4DC39BAF /* Transactions */,
-				36A306E145BB08C9FAD644AB /* Trigger Logic */,
-			);
-			path = Superwall;
-			sourceTree = "<group>";
-		};
-		54E5CCF4FCDD6A7A5097B527 /* Trigger */ = {
-			isa = PBXGroup;
-			children = (
-				2C69250C9C29C6062BD58A0C /* TriggerSessionExperiment.swift */,
-				5E2F873BF32DB7D791C152C1 /* TriggerSessionTrigger.swift */,
-			);
-			path = Trigger;
 			sourceTree = "<group>";
 		};
 		57063E03347E51C4D0C9DD90 /* Localizations */ = {
@@ -969,6 +1282,35 @@
 				C7FFF0EDFF6DA910E4B5CCB7 /* LocalizationOption.swift */,
 			);
 			path = Localizations;
+			sourceTree = "<group>";
+		};
+		5902F3245E7904B5F94D6E4A /* Manager */ = {
+			isa = PBXGroup;
+			children = (
+				58BA95995DE57E811FD65C02 /* PaywallCacheLogicTests.swift */,
+				5C57C1CCAF97244AE0DC953F /* PaywallManagerMock.swift */,
+				672776875A4286319C2F2D61 /* PaywallViewControllerCacheTests.swift */,
+			);
+			path = Manager;
+			sourceTree = "<group>";
+		};
+		5943C0902B0D5EC30C0C3B8C /* Game Controller */ = {
+			isa = PBXGroup;
+			children = (
+				21C52F36F0BFF59363EBB4C7 /* GameControllerEvent.swift */,
+				577A16EE2161E2CDEDFA48C0 /* GameControllerManager.swift */,
+				010F0F8FCE0A86D8F2823A47 /* PublicGameController.swift */,
+			);
+			path = "Game Controller";
+			sourceTree = "<group>";
+		};
+		5A283279282EA87CE954371B /* View Controller */ = {
+			isa = PBXGroup;
+			children = (
+				A453816DBA43C08410D12DE6 /* PaywallViewControllerMock.swift */,
+				3BE2C31A01D986D7FED5C4F4 /* Web View */,
+			);
+			path = "View Controller";
 			sourceTree = "<group>";
 		};
 		5A97AB5D43D21F410D91982E /* Cache */ = {
@@ -983,9 +1325,10 @@
 		5AB0F620BC24555C62C913FF /* Triggers */ = {
 			isa = PBXGroup;
 			children = (
+				5836EFACFA00594CE8F9F377 /* Experiment.swift */,
 				7611B89AB647CB1AB79CA912 /* RawExperiment.swift */,
 				2628BCB13E80DC539F35C7B5 /* Trigger.swift */,
-				35BA5B3787B2B3122EAA11B5 /* TriggerInfo.swift */,
+				25515131DF0AE67E26BFF462 /* TriggerResult.swift */,
 				481D47E5121C521DDA268609 /* TriggerRule.swift */,
 				4B6C286BF417074EEE0D3D55 /* TriggerRuleOccurrence.swift */,
 				194B8214C0A66407CEDCC0F4 /* VariantOption.swift */,
@@ -993,15 +1336,15 @@
 			path = Triggers;
 			sourceTree = "<group>";
 		};
-		5B047E5469DEEA72398F0759 /* Superwall Event */ = {
+		5C796231D913B9C1E64B8EA3 /* Get Paywall */ = {
 			isa = PBXGroup;
 			children = (
-				8AD39245CEC3FF3EBD5EDE5C /* SuperwallEvent.swift */,
-				2357B335109EA70FD685C993 /* SuperwallEventInfo.swift */,
-				5D6BFF0F26C146D7C443388F /* SuperwallEventObjc.swift */,
-				1269B5184768FDA6BE892B20 /* TransactionProduct.swift */,
+				24EA03270476CD31B906CDC8 /* GetPaywallResult.swift */,
+				6C9F31221C5E26E20514E0C1 /* InternalGetPaywall.swift */,
+				A5110E43405C69969E9DA67B /* PublicGetPaywall.swift */,
+				235D83B13EFD27C91FDBCA6F /* Operators */,
 			);
-			path = "Superwall Event";
+			path = "Get Paywall";
 			sourceTree = "<group>";
 		};
 		5CE8CEF97A892FFF3D0D8F06 = {
@@ -1013,24 +1356,85 @@
 			);
 			sourceTree = "<group>";
 		};
-		641CBC9224AD1381171DCA7F /* Trackable Events */ = {
+		5E1272F6F935DC1417B03A9F /* Operators */ = {
 			isa = PBXGroup;
 			children = (
-				7AD581390E2944BCA2603D5B /* Trackable.swift */,
-				8121467D535878BE104DF9AF /* TrackableSuperwallEvent.swift */,
-				5E36C7A628CE395D4E118CDE /* UserInitiatedEvents.swift */,
+				E815C43EB5A02E48B618DD9F /* CheckDebuggerPresentationOperatorTests.swift */,
+				079455F8D3D241361EF5F0AA /* CheckPaywallPresentableOperatorTests.swift */,
+				83F3F6FCA1A755FC0A6CD8EC /* CheckUserSubscriptionOperatorTests.swift */,
+				018F5856F39FC33AFE9740D4 /* ConfirmHoldoutAssignmentTests.swift */,
+				8FC7F8602B38644BCCDAD159 /* ConfirmPaywallAssignmentOperatorTests.swift */,
+				16AC8D761A7F5A7F012EA39B /* EvaluateRulesOperatorTests.swift */,
+				943CA7F8AE219A07C1245232 /* GetPaywallVcOperatorTests.swift */,
+				B27F0D55EF3480E2B65C8DFD /* HandleTriggerResultOperatorTests.swift */,
+				EEA21AF7F6C5FB0EC83E4E1A /* PresentPaywallOperatorTests.swift */,
+				8BDA9D233EACAB5090B0657D /* StorePresentationObjectsOperatorTests.swift */,
+				4A978542D21EC187C1A3C499 /* WaitToPresentOperatorTests.swift */,
 			);
-			path = "Trackable Events";
+			path = Operators;
 			sourceTree = "<group>";
 		};
-		64B8492049AD533A81454E90 /* Expression Evaluator */ = {
+		63D095FC7C91CDED1647E303 /* PKCS7 */ = {
 			isa = PBXGroup;
 			children = (
-				4341A45FFB9258457E962532 /* ExpressionEvaluator.swift */,
-				CDD938341ED4745A6206D944 /* ExpressionEvaluatorLogic.swift */,
-				6B052A053B815537646DD70D /* ExpressionEvaluatorParams.swift */,
+				30C2B369C690AAB9C085E2E9 /* PKCS7.swift */,
 			);
-			path = "Expression Evaluator";
+			path = PKCS7;
+			sourceTree = "<group>";
+		};
+		648ECF7113CF1C8A74688E97 /* Request */ = {
+			isa = PBXGroup;
+			children = (
+				FC6C4D551369C55D8AFB7F96 /* PaywallLogic.swift */,
+				1AB5B56470F69FBE1C34EAA8 /* PaywallRequest.swift */,
+				1528915438E6714B1F7F7BD4 /* PaywallRequestManager.swift */,
+				AF6F5F7F77820487CA98B6CA /* Operators */,
+			);
+			path = Request;
+			sourceTree = "<group>";
+		};
+		649EA1E5386E4FED85A7B338 /* ASN1Swift */ = {
+			isa = PBXGroup;
+			children = (
+				9F72210F85864F3000F13646 /* ASN1Coder.swift */,
+				F49804DCB74FEEFA0D3438A9 /* ASN1Decoder.swift */,
+				D07ACB41E733B6CF8EA722E0 /* ASN1Decoder+Extras.swift */,
+				DAF94D451CB6346AE3C5863B /* ASN1Decoder+KeyedDecodingContainer.swift */,
+				184CC04EBE95A64F30F83EA0 /* ASN1Decoder+SingleValueContainer.swift */,
+				70FC86C1189200C486627EAD /* ASN1Decoder+Unboxing.swift */,
+				D31BB6D0C57337C6E929D617 /* ASN1Decoder+UnkeyedDecodingContainer.swift */,
+				37B17A8801A2A9454E66D892 /* ASN1Decoder+Utils.swift */,
+				7588892D6DD1C4437CF507DE /* ASN1Serialization.swift */,
+				45AFD6EE9BED296D075A9618 /* ASN1Templates.swift */,
+				8087A8CD8F4FC7C745010428 /* ASN1Types.swift */,
+				6EDC14C0D6958144679F149D /* DecodingError+Extensions.swift */,
+				80281364A23252E30DEEA1AA /* Foundation+ASN1Coder.swift */,
+				63D095FC7C91CDED1647E303 /* PKCS7 */,
+			);
+			path = ASN1Swift;
+			sourceTree = "<group>";
+		};
+		656E0B996F9B9455C0F85C0F /* Resources */ = {
+			isa = PBXGroup;
+			children = (
+				B23E9FB48867BAE49688784F /* Assets.xcassets */,
+				F34468E3988E779132CE101A /* BundleHelper.swift */,
+				42AAF2ACFDE72A9C5EA013BF /* Certificates */,
+			);
+			path = Resources;
+			sourceTree = "<group>";
+		};
+		66F9C998E9BBCFFCF80386FE /* Identity */ = {
+			isa = PBXGroup;
+			children = (
+				3C1EB433A4E4342E03BB7744 /* IdentityInfo.swift */,
+				AB3F04AC933701EE33F5F325 /* IdentityLogic.swift */,
+				236900A8A8F95CE92E612458 /* IdentityManager.swift */,
+				320AA5349848F696950F441A /* IdentityOptions.swift */,
+				A4493EE88B00CADF85EF1196 /* PublicIdentity.swift */,
+				B52A0EFBBFE9D2F949EA4C28 /* UserAttributes.swift */,
+			);
+			path = Identity;
 			sourceTree = "<group>";
 		};
 		67DBEF230C3E8EECA007FC2E /* Postback */ = {
@@ -1042,51 +1446,49 @@
 			path = Postback;
 			sourceTree = "<group>";
 		};
-		697DB2F7B09A1976AA897A2C /* Receipt Manager */ = {
+		6F9276EC956CE4A6C09949CE /* Delegates */ = {
 			isa = PBXGroup;
 			children = (
-				EE253DB1E7B6723EC24216CE /* MockReceiptData.swift */,
-				D78D73D3C35F8A910272BD4A /* ReceiptManagerTests.swift */,
+				88EBF6FC3090E004EE1377B4 /* PaywallViewControllerDelegate.swift */,
+				990461F7A9B2F3ED62B3A628 /* PaywallViewControllerDelegateAdapter.swift */,
 			);
-			path = "Receipt Manager";
+			path = Delegates;
 			sourceTree = "<group>";
 		};
-		6B1344BC3DF3ADC5E72EB658 /* Push Transition */ = {
+		70804E322E668D2320A4F9A4 /* Expression Evaluator */ = {
 			isa = PBXGroup;
 			children = (
-				83043016E578123D1E2D2C90 /* PushTransition.swift */,
-				806911E8F01C4115843E2019 /* PushTransitionDelegate.swift */,
-				14926B3770019BAF544EE626 /* PushTransitionLogic.swift */,
+				1CC8F4AB247F86988A71BF01 /* ExpressionEvaluator.swift */,
+				C1B7E4FC6B4AAEA58D95A052 /* ExpressionEvaluatorParams.swift */,
 			);
-			path = "Push Transition";
+			path = "Expression Evaluator";
 			sourceTree = "<group>";
 		};
-		6BCBA25EC6544B8A42C0E12E /* Config */ = {
+		73CC4161577DC2E4D1B3DE07 /* Date */ = {
 			isa = PBXGroup;
 			children = (
-				6842E9305150D3702AB48E2E /* Config.swift */,
-				424E0C25FF267517F70AFC6B /* FeatureFlags.swift */,
-				5288181962FAFEBEEF58E19C /* LocalizationConfig.swift */,
-				4FEBF2A47374CE665EC5D33D /* PaywallConfig.swift */,
+				C2AF370C9EDF3C7A4605D385 /* Date+IsoString.swift */,
+				E51D0B38180377D9CD3E65DA /* Date+TimeIntervalMilliseconds.swift */,
 			);
-			path = Config;
+			path = Date;
 			sourceTree = "<group>";
 		};
-		75A5BC8832BFCDDCCA5B95FB /* Operators */ = {
+		75743C9AAFCAB9D91984F19C /* Presentation */ = {
 			isa = PBXGroup;
 			children = (
-				999EAA9CED33866246D75177 /* AwaitIdentityOperator.swift */,
-				352D6CA631F149C0B0C29DAE /* CheckPaywallPresentableOperator.swift */,
-				2AEAF9E84CF443750C23DFCF /* ConfirmAssignmentOperator.swift */,
-				BBD023FB713C2A223849B1EF /* DebuggerCheckerOperator.swift */,
-				8A3F246F74018E6AD4B82CBF /* GetPaywallVcOperator.swift */,
-				D636EDD4E9ABEE40510C1BD5 /* HandleTriggerOutcomeOperator.swift */,
-				B979A4EBDBD32C0985FD74DC /* LogPresentationOperator.swift */,
-				E1FFFB20CA2231FC607BE44A /* PresentationPipelineError.swift */,
-				844207A4B6BC4A2A29FDCEF7 /* PresentPaywallOperator.swift */,
-				A511EA01417DE3299BCD363B /* TriggerOutcomeOperator.swift */,
+				B2C3E282003472D3326477C4 /* Internal Presentation */,
 			);
-			path = Operators;
+			path = Presentation;
+			sourceTree = "<group>";
+		};
+		7662FF6DDBA21E90C9CD5056 /* Presentation Request */ = {
+			isa = PBXGroup;
+			children = (
+				A9904A3538DF80EA8EEC2687 /* PaywallOverrides.swift */,
+				18A22BD77510896343D76A1C /* PresentationInfo.swift */,
+				7397C5FD11E7A09B6AD39165 /* PresentationRequest.swift */,
+			);
+			path = "Presentation Request";
 			sourceTree = "<group>";
 		};
 		778C04FFAA9840C37CA3C1CA /* Products */ = {
@@ -1098,23 +1500,36 @@
 			name = Products;
 			sourceTree = "<group>";
 		};
-		795994FDA7117CE7438E4D0E /* Transaction */ = {
-			isa = PBXGroup;
-			children = (
-				06F06F088D9FA3AE24C04986 /* TriggerSessionTransaction.swift */,
-				51896B21B1D98B714DB4E4B6 /* Product */,
-			);
-			path = Transaction;
-			sourceTree = "<group>";
-		};
 		795C742F8CF4BEDF36234CA5 /* String */ = {
 			isa = PBXGroup;
 			children = (
 				F16AFE9C93A441CFB6A95F10 /* String+CamelCase.swift */,
 				D449672964023589DA5535E3 /* String+MD5.swift */,
 				3E3E1BAFC4A22DC46C49F00C /* String+RemoveChars.swift */,
+				DB518DC9EFF0FE0C3A022982 /* String+RFC339.swift */,
 			);
 			path = String;
+			sourceTree = "<group>";
+		};
+		79E3E1B6A224AE8B4085CF9B /* Templating */ = {
+			isa = PBXGroup;
+			children = (
+				65EDE0BAE33F351217CC8E2D /* TemplateLogicTests.swift */,
+			);
+			path = Templating;
+			sourceTree = "<group>";
+		};
+		7C269C72AFB35BBAA962E69D /* Internal Presentation */ = {
+			isa = PBXGroup;
+			children = (
+				583DED0D7CA8A26424C8364A /* InternalPresentation.swift */,
+				13CD313E1E0B5EFBFA4B041F /* InternalPresentationLogic.swift */,
+				77444F578076D619C97EA6BB /* PaywallPresentationRequestStatus.swift */,
+				350D807108D945732F8F0614 /* Operators */,
+				7662FF6DDBA21E90C9CD5056 /* Presentation Request */,
+				DFCE4A0E8DD9BAF5609D57CE /* Presentation State */,
+			);
+			path = "Internal Presentation";
 			sourceTree = "<group>";
 		};
 		7F2D974D8CC6480A6D0EBDE0 /* Product */ = {
@@ -1126,54 +1541,97 @@
 			path = Product;
 			sourceTree = "<group>";
 		};
-		7F308839A545612C4BD35C1B /* Paywall Presentation */ = {
+		7FD9FD7878BD11B222C69278 /* Trackable Events */ = {
 			isa = PBXGroup;
 			children = (
-				BA296F4FCD50E811939A9B9D /* InternalPresentation.swift */,
-				AE90F82958684A445132862C /* InternalPresentationLogic.swift */,
-				C28014EF3A8BF357F2E71FC1 /* PaywallInfo.swift */,
-				641CDF0D4256D135D4461FE8 /* PublicPresentation.swift */,
-				75A5BC8832BFCDDCCA5B95FB /* Operators */,
-				B96921E9952FBCE4E71BA10C /* Presentation Request */,
-				EFF8D95BD42097532BEB7A62 /* Presentation State */,
-				6B1344BC3DF3ADC5E72EB658 /* Push Transition */,
+				BFE42FD8C7F01915D74D0008 /* Trackable.swift */,
+				3D8AD1A7B62E8CBBDFB65BE5 /* TrackableSuperwallEvent.swift */,
+				AE406AAED11F2B63E4A5A1FD /* UserInitiatedEvents.swift */,
 			);
-			path = "Paywall Presentation";
+			path = "Trackable Events";
 			sourceTree = "<group>";
 		};
-		8315DDA74AE879DECB3CB2A5 /* Identity */ = {
+		8402810DFB45192BB3E7636B /* Rule Logic */ = {
 			isa = PBXGroup;
 			children = (
-				1BCAA3FE5110CCAADEA9CC0E /* IdentityLogicTests.swift */,
-				365CD0C3A1A3A605271B1DB7 /* IdentityManagerMock.swift */,
+				1376F233A5CF79DAD2428171 /* RuleAttributes.swift */,
+				2BE63AAEDD12E85626744ED5 /* RuleLogic.swift */,
+				70804E322E668D2320A4F9A4 /* Expression Evaluator */,
 			);
-			path = Identity;
+			path = "Rule Logic";
 			sourceTree = "<group>";
 		};
 		84C47D069F1C218A2E2979E7 /* SuperwallKit */ = {
 			isa = PBXGroup;
 			children = (
-				56778050EC54F641333F5CDB /* Assets.xcassets */,
-				5765F9403E44383A8FC7D3AD /* BundleHelper.swift */,
 				C22CA9431D5F791BE7A9BE27 /* Documentation.docc */,
 				E5A461C7228BE71FF8695236 /* SDKJS.swift */,
+				2F7EDB6D68D0AEDD332E40BB /* Superwall.swift */,
+				33C89C06ECF942287FA14087 /* Analytics */,
+				91B8F43244A7C30402275032 /* Config */,
 				97F6AA52B81B82F72AB80D7C /* Debug */,
+				9C21AAF80FD220C960FE568F /* Delegate */,
+				A34416D82C5BDBAA82A119C1 /* Dependencies */,
+				5943C0902B0D5EC30C0C3B8C /* Game Controller */,
+				C36C5C30F60C1DFCDCF25E16 /* Graveyard */,
+				66F9C998E9BBCFFCF80386FE /* Identity */,
+				1C2D445F729CF0EC69FB1B5A /* Logger */,
 				ED389E60F716C417202738F0 /* Misc */,
 				AE7A07F03C028F373EFE1409 /* Models */,
 				EDFD560CA72266982EE04681 /* Network */,
-				D86A09A9C682F6D518463C32 /* Products */,
+				892B0A1D357DB8287FF5AD50 /* Paywall */,
+				656E0B996F9B9455C0F85C0F /* Resources */,
 				2B842BD3867B226B4F0AA864 /* Storage */,
-				23C4C11FF1FB634090CB9972 /* Superwall */,
+				D39A799D29B69CA09069877D /* StoreKit */,
 			);
 			path = SuperwallKit;
 			sourceTree = "<group>";
 		};
-		8A6849BD9CDD67832DFB0CBD /* Trigger Session Manager */ = {
+		86DD4496D1218324B5CBBB89 /* Paywall */ = {
 			isa = PBXGroup;
 			children = (
-				3EB9F4F9ACAEA150B071FDA5 /* MockSkProduct.swift */,
-				3C1998A6FF59883ECD906E84 /* TriggerSessionManagerLogicTests.swift */,
-				5C9C75A8DD2B4612C74C986B /* TriggerSessionManagerTests.swift */,
+				5902F3245E7904B5F94D6E4A /* Manager */,
+				75743C9AAFCAB9D91984F19C /* Presentation */,
+				C800729D322B65BAD6FB3668 /* Request */,
+				5A283279282EA87CE954371B /* View Controller */,
+			);
+			path = Paywall;
+			sourceTree = "<group>";
+		};
+		892B0A1D357DB8287FF5AD50 /* Paywall */ = {
+			isa = PBXGroup;
+			children = (
+				47CAC36D95CB240FF1B2A9CD /* Manager */,
+				D6A7BE39310E37ABB4B36343 /* Presentation */,
+				648ECF7113CF1C8A74688E97 /* Request */,
+				35F2394099558A2416E3AC55 /* View Controller */,
+			);
+			path = Paywall;
+			sourceTree = "<group>";
+		};
+		8DD7B7C5E111EAB0878886B6 /* Logger */ = {
+			isa = PBXGroup;
+			children = (
+				A00C04BE1449BE21E13B61A0 /* LoggerMock.swift */,
+			);
+			path = Logger;
+			sourceTree = "<group>";
+		};
+		8DF7C2D420C3EE8CFB96C80E /* Listeners */ = {
+			isa = PBXGroup;
+			children = (
+				C9B0C261DCC1ED74DD2BF3EA /* HiddenListener.swift */,
+				9DC4D23D1EDDA249C928930D /* PaddingListener.swift */,
+			);
+			path = Listeners;
+			sourceTree = "<group>";
+		};
+		8F8F663B2A11FC44292178F7 /* Trigger Session Manager */ = {
+			isa = PBXGroup;
+			children = (
+				719FE7C289CB0A621595A2A4 /* MockSkProduct.swift */,
+				1BC1DAA412BF11AE6B58D59D /* TriggerSessionManagerLogicTests.swift */,
+				BA46295F06642C4306BEA957 /* TriggerSessionManagerTests.swift */,
 			);
 			path = "Trigger Session Manager";
 			sourceTree = "<group>";
@@ -1189,95 +1647,104 @@
 			path = Dictionary;
 			sourceTree = "<group>";
 		};
-		966C70C3FB35FE0C9C63B147 /* Trigger Session Manager */ = {
+		91B8F43244A7C30402275032 /* Config */ = {
 			isa = PBXGroup;
 			children = (
-				FAA2D928566A5D0A3D436865 /* TriggerSessionManager.swift */,
-				B0240B2878A43A1164D2F2D6 /* TriggerSessionManagerLogic.swift */,
-				A7F9D2B6E44E7A6F56EBB91D /* Model */,
+				B634347011742D475E3F1A27 /* ConfigLogic.swift */,
+				4EC3DA8E774FBFE31F811FAF /* ConfigManager.swift */,
+				C262D74444D7EF5F2701EC6A /* Models */,
+				E7D208EAB24A633EB74B1E31 /* Options */,
 			);
-			path = "Trigger Session Manager";
+			path = Config;
 			sourceTree = "<group>";
 		};
-		96E795B4136F24FB368B5914 /* Mocks */ = {
+		96C4C79D11E09021AA993793 /* Superwall Event */ = {
 			isa = PBXGroup;
 			children = (
-				F787CE1E5BC1B7FAD479F0DC /* MockIntroductoryPeriod.swift */,
-				2D32BFD05F5B55287EFB19FD /* MockSubscriptionPeriod.swift */,
+				07D0428CF2880D29405900F7 /* SuperwallEvent.swift */,
+				5238DE736E2EF395E44ABCE1 /* SuperwallEventInfo.swift */,
+				FFCF5B904164BFB6A8C87BAB /* SuperwallEventObjc.swift */,
+				A454A48473801779E36C9709 /* TransactionProduct.swift */,
 			);
-			path = Mocks;
+			path = "Superwall Event";
 			sourceTree = "<group>";
 		};
 		97F6AA52B81B82F72AB80D7C /* Debug */ = {
 			isa = PBXGroup;
 			children = (
+				5383FA48A6E9EF8F30683C9B /* DebugManager.swift */,
+				F9098101E599AEB01521FE89 /* DebugViewController.swift */,
 				299F91895EE88281B5ED8320 /* SWBounceButton.swift */,
 				3CDFBF0FA8B313E0D84A51DB /* SWConsoleViewController.swift */,
-				4252EDEF1B7AFBCB44CD5000 /* SWDebugManager.swift */,
 				76CE4D7606C896027C76520E /* SWDebugManagerLogic.swift */,
-				1F5EF184B150FC221A8B7CCA /* SWDebugViewController.swift */,
 				FBE7D1E1AF61D199E17B5C05 /* SWLocalizationViewController.swift */,
 				57063E03347E51C4D0C9DD90 /* Localizations */,
 			);
 			path = Debug;
 			sourceTree = "<group>";
 		};
-		9931439EDF93D7ABECE38C4F /* Loading */ = {
+		9C21AAF80FD220C960FE568F /* Delegate */ = {
 			isa = PBXGroup;
 			children = (
-				69D11EF72866A27D016C9140 /* ActivityIndicatorView.swift */,
-				10552F325E6976EC5825C6EA /* DarkBlurredBackground.swift */,
-				57BBC30EF2E06EBADE774802 /* LoadingModel.swift */,
-				AB7DA08E93F886E54733004B /* LoadingView.swift */,
-				F8FA16E10142CB82A233C7F2 /* LoadingViewController.swift */,
-				E709EA62F0785E7025CC3C05 /* ShimmerView.swift */,
-				A094EE04CADDA5B3B9B89F8F /* Animations */,
-				D3712D16D59DAD2F0AD98C4F /* Listeners */,
+				2165AB24A77F58698AAFC04A /* PurchaseResult.swift */,
+				B2AFFA0F0D2BCDFEC8BEC856 /* RestorationResult.swift */,
+				CD69396B509844FFA8452452 /* SubscriptionStatus.swift */,
+				7318EF33D7374DC5C8B4549D /* SuperwallDelegate.swift */,
+				8E441343EAC43B2ECF35F929 /* SuperwallDelegateAdapter.swift */,
+				33A9E0597972B90E3B9DFFE1 /* SuperwallDelegateObjc.swift */,
+				47BB9A3687BE8520EE4410AF /* Subscription Controller */,
 			);
-			path = Loading;
+			path = Delegate;
 			sourceTree = "<group>";
 		};
-		9AE664477D2B01CF2F72E04C /* Publishers */ = {
+		9C22A9DDC2F2A72B0BBDC757 /* Product */ = {
 			isa = PBXGroup;
 			children = (
-				A42411E84D1A21D73D0BDA0E /* Publisher+Async.swift */,
-				FDBE29280BE3AE1C147CD39B /* Publisher+AsyncMap.swift */,
-				F982A447662FAA74CAA606A2 /* Publisher+HasRetrieved.swift */,
+				E4A5468741F21E02115E2C61 /* ProductPeriod.swift */,
+				7ACA213FA146D819AAFDB787 /* ProductPrice.swift */,
+				61DF3B7A43B6FFAEA3DD9BE9 /* ProductTrial.swift */,
+				0F2070ACE29ED3EA357228DC /* TriggerSessionProduct.swift */,
 			);
-			path = Publishers;
+			path = Product;
 			sourceTree = "<group>";
 		};
-		9C609BF15902C7D620E4AB61 /* Paywall View Controller */ = {
+		9C4C1D13B7C7D97BE6ABFEA9 /* Assignments */ = {
 			isa = PBXGroup;
 			children = (
-				C0F807DE042D48EB3DCB59F0 /* PaywallViewController.swift */,
-				9931439EDF93D7ABECE38C4F /* Loading */,
-				ED56553A92D0D031F6D62A0D /* Web View */,
+				3501D12845840D6CBA1F0081 /* AssignmentLogicTests.swift */,
+				0F66E51FB152C87F796F9466 /* Expression Evaluator */,
 			);
-			path = "Paywall View Controller";
+			path = Assignments;
 			sourceTree = "<group>";
 		};
-		9FF92D974C2C3B52BE4783D8 /* Internal Tracking */ = {
+		9CB6C2165B6C8E43C56CB151 /* Get Presentation Result */ = {
 			isa = PBXGroup;
 			children = (
-				B81601941E6DCEEEC38A2868 /* Tracking.swift */,
-				42F51ED1275B5BBD0893B067 /* TrackingLogic.swift */,
-				B80E862E0AF5DCEC8142696A /* TrackingParameters.swift */,
-				2200BA9DBFD79CD558E7C542 /* TrackingResult.swift */,
-				641CBC9224AD1381171DCA7F /* Trackable Events */,
+				1A2E8A96B1F4C3C78CFA696C /* GetPresentationResultLogic.swift */,
+				F57F454704875FFFC5CE1827 /* InternalGetPresentationResult.swift */,
+				94125DB9AC8A2EA66F983EDA /* PresentationResult.swift */,
+				544C032167E8198513B2A860 /* PresentationValueObjc.swift */,
+				D4F676D3A0F5B540052D36B1 /* PublicGetPresentationResult.swift */,
 			);
-			path = "Internal Tracking";
+			path = "Get Presentation Result";
 			sourceTree = "<group>";
 		};
-		A094EE04CADDA5B3B9B89F8F /* Animations */ = {
+		9D3A25014A0BEB0AB070F40C /* Products */ = {
 			isa = PBXGroup;
 			children = (
-				9B3F1C3A01E3C951974667D7 /* BottomPaddingAnimation.swift */,
-				1F8C5C62885BCF23722904B0 /* RotationAnimation.swift */,
-				1D8DA08B90AA82CB3337B624 /* ScaleAnimation.swift */,
-				985210E1D07FB0EC67510B32 /* SpringAnimation.swift */,
+				0C4CEDEB039548ABF39B528E /* ProductsFetcherSK1.swift */,
+				E36E6C0CB40C3F44423C80CF /* Receipt Manager */,
 			);
-			path = Animations;
+			path = Products;
+			sourceTree = "<group>";
+		};
+		9EC210B9F15B56C4C9230BAD /* Coordinator */ = {
+			isa = PBXGroup;
+			children = (
+				D4268B8B324D767409873B4C /* CoordinatorProtocols.swift */,
+				A829C96661335814CCF85BE3 /* StoreKitCoordinator.swift */,
+			);
+			path = Coordinator;
 			sourceTree = "<group>";
 		};
 		A1B28DB5B07A66105FE6B0A7 /* Data Structures */ = {
@@ -1299,86 +1766,27 @@
 			path = Storage;
 			sourceTree = "<group>";
 		};
-		A42A5AD2E2BE079CBB9FA0D5 /* App Session */ = {
+		A34416D82C5BDBAA82A119C1 /* Dependencies */ = {
 			isa = PBXGroup;
 			children = (
-				A2AB593578F0AB2F11158D5A /* AppSessionLogicTests.swift */,
-				F07DED9EBBD92558DD3ABAD9 /* AppSessionManagerMock.swift */,
-				0570862FCFAF7FB6B125F7E4 /* AppSessionManagerTests.swift */,
+				124F219E38F8398A65A7EB32 /* DependencyContainer.swift */,
+				5C2E30544869C5469AA31832 /* FactoryProtocols.swift */,
 			);
-			path = "App Session";
+			path = Dependencies;
 			sourceTree = "<group>";
 		};
-		A5CB7B5466A834AD98F25968 /* Config */ = {
+		A442CC58DCB40217A6761E25 /* StoreProduct */ = {
 			isa = PBXGroup;
 			children = (
-				9B7D272921BDC60D44BA5FCB /* AssignmentLogicTests.swift */,
-				128A1A9EAD883A4065875CFD /* ConfigLogicTests.swift */,
-				2CF6099237A88F3736F766A8 /* ConfigManagerMock.swift */,
-				754F0DDCB9D2D87A822F83C0 /* ConfigManagerTests.swift */,
+				6A541560191B2FE1CC1D970C /* PriceFormatterProvider.swift */,
+				AB6E84EBB6257BAA57F74229 /* Sk1StoreProduct.swift */,
+				E2CB827497BCEBDF9E1E2707 /* SK2StoreProduct.swift */,
+				BD8751EBBA905FB4F7E3C0BC /* StoreProduct.swift */,
+				0B5C66252BBED43067E4CD87 /* StoreProductType.swift */,
+				8D60F06C8685538A9486B97D /* SubscriptionPeriod.swift */,
+				DD0CAA6BD586AC27A1F07806 /* Discount */,
 			);
-			path = Config;
-			sourceTree = "<group>";
-		};
-		A661F501E8C4FD0EA0D6C35F /* UIKit */ = {
-			isa = PBXGroup;
-			children = (
-				CF78EA507375E36880AB33AB /* InternalPresentationLogicTests.swift */,
-			);
-			path = UIKit;
-			sourceTree = "<group>";
-		};
-		A751B18D14C5704E8E2482E2 /* Session Events */ = {
-			isa = PBXGroup;
-			children = (
-				E03E830ADACA9E5D41E5CFC4 /* MockSessionEventsQueue.swift */,
-				BBDE3A7712EC4EF8592A53FB /* SessionEventsDelegateMock.swift */,
-				2B0BE8481AD0F840392AE4BF /* SessionEventsManagerTests.swift */,
-				8A6849BD9CDD67832DFB0CBD /* Trigger Session Manager */,
-			);
-			path = "Session Events";
-			sourceTree = "<group>";
-		};
-		A7F7D993A4070FCDE4B17AFB /* Operators */ = {
-			isa = PBXGroup;
-			children = (
-				24743C72BA7EC046E88AF16E /* AddProductsOperator.swift */,
-				719BEEC0C3F6E63F9542A153 /* RawResponseOperator.swift */,
-			);
-			path = Operators;
-			sourceTree = "<group>";
-		};
-		A7F9D2B6E44E7A6F56EBB91D /* Model */ = {
-			isa = PBXGroup;
-			children = (
-				2697574309A971468AC12635 /* TriggerSession.swift */,
-				544F99BB5858C75E3220B4EB /* TriggerSessionPaywall.swift */,
-				368931F3E7FD5474629096FB /* TriggerSessionProducts.swift */,
-				795994FDA7117CE7438E4D0E /* Transaction */,
-				54E5CCF4FCDD6A7A5097B527 /* Trigger */,
-			);
-			path = Model;
-			sourceTree = "<group>";
-		};
-		ABD3E9ED02195BE3960B7A33 /* Paywall Presentation */ = {
-			isa = PBXGroup;
-			children = (
-				A661F501E8C4FD0EA0D6C35F /* UIKit */,
-			);
-			path = "Paywall Presentation";
-			sourceTree = "<group>";
-		};
-		ADFF20387DA4BCA7FE575231 /* Transactions */ = {
-			isa = PBXGroup;
-			children = (
-				4641647787524DB540D4969B /* RestorationHandler.swift */,
-				9B7237D632C045D7FD585EC4 /* Sk1TransactionObserver.swift */,
-				FD9DCF41F38A46DEDB3AD663 /* Sk2TransactionObserver.swift */,
-				D4D811522FFC29BB16F367FF /* TransactionErrorLogic.swift */,
-				9269654937F069D15D5112CE /* TransactionManager.swift */,
-				FB877474D041ADD8CEC868B8 /* Transaction Recorder */,
-			);
-			path = Transactions;
+			path = StoreProduct;
 			sourceTree = "<group>";
 		};
 		AE7A07F03C028F373EFE1409 /* Models */ = {
@@ -1389,7 +1797,6 @@
 				B40D6FA6547CB5B9520B0B64 /* SessionEventsRequest.swift */,
 				E3BFF03C1812D7239003448A /* Stubbable.swift */,
 				FDE615F75C33C2B386199444 /* Assignment */,
-				6BCBA25EC6544B8A42C0E12E /* Config */,
 				46CEF77B52399F8A27F8452F /* Events */,
 				068A223BBB54F9127201504F /* Paywall */,
 				67DBEF230C3E8EECA007FC2E /* Postback */,
@@ -1401,6 +1808,24 @@
 			path = Models;
 			sourceTree = "<group>";
 		};
+		AEF92489C827187888EA0370 /* Validation */ = {
+			isa = PBXGroup;
+			children = (
+				DFE7B1045C0541E66A965FC1 /* IARError.swift */,
+				498D6155C2B8B18E7F3D0E79 /* Validation.swift */,
+			);
+			path = Validation;
+			sourceTree = "<group>";
+		};
+		AF6F5F7F77820487CA98B6CA /* Operators */ = {
+			isa = PBXGroup;
+			children = (
+				83A6A722D119902A42DC2737 /* AddPaywallProducts.swift */,
+				B5637C2D7DDA38C11E48DD1C /* RawPaywallResponse.swift */,
+			);
+			path = Operators;
+			sourceTree = "<group>";
+		};
 		B26ABA960333F1BE7CAF7FAF /* Config */ = {
 			isa = PBXGroup;
 			children = (
@@ -1408,6 +1833,15 @@
 				355B043004EA75053A0524DD /* ConfigResponseTests.swift */,
 			);
 			path = Config;
+			sourceTree = "<group>";
+		};
+		B2C3E282003472D3326477C4 /* Internal Presentation */ = {
+			isa = PBXGroup;
+			children = (
+				7F4EC7B3BCFACD602B9BFA41 /* InternalPresentationLogicTests.swift */,
+				5E1272F6F935DC1417B03A9F /* Operators */,
+			);
+			path = "Internal Presentation";
 			sourceTree = "<group>";
 		};
 		B5768D312352E16D6AC021D2 /* Custom URL Session */ = {
@@ -1419,6 +1853,16 @@
 			path = "Custom URL Session";
 			sourceTree = "<group>";
 		};
+		B8233519DFC91F5DB62827F7 /* Session Events */ = {
+			isa = PBXGroup;
+			children = (
+				21B510F7222F3E052A862A66 /* MockSessionEventsQueue.swift */,
+				C601D23DAA4F0CE7078FD77F /* SessionEventsDelegateMock.swift */,
+				3EC6869BE9279D725C1F822E /* SessionEventsManagerTests.swift */,
+			);
+			path = "Session Events";
+			sourceTree = "<group>";
+		};
 		B95C41E4499A61EDED234DEF /* Migration */ = {
 			isa = PBXGroup;
 			children = (
@@ -1427,23 +1871,23 @@
 			path = Migration;
 			sourceTree = "<group>";
 		};
-		B96921E9952FBCE4E71BA10C /* Presentation Request */ = {
+		BE0950BAE176C25A01316744 /* Models */ = {
 			isa = PBXGroup;
 			children = (
-				9F25D59E046C6483853DDE7D /* PaywallOverrides.swift */,
-				9DE5293C9C76FBE2A418AE67 /* PresentationInfo.swift */,
-				AB817B50385C1C04C49E277B /* PresentationRequest.swift */,
+				D3E5C31CEEDC9C2853D91C50 /* DeviceTemplate.swift */,
+				7553D295A9E169B45FAC1477 /* FreeTrialTemplate.swift */,
+				2B430DE1BA468E280567F03C /* ProductTemplate.swift */,
+				9B75209DF76859131941CA0F /* Variables.swift */,
 			);
-			path = "Presentation Request";
+			path = Models;
 			sourceTree = "<group>";
 		};
-		BED3691458781AFD20950387 /* Assignments */ = {
+		C0D3F44546D33F8AA71A79B9 /* Mocks */ = {
 			isa = PBXGroup;
 			children = (
-				8258E9C6F333EB19A7695EB9 /* AssignmentLogic.swift */,
-				64B8492049AD533A81454E90 /* Expression Evaluator */,
+				D5BF66C3986E287B7B2F5E27 /* SKProductSubscriptionPeriodMock.swift */,
 			);
-			path = Assignments;
+			path = Mocks;
 			sourceTree = "<group>";
 		};
 		C0D5D5E0E82C83BF2BF1654D /* Array */ = {
@@ -1455,50 +1899,66 @@
 			path = Array;
 			sourceTree = "<group>";
 		};
-		C14C7F1DC0E6201AE8E7D3AB /* Config */ = {
-			isa = PBXGroup;
-			children = (
-				762D43B5A353A6871C058792 /* ConfigLogic.swift */,
-				4ADB18BDD8A9BF03BDE396C0 /* ConfigManager.swift */,
-				BED3691458781AFD20950387 /* Assignments */,
-				4B9961AAC21F8B221FEA42BA /* Options */,
-			);
-			path = Config;
-			sourceTree = "<group>";
-		};
 		C1B0B520B9B41EFC6141B0BF /* SuperwallKitTests */ = {
 			isa = PBXGroup;
 			children = (
 				FE0E783785F917188D12F4B4 /* Utils.swift */,
-				A42A5AD2E2BE079CBB9FA0D5 /* App Session */,
+				E338A5AE4BB82E592AE9B9BA /* Analytics */,
+				D554340BB6652F5FA1F21FF8 /* Config */,
+				38C02C19ED9C9958A7A61FB1 /* Debug */,
+				E9FF04AB866B9CCA7DFBE592 /* Dependencies */,
+				373AFF230833A951B6E5DF36 /* Identity */,
+				8DD7B7C5E111EAB0878886B6 /* Logger */,
 				4D7656D6A565958F58A644AF /* Misc */,
 				2AF21BD63950D63A4F96F6C6 /* Models */,
 				14F8842196EB2B1F82B3E024 /* Network */,
+				86DD4496D1218324B5CBBB89 /* Paywall */,
 				A1EF6DDE57A911501DFB2B4D /* Storage */,
-				52E46A3CB182D81370F207E4 /* Superwall */,
+				0FCC395C1553C4B0C3A69E1A /* StoreKit */,
 			);
 			path = SuperwallKitTests;
 			sourceTree = "<group>";
 		};
-		C3021B0F2C69C77754B46FF3 /* Receipt Manager */ = {
+		C262D74444D7EF5F2701EC6A /* Models */ = {
 			isa = PBXGroup;
 			children = (
-				EFBFA0E9940718D6F8B28EE5 /* ReceiptLogic.swift */,
-				3BEE62C0226A4AD750011CFD /* ReceiptManager.swift */,
-				1DD90B7ABCBFF411CEBAC413 /* Receipt Payload Models */,
+				51445FD3A0C38C2B502EAF1D /* ComputedPropertyRequest.swift */,
+				F98F66F7AA2F9F3E96849D8A /* Config.swift */,
+				28A1C8B0D79B8AC70ECF0CBB /* ConfigState.swift */,
+				83416F0F1B5294C350D5CF70 /* FeatureFlags.swift */,
+				24B8D7F537204EAB13BB7F10 /* FeatureGatingBehaviour.swift */,
+				67C4FC41FEE0B47EA402D738 /* LocalizationConfig.swift */,
+				5283BA49E380740C34D78856 /* OnDeviceCaching.swift */,
+				ECEF5CE080936CBEDE201F13 /* PaywallConfig.swift */,
+				46D2598EB46E9A27E2BD5104 /* PreloadingDisabled.swift */,
 			);
-			path = "Receipt Manager";
+			path = Models;
 			sourceTree = "<group>";
 		};
-		C95694BAD44C0A2088F0A187 /* Delegate */ = {
+		C36C5C30F60C1DFCDCF25E16 /* Graveyard */ = {
 			isa = PBXGroup;
 			children = (
-				7334CD5C8989BE285765BC3E /* PurchaseResult.swift */,
-				0897A9C4AC47DEE2F0FB20D4 /* SuperwallDelegate.swift */,
-				EA1DF58EB09E500977460E0E /* SuperwallDelegateAdapter.swift */,
-				120AB0D996202873DA53A667 /* SuperwallDelegateObjc.swift */,
+				D36898353ABCE620BA7AEE59 /* SuperwallGraveyard.swift */,
 			);
-			path = Delegate;
+			path = Graveyard;
+			sourceTree = "<group>";
+		};
+		C5DBF410102721FC5D440DF8 /* Mocks */ = {
+			isa = PBXGroup;
+			children = (
+				296A4AFE25C5E55DC5DD207D /* MockIntroductoryPeriod.swift */,
+				A5C4AD6349F2D432132F36D5 /* MockSubscriptionPeriod.swift */,
+			);
+			path = Mocks;
+			sourceTree = "<group>";
+		};
+		C800729D322B65BAD6FB3668 /* Request */ = {
+			isa = PBXGroup;
+			children = (
+				8A7140A8B0B006F2080D8915 /* PaywallLogicTests.swift */,
+				C5DBF410102721FC5D440DF8 /* Mocks */,
+			);
+			path = Request;
 			sourceTree = "<group>";
 		};
 		C9D58EBCE1AAA5A622269EB8 /* UIViewController */ = {
@@ -1511,21 +1971,12 @@
 			path = UIViewController;
 			sourceTree = "<group>";
 		};
-		CAD5EB9046BC41F6685C38A1 /* Internal Tracking */ = {
-			isa = PBXGroup;
-			children = (
-				31BFC6917BDCE905B903E8FE /* OccurrenceLogicTests.swift */,
-				AF09F3137AD182B8B4AF8BFC /* TrackingLogicTests.swift */,
-			);
-			path = "Internal Tracking";
-			sourceTree = "<group>";
-		};
 		CD5624E84B39A2D8EC0A4E96 /* Core Data */ = {
 			isa = PBXGroup;
 			children = (
 				0E3AC3B23DAAA8C1D125BDD3 /* CoreDataManager.swift */,
 				50458143450675EF205CE2C3 /* CoreDataStack.swift */,
-				E36770FA7C30179E09D62489 /* Model.xcdatamodeld */,
+				EC51351CA716C5C3B71E2FA1 /* SuperwallKit_Model.xcdatamodeld */,
 				2DAF3427CF469F5373C2BFD7 /* Managed Models */,
 			);
 			path = "Core Data";
@@ -1542,75 +1993,125 @@
 			path = "Core Data";
 			sourceTree = "<group>";
 		};
-		D3712D16D59DAD2F0AD98C4F /* Listeners */ = {
+		D13E0D5732177680FB43AA9F /* Internal Tracking */ = {
 			isa = PBXGroup;
 			children = (
-				7E33BFE573CD9D7C0BA05F7B /* HiddenListener.swift */,
-				04E8EB76AB037B3586240A4B /* PaddingListener.swift */,
+				2F6AFBC7C60A5074ACE8DF88 /* Tracking.swift */,
+				95ED8690E8B88125776BC247 /* TrackingLogic.swift */,
+				764012CF0C0972240A73E3CF /* TrackingParameters.swift */,
+				F85ED994DEC92BB90ACC6AC2 /* TrackingResult.swift */,
+				7FD9FD7878BD11B222C69278 /* Trackable Events */,
 			);
-			path = Listeners;
+			path = "Internal Tracking";
 			sourceTree = "<group>";
 		};
-		D86A09A9C682F6D518463C32 /* Products */ = {
+		D39A799D29B69CA09069877D /* StoreKit */ = {
 			isa = PBXGroup;
 			children = (
-				9DB8450EB537722D79EB8194 /* ProductsManager.swift */,
-				983AC5AC5E0DAF2B2938E45D /* StoreKitManager.swift */,
-				C3021B0F2C69C77754B46FF3 /* Receipt Manager */,
+				910786130E2D7EDE2ED5452D /* StoreKitManager.swift */,
+				052F4F31AEADDB2A94B69EE4 /* Abstractions */,
+				9EC210B9F15B56C4C9230BAD /* Coordinator */,
+				9D3A25014A0BEB0AB070F40C /* Products */,
+				F2B97376CC3325C950AC2F33 /* Transactions */,
 			);
-			path = Products;
+			path = StoreKit;
 			sourceTree = "<group>";
 		};
-		DAC8B81E81A101792B00B1E1 /* Paywall Cache Manager */ = {
+		D554340BB6652F5FA1F21FF8 /* Config */ = {
 			isa = PBXGroup;
 			children = (
-				F678F0A727A6D50A073DE6FE /* PaywallCache.swift */,
-				78868C8AC13F6AAE49391877 /* PaywallCacheLogic.swift */,
-				1C1382B972905BF5393D30B7 /* PaywallManager.swift */,
+				97D7F499B2CBFFF0A61F8D72 /* ConfigLogicTests.swift */,
+				DAAE50F011668C1D62B86751 /* ConfigManagerMock.swift */,
+				92A6B82F855E19B9C180C659 /* ConfigManagerTests.swift */,
+				9C4C1D13B7C7D97BE6ABFEA9 /* Assignments */,
 			);
-			path = "Paywall Cache Manager";
+			path = Config;
 			sourceTree = "<group>";
 		};
-		E03A29FB5FB7F20FF55015BD /* Identity */ = {
+		D6A7BE39310E37ABB4B36343 /* Presentation */ = {
 			isa = PBXGroup;
 			children = (
-				A981B0C90E5F0E40187C0310 /* IdentityError.swift */,
-				60A486DE7BE9D8DAE69BFF2E /* IdentityLogic.swift */,
-				C8AA3BB9F834B8758CB45DD2 /* IdentityManager.swift */,
-				4955958DB59356ABF25A5D4F /* PublicIdentity.swift */,
-				166374D62DB0AE4E759F2CA4 /* UserAttributes.swift */,
+				C36308E59620C724F701B803 /* PaywallCloseReason.swift */,
+				299441C3A6D3948BC5E0C741 /* PaywallInfo.swift */,
+				6B9E9E16EBDA97E736968496 /* PaywallPresentationHandler.swift */,
+				852DB0D6CF864AE3433EF7F9 /* PresentationErrors.swift */,
+				E23F2FE294EBC63F81786A85 /* PresentationItems.swift */,
+				01E54BC1CA38F828AC77F774 /* PublicPresentation.swift */,
+				5C796231D913B9C1E64B8EA3 /* Get Paywall */,
+				9CB6C2165B6C8E43C56CB151 /* Get Presentation Result */,
+				7C269C72AFB35BBAA962E69D /* Internal Presentation */,
+				8402810DFB45192BB3E7636B /* Rule Logic */,
 			);
-			path = Identity;
+			path = Presentation;
 			sourceTree = "<group>";
 		};
-		E349A6D46ADF5C503E47C0F6 /* Analytics */ = {
+		DD0CAA6BD586AC27A1F07806 /* Discount */ = {
 			isa = PBXGroup;
 			children = (
-				692A22164EF856F75B39764C /* SessionEventsManager.swift */,
-				723B2E9D1C844BC39A9B6488 /* SessionEventsQueue.swift */,
-				4E3F82D0E4031D991CE33A8C /* App Session */,
-				9FF92D974C2C3B52BE4783D8 /* Internal Tracking */,
-				5B047E5469DEEA72398F0759 /* Superwall Event */,
-				966C70C3FB35FE0C9C63B147 /* Trigger Session Manager */,
+				3C064AE76E6545B9595305D7 /* SK1StoreProductDiscount.swift */,
+				6CFA5F684C1732D79CBA2C49 /* SK2StoreProductDiscount.swift */,
+				2CB5E7278D5B95BC2EBC3474 /* StoreProductDiscount.swift */,
+				AFA4E94285A5E9430D48CB14 /* StoreProductDiscountType.swift */,
+			);
+			path = Discount;
+			sourceTree = "<group>";
+		};
+		DFCE4A0E8DD9BAF5609D57CE /* Presentation State */ = {
+			isa = PBXGroup;
+			children = (
+				4A41E45077BFED96FCC25457 /* PaywallSkippedReason.swift */,
+				6397684C0676181147C32AFB /* PaywallState.swift */,
+			);
+			path = "Presentation State";
+			sourceTree = "<group>";
+		};
+		E338A5AE4BB82E592AE9B9BA /* Analytics */ = {
+			isa = PBXGroup;
+			children = (
+				29EFE2945707407DD1377584 /* App Session */,
+				16BDE72FF436AB5439DCB69E /* Internal Tracking */,
+				B8233519DFC91F5DB62827F7 /* Session Events */,
+				8F8F663B2A11FC44292178F7 /* Trigger Session Manager */,
 			);
 			path = Analytics;
 			sourceTree = "<group>";
 		};
-		E7D9D0A1EBFBAA5BD7101FA1 /* Model */ = {
+		E36E6C0CB40C3F44423C80CF /* Receipt Manager */ = {
 			isa = PBXGroup;
 			children = (
-				33BB1232A536B665B0C33E09 /* TransactionModel.swift */,
-				6B8D19C18FFC8A968902F554 /* TransactionPayment.swift */,
+				C0A53CC571B7BC3F5AAD71BF /* ReceiptLogic.swift */,
+				0741078E82A1B595D71D13E0 /* ReceiptManager.swift */,
+				649EA1E5386E4FED85A7B338 /* ASN1Swift */,
+				F84F8DE67672A365D2DB6AD3 /* Receipt Models */,
+				AEF92489C827187888EA0370 /* Validation */,
 			);
-			path = Model;
+			path = "Receipt Manager";
 			sourceTree = "<group>";
 		};
-		EB16FEB8B0FE549F4DC39BAF /* Transactions */ = {
+		E4C1D2384C6CAD193D3CE652 /* Templating */ = {
 			isa = PBXGroup;
 			children = (
-				FEA69FDA521EC78AB76BFAAF /* Transaction Recorder */,
+				C2E541F079BC78206BC44D6E /* TemplateLogic.swift */,
+				BE0950BAE176C25A01316744 /* Models */,
 			);
-			path = Transactions;
+			path = Templating;
+			sourceTree = "<group>";
+		};
+		E7D208EAB24A633EB74B1E31 /* Options */ = {
+			isa = PBXGroup;
+			children = (
+				B1A64CCBCB23CC1715DF79AC /* PaywallOptions.swift */,
+				CFDA311A030FDFC45AEE248A /* SuperwallOptions.swift */,
+			);
+			path = Options;
+			sourceTree = "<group>";
+		};
+		E9FF04AB866B9CCA7DFBE592 /* Dependencies */ = {
+			isa = PBXGroup;
+			children = (
+				07B04D40ECF8BAFFC0CA9F26 /* StoreKitCoordinatorFactoryMock.swift */,
+			);
+			path = Dependencies;
 			sourceTree = "<group>";
 		};
 		ED389E60F716C417202738F0 /* Misc */ = {
@@ -1619,10 +2120,9 @@
 				EEE0510BC2F7917AA57B896D /* AlertControllerFactory.swift */,
 				643A346628DA026FEA092C27 /* ButtonFactory.swift */,
 				42956918D4FFA5FBA79F3AA5 /* Constants.swift */,
-				9152116E6A842164DB3339DE /* ConvenienceFunctions.swift */,
-				0B0EE285A4202B015060049B /* Debug.swift */,
 				2E2027BFC214905CBE589AF2 /* KeypathWritable.swift */,
 				19F010DC597017F5BEAEDE86 /* SwiftyJSON.swift */,
+				62EC6A60945A85646E1230C1 /* ThrowableDecodable.swift */,
 				848592ACE8760E53F2163F01 /* Typealiases.swift */,
 				A1B28DB5B07A66105FE6B0A7 /* Data Structures */,
 				3547E09D300E2C1E5D42FD60 /* Extensions */,
@@ -1630,36 +2130,29 @@
 			path = Misc;
 			sourceTree = "<group>";
 		};
-		ED56553A92D0D031F6D62A0D /* Web View */ = {
-			isa = PBXGroup;
-			children = (
-				EFACE6CE4DAE20FB9863302E /* SWWebView.swift */,
-				4DD18814E637A4001354FDAD /* Message Handling */,
-				40BEEC55601E9330E4BA0207 /* Templating */,
-			);
-			path = "Web View";
-			sourceTree = "<group>";
-		};
 		EDFD560CA72266982EE04681 /* Network */ = {
 			isa = PBXGroup;
 			children = (
-				F915C5C4DDA15706C36E58C4 /* APIs.swift */,
-				6873BA70C13AB08F307AA972 /* DeviceHelper.swift */,
+				CD9298A79020030E9A1357A6 /* API.swift */,
 				258FC2DB67022EF3D9B1FB67 /* Endpoint.swift */,
 				79E2143AD65D151AE7A4BF0F /* Network.swift */,
 				07E6639F9A75A887A9B3398E /* Custom URL Session */,
+				1F29B244553BD815519B80A9 /* Device Helper */,
 			);
 			path = Network;
 			sourceTree = "<group>";
 		};
-		EFF8D95BD42097532BEB7A62 /* Presentation State */ = {
+		F2B97376CC3325C950AC2F33 /* Transactions */ = {
 			isa = PBXGroup;
 			children = (
-				A584F8FE6F1C4B3ACC0AFACC /* PaywallDismissedResult.swift */,
-				BF03C89BD8E474D8F539C181 /* PaywallSkippedReason.swift */,
-				767385007521EEE45C1F4D76 /* PaywallState.swift */,
+				448D7B7B467CBA2A4359E3F4 /* NotificationScheduler.swift */,
+				CC171FFE5F68BD457364481A /* RestorationManager.swift */,
+				76A719AD2F4475F83DFC9575 /* TransactionErrorLogic.swift */,
+				646E6799FE4934BF76A06F34 /* TransactionManager.swift */,
+				6AB850ECCAF10AF0C1AF66F9 /* TransactionVerifierSK2.swift */,
+				118B5EF9AC7A21C2AFA1DED1 /* Purchasing */,
 			);
-			path = "Presentation State";
+			path = Transactions;
 			sourceTree = "<group>";
 		};
 		F2F75130AF54DFC4C7FA839A /* Extensions */ = {
@@ -1678,24 +2171,38 @@
 			path = Sources;
 			sourceTree = "<group>";
 		};
-		FAF32EA90EE4CADC39AED611 /* Paywall Request */ = {
+		F4AE7105F72063122615EFF1 /* Message Handling */ = {
 			isa = PBXGroup;
 			children = (
-				C6E8278A89BA67AE4FF032DB /* PaywallLogic.swift */,
-				1DE6A6C484F28CD71BEA78B0 /* PaywallRequest.swift */,
-				3660DCD99EE318F7A12FE16F /* PaywallRequestManager.swift */,
-				A7F7D993A4070FCDE4B17AFB /* Operators */,
+				CC653A44D9B40812BDDD94E7 /* PaywallMessage.swift */,
+				BF61DCA9CF170E0AFC507BAE /* PaywallMessageHandler.swift */,
+				260AE52B33B132D5A5C04911 /* PaywallWebEvent.swift */,
+				0C39015ED9E8F5D9F0F78F1E /* RawWebMessageHandler.swift */,
 			);
-			path = "Paywall Request";
+			path = "Message Handling";
 			sourceTree = "<group>";
 		};
-		FB877474D041ADD8CEC868B8 /* Transaction Recorder */ = {
+		F84F8DE67672A365D2DB6AD3 /* Receipt Models */ = {
 			isa = PBXGroup;
 			children = (
-				4A1AAD9CA30CFB266D26F7C7 /* TransactionRecorder.swift */,
-				E7D9D0A1EBFBAA5BD7101FA1 /* Model */,
+				AF0A461D50AF945239D3D048 /* InAppPurchase.swift */,
+				0695B39826F85AACBA833B77 /* InAppReceipt.swift */,
+				9E80C81546752BCF32016A27 /* InAppReceipt+ASN1.swift */,
+				B9553EC1E394EF7AE8788291 /* InAppReceiptAttribute.swift */,
+				072886BB8C0E08DF414D9162 /* InAppReceiptPayload.swift */,
+				862888AB2869D09AA55A017D /* InAppReceiptPayloadContainer.swift */,
 			);
-			path = "Transaction Recorder";
+			path = "Receipt Models";
+			sourceTree = "<group>";
+		};
+		FD8F67EFF69ECDBE85EB24F5 /* Message Handling */ = {
+			isa = PBXGroup;
+			children = (
+				F798D9662212AD1CC75666F3 /* PaywallMessageHandlerDelegateMock.swift */,
+				B45A6006E4299E75E91CC2ED /* PaywallMessageHandlerTests.swift */,
+				EC91544C3B7D209A8D51397F /* RawWebMessageHandlerTests.swift */,
+			);
+			path = "Message Handling";
 			sourceTree = "<group>";
 		};
 		FDE615F75C33C2B386199444 /* Assignment */ = {
@@ -1708,13 +2215,11 @@
 			path = Assignment;
 			sourceTree = "<group>";
 		};
-		FEA69FDA521EC78AB76BFAAF /* Transaction Recorder */ = {
+		"TEMP_89BC623C-3735-4CC4-AA1A-3C36C0A6D055" /* Events */ = {
 			isa = PBXGroup;
 			children = (
-				91B2F0F10B6207B5092AC539 /* MockSKPaymentTransaction.swift */,
-				82D71435A6AFB8E6599B1B20 /* TransactionRecorderTests.swift */,
 			);
-			path = "Transaction Recorder";
+			path = Events;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -1734,6 +2239,7 @@
 			);
 			name = SuperwallKit;
 			packageProductDependencies = (
+				5BE89F371D9B5971F3271921 /* ASN1Swift */,
 			);
 			productName = SuperwallKit;
 			productReference = 04FB15C76DE3D22CB370AFDB /* SuperwallKit.framework */;
@@ -1754,6 +2260,7 @@
 			);
 			name = SuperwallKitTests;
 			packageProductDependencies = (
+				36F71E474FE3523EF5DBADB3 /* ASN1Swift */,
 			);
 			productName = SuperwallKitTests;
 			productReference = 92001AC11F099F7B03AF338A /* SuperwallKitTests.xctest */;
@@ -1766,6 +2273,8 @@
 			isa = PBXProject;
 			attributes = {
 				LastUpgradeCheck = 1200;
+				TargetAttributes = {
+				};
 			};
 			buildConfigurationList = B7BB212B66F694F1FDA2FA4F /* Build configuration list for PBXProject "SuperwallKit" */;
 			compatibilityVersion = "Xcode 10.0";
@@ -1777,6 +2286,7 @@
 			);
 			mainGroup = 5CE8CEF97A892FFF3D0D8F06;
 			packageReferences = (
+				6A0AB63DCE10E48A17E4F411 /* XCRemoteSwiftPackageReference "ASN1Swift" */,
 			);
 			projectDirPath = "";
 			projectRoot = "";
@@ -1792,7 +2302,9 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				0FAA671AB9474D156FF539C2 /* Assets.xcassets in Resources */,
+				7A1519F9AAF8CA9914E9C5C8 /* AppleIncRootCertificate.cer in Resources */,
+				52973FEBBC4D2E753F673859 /* Assets.xcassets in Resources */,
+				3D3011B55A86A504B91EDA44 /* StoreKitTestCertificate.cer in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1803,16 +2315,21 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				8BB27D953027025A087227EB /* AppSessionLogicTests.swift in Sources */,
-				027D79A608E75E7634525785 /* AppSessionManagerMock.swift in Sources */,
-				06BD78BAAA64F0EDAE5C944E /* AppSessionManagerTests.swift in Sources */,
-				49589ABCD4E7BBB1D8A853A5 /* AssignmentLogicTests.swift in Sources */,
+				9B49485A1CFAC2621A89B150 /* AppSessionLogicTests.swift in Sources */,
+				1E81A71ADE8A5EAD9E609E1D /* AppSessionManagerMock.swift in Sources */,
+				E2E0E2A82200943E73E3A92A /* AppSessionManagerTests.swift in Sources */,
+				59685CE55D34FA6A96A8F890 /* AssignmentLogicTests.swift in Sources */,
 				11C591E04AF6C3814A986463 /* CacheMock.swift in Sources */,
-				D26CB433B7DCC1C59CFAFE4F /* ConfigLogicTests.swift in Sources */,
-				F96AE1AC5DA8C2F5FBF7E35D /* ConfigManagerMock.swift in Sources */,
-				261FC6DA888DD3E8151A8D3B /* ConfigManagerTests.swift in Sources */,
+				2A07A8F4A55E28D13777D03E /* CheckDebuggerPresentationOperatorTests.swift in Sources */,
+				113402664781E7374E583FAA /* CheckPaywallPresentableOperatorTests.swift in Sources */,
+				6B3DA52EEC1753FC97B1BE5C /* CheckUserSubscriptionOperatorTests.swift in Sources */,
+				A73497BB3DCD881318A5CD86 /* ConfigLogicTests.swift in Sources */,
+				63CED0C62636A9FD03B7315A /* ConfigManagerMock.swift in Sources */,
+				FCD7C16E35F139DCC2386B91 /* ConfigManagerTests.swift in Sources */,
 				BCF808C7AC319C2B1F0AD52D /* ConfigResponseLogicTests.swift in Sources */,
 				E63BD2E9AA7F1CCC70C889D5 /* ConfigResponseTests.swift in Sources */,
+				AE1D15070BC159212967CAD4 /* ConfirmHoldoutAssignmentTests.swift in Sources */,
+				61EC2A032D127B323D4A8124 /* ConfirmPaywallAssignmentOperatorTests.swift in Sources */,
 				AEAB0C0C168B0B3D864109EA /* CoreDataManagerFakeDataMock.swift in Sources */,
 				A1621A749D8F05959A486ACE /* CoreDataManagerMock.swift in Sources */,
 				C7AB21123540550E513AD28A /* CoreDataManagerTests.swift in Sources */,
@@ -1820,39 +2337,53 @@
 				85728EABBC5C73193AC5F876 /* CustomURLSessionMock.swift in Sources */,
 				D91750797BB4947F6975B2B9 /* Date+IsoStringTests.swift in Sources */,
 				0CA13E721ADB243882536D4A /* DeviceHelperMock.swift in Sources */,
-				167F63E5A828953F4B43720B /* ExpressionEvaluatorLogicTests.swift in Sources */,
-				C1F4379AB924DF559E8B1C23 /* ExpressionEvaluatorTests.swift in Sources */,
+				1225B991B40D16B7FB4EF1A5 /* EvaluateRulesOperatorTests.swift in Sources */,
+				BBCB4880B7BF29743FEC82EC /* ExpressionEvaluatorLogicTests.swift in Sources */,
+				5D9AC3A1B3B9DB379856E0A4 /* ExpressionEvaluatorTests.swift in Sources */,
 				AC7D527612F631AAADC7D225 /* FileManagerMigratorTests.swift in Sources */,
-				0F540F0364F986E183B1B3A8 /* IdentityLogicTests.swift in Sources */,
-				5E025C05CC8F758569CB2DFF /* IdentityManagerMock.swift in Sources */,
-				A9A569AE8B039F1BE950ADA4 /* InternalPresentationLogicTests.swift in Sources */,
-				E82B6B4AD270B08CA5F3244C /* MockIntroductoryPeriod.swift in Sources */,
-				06D0B71C6119B03B7CD25A1B /* MockReceiptData.swift in Sources */,
-				4D04FBD1B06BF7F41FBACE78 /* MockSKPaymentTransaction.swift in Sources */,
-				A452C13E1F76B7DD715C7470 /* MockSessionEventsQueue.swift in Sources */,
-				9CD675C5051BE4389835ADBB /* MockSkProduct.swift in Sources */,
-				AFE36A8062A6BAC8F2F1612E /* MockSubscriptionPeriod.swift in Sources */,
+				D4B5A9708204AB6D58904733 /* GetPaywallVcOperatorTests.swift in Sources */,
+				AF4AD928FACF9056E00D5920 /* HandleTriggerResultOperatorTests.swift in Sources */,
+				77EDD2927FF8DCF95579BE3E /* IdentityLogicTests.swift in Sources */,
+				D89E9C69317044050B97B573 /* IdentityManagerMock.swift in Sources */,
+				BDCB094C8EAC080EE35DDF0A /* InternalPresentationLogicTests.swift in Sources */,
+				4DE01655FC4CC148DD3D161C /* LoggerMock.swift in Sources */,
+				BA957415E2E1A38A25550B99 /* MockIntroductoryPeriod.swift in Sources */,
+				B2AB1E9283FDE2D544C8BCA8 /* MockReceiptData.swift in Sources */,
+				DCE85B4A9DBD672B658F6EB3 /* MockSKPaymentTransaction.swift in Sources */,
+				443C104A8DE35D192C11560F /* MockSessionEventsQueue.swift in Sources */,
+				F15479C499547FE1B47DEA6B /* MockSkProduct.swift in Sources */,
+				A51060CF6339BF9383F94B51 /* MockSubscriptionPeriod.swift in Sources */,
 				4EFA142D3D37B0564BDB52CB /* NetworkMock.swift in Sources */,
 				58185F7A0770111BDE259936 /* NetworkTests.swift in Sources */,
-				710357F3AD844D767E1620F6 /* OccurrenceLogicTests.swift in Sources */,
-				20E7F1EE5D48B95F3C35D0C0 /* PaywallCacheLogicTests.swift in Sources */,
-				38BA1F430BC3ED6B68946DF4 /* PaywallCacheTests.swift in Sources */,
-				821FBEF8A036815D6967C24B /* PaywallLogicTests.swift in Sources */,
-				947F5D924E73A70F4BACC910 /* PaywallTests.swift in Sources */,
-				775B0FD111BDDC7FD76FC62F /* ProductsManagerMock.swift in Sources */,
-				0836FF2D327E428E25B5A995 /* ReceiptManagerTests.swift in Sources */,
-				019397BB0BFA469A1F87C911 /* SWDebugManagerLogicTests.swift in Sources */,
-				97F9D03859ECD517B9F3B9EF /* SessionEventsDelegateMock.swift in Sources */,
-				F2F8B839FF59CE357067389F /* SessionEventsManagerTests.swift in Sources */,
+				A191F045B8A9EE2D4A3B757D /* OccurrenceLogicTests.swift in Sources */,
+				27E396F717A62BA4E0D98086 /* PaywallCacheLogicTests.swift in Sources */,
+				2205A0CC8F059B3D6231C603 /* PaywallLogicTests.swift in Sources */,
+				C5A1C6E1DB61246348A88768 /* PaywallManagerMock.swift in Sources */,
+				A138759EEB6B669C19FB5AFF /* PaywallMessageHandlerDelegateMock.swift in Sources */,
+				E0DA50D9E75BADFBBABB8768 /* PaywallMessageHandlerTests.swift in Sources */,
+				4B0E203D477E48611797047C /* PaywallViewControllerCacheTests.swift in Sources */,
+				5F1F480AA12C8D17B179D96B /* PaywallViewControllerMock.swift in Sources */,
+				3BE562844FD54486450CE6BB /* PresentPaywallOperatorTests.swift in Sources */,
+				68FF8D03BAD0F2BE33B9C976 /* ProductPurchaserSK1Tests.swift in Sources */,
+				A44BAE75AAE4713FAE38F992 /* ProductsFetcherSK1.swift in Sources */,
+				5EF4EE04BAA930A2CC4379A1 /* RawWebMessageHandlerTests.swift in Sources */,
+				3BA17B2DA6B69A7B90D39AF9 /* ReceiptManagerTests.swift in Sources */,
+				B8483A96A7AE8440AF1E0C3B /* SKProductSubscriptionPeriodMock.swift in Sources */,
+				E1A838C9CE62C9479D0C68F4 /* SWDebugManagerLogicTests.swift in Sources */,
+				3BB870FFD27F80A82E8924F4 /* SessionEventsDelegateMock.swift in Sources */,
+				4595C5ACC78639E77D4636A4 /* SessionEventsManagerTests.swift in Sources */,
 				919A08D7F25BD2DF27A22697 /* StorageMock.swift in Sources */,
-				31FA52BB6DD7DF9C3FFA13EB /* StoreKitManagerTests.swift in Sources */,
-				0CC2CEBF869822B7014B204F /* SuperwallLogicTests.swift in Sources */,
-				8DBFB47EABCD57AFC9C9946A /* TrackingLogicTests.swift in Sources */,
-				AED0F0AA92480E68279450A5 /* TransactionRecorderTests.swift in Sources */,
-				FE6C2F5C3BED509814DE2E58 /* TriggerSessionManagerLogicTests.swift in Sources */,
-				471AE92D554214DD3580FFFA /* TriggerSessionManagerTests.swift in Sources */,
+				AC821D5E03C0C97DEE9BA7BD /* StoreKitCoordinatorFactoryMock.swift in Sources */,
+				701B1B586B6C1E3F0B3AF560 /* StoreKitManagerTests.swift in Sources */,
+				F5F8C2E02A057DA15C2936AB /* StorePresentationObjectsOperatorTests.swift in Sources */,
+				14D8827BA663A0EFD64DEC2C /* TemplateLogicTests.swift in Sources */,
+				4AA4E2CE223DC7CF1678E83C /* TrackTests.swift in Sources */,
+				9304297F3B76DB512F2F9D53 /* TrackingLogicTests.swift in Sources */,
+				F1C87596E2893379C74907F6 /* TriggerSessionManagerLogicTests.swift in Sources */,
+				8C75B925E7ADDCCEA7740895 /* TriggerSessionManagerTests.swift in Sources */,
 				744F0D34C800E17CF8462820 /* URLSessionRetryLogicTests.swift in Sources */,
 				8B200F99B71D706D45948339 /* Utils.swift in Sources */,
+				6AB737FD60B729CE6F85E0A9 /* WaitToPresentOperatorTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1860,43 +2391,62 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				C28C9580007CDFF029DD665B /* APIs.swift in Sources */,
-				87DAD5B313899D1FD9F73B5E /* ActivityIndicatorView.swift in Sources */,
-				3F7E59BF0FCE58E5768C05EE /* AddProductsOperator.swift in Sources */,
+				822B2898CDD9C6E50816F62B /* API.swift in Sources */,
+				0E90E90DE890CC9B5B9AC02B /* ASN1Coder.swift in Sources */,
+				9F50FBB5826FF0A4ED075F26 /* ASN1Decoder+Extras.swift in Sources */,
+				A29904A22F5E10DB8D2AE241 /* ASN1Decoder+KeyedDecodingContainer.swift in Sources */,
+				8B58E4DC7A49D2DFB3CA1F7F /* ASN1Decoder+SingleValueContainer.swift in Sources */,
+				F79C378E19116B9312AE5873 /* ASN1Decoder+Unboxing.swift in Sources */,
+				81680E02D1693BF58E015C0C /* ASN1Decoder+UnkeyedDecodingContainer.swift in Sources */,
+				BBC0ADE1AAB3E8C2DC5E4F01 /* ASN1Decoder+Utils.swift in Sources */,
+				01F3133229388B9E69B10E4A /* ASN1Decoder.swift in Sources */,
+				BDBEE781EC4910025379F0B6 /* ASN1Serialization.swift in Sources */,
+				E95C8C0485512D77E37703C5 /* ASN1Templates.swift in Sources */,
+				2C7867867DDAD83E5856ECC9 /* ASN1Types.swift in Sources */,
+				5E05FDE4F45BD5B0DF6AFB9F /* ActivityIndicatorView.swift in Sources */,
+				90EE0190126A3BBA4661122E /* AddPaywallProducts.swift in Sources */,
 				14D4EA6EAA43647D24A9716A /* AlertControllerFactory.swift in Sources */,
-				E2C32146C9B1E9EA1E1143DC /* AppSession.swift in Sources */,
-				60C79DA10DD627D7A64FD3C2 /* AppSessionLogic.swift in Sources */,
-				BBEF040F3E72B3F8CC88ED72 /* AppSessionManager.swift in Sources */,
+				AE9F583082A5CDCE595BDA2D /* AppSession.swift in Sources */,
+				995FD66283C7B03D3B33DF89 /* AppSessionLogic.swift in Sources */,
+				E986B0CF98B8C09AAA961E94 /* AppSessionManager.swift in Sources */,
 				F8E799A3A83A2758D6EAA385 /* Array+Guarded.swift in Sources */,
 				B0B0AD9409CEFE7CA8225146 /* Array+SafeRemove.swift in Sources */,
 				2428529A6B2B6E873DEC22E8 /* Assignment.swift in Sources */,
-				9401F2546B9758A6797C9DF8 /* AssignmentLogic.swift in Sources */,
 				F63B1A0AB2214948A14C9F88 /* AssignmentPostback.swift in Sources */,
-				EBF18BE21B633EDC931C10B3 /* AwaitIdentityOperator.swift in Sources */,
-				E8B60A6F863B0F4FD6282F45 /* BottomPaddingAnimation.swift in Sources */,
+				8C3A81E3D75F027539933310 /* BottomPaddingAnimation.swift in Sources */,
 				90E9A3B2C922288C8A86BCC9 /* Bundle+Helpers.swift in Sources */,
-				4C3C20A6359DE80DDA07EF49 /* BundleHelper.swift in Sources */,
+				DE62F8E261EC7C60FBAAAE1D /* BundleHelper.swift in Sources */,
 				BADAD7DDF7A8F0460CBFF362 /* ButtonFactory.swift in Sources */,
 				B2B5684F46FB49AB9E3C1BE0 /* Cache.swift in Sources */,
 				53113582D4E7F54236FD493C /* CacheKeys.swift in Sources */,
-				95EF88822DDFE3BC83306969 /* CheckPaywallPresentableOperator.swift in Sources */,
-				53567ADDA1C3FE1AC646014A /* Config.swift in Sources */,
-				D87DFF2B47537836DB531474 /* ConfigLogic.swift in Sources */,
-				5DEE758BE8E42F90C7470264 /* ConfigManager.swift in Sources */,
-				461239E670BAE84A666A4E8F /* ConfirmAssignmentOperator.swift in Sources */,
+				9867958FEB6C268B7A213591 /* CheckDebuggerPresentation.swift in Sources */,
+				32555BD6BFE2017158E48F37 /* CheckNoPaywallAlreadyPresented.swift in Sources */,
+				101F81081753F2A151386EFA /* CheckSubscriptionStatus.swift in Sources */,
+				3B6A91035DE4D806BC420103 /* CheckUserSubscription.swift in Sources */,
+				309EC3675C7EF75050B076E7 /* ComputedPropertyRequest.swift in Sources */,
+				2C1CC812D17087B1CE54161A /* Config.swift in Sources */,
+				D4D09356A2650ED3F8D518EE /* ConfigLogic.swift in Sources */,
+				76CC2455A437DC1DB0F3424E /* ConfigManager.swift in Sources */,
+				98BFA6594FE9A9097AC5F88F /* ConfigState.swift in Sources */,
+				670829E4DF02F3BB60444B38 /* ConfirmHoldoutAssignment.swift in Sources */,
+				C06AC148BC549114D020152D /* ConfirmPaywallAssignment.swift in Sources */,
 				3ADCB411A734117FF37DDA39 /* ConfirmedAssignmentResponse.swift in Sources */,
 				DBF70D987418DD9EB504FBDE /* Constants.swift in Sources */,
-				B2082DF2D5D0069EA2757A4F /* ConvenienceFunctions.swift in Sources */,
+				51ED6FE7AC4B8EFB97D4B376 /* CoordinatorProtocols.swift in Sources */,
 				94908C7FD2227D917187FEEF /* CoreDataManager.swift in Sources */,
 				41EAF9340665BF7459B2C29C /* CoreDataStack.swift in Sources */,
 				9E21D97817B1BA97806283B3 /* CustomURLSession.swift in Sources */,
-				61BF8F296579B092CE533A8D /* DarkBlurredBackground.swift in Sources */,
-				9B5E4C60905A923EFD16D740 /* Date+IsoString.swift in Sources */,
-				236FD721BBCC20C9CC44D391 /* Debug.swift in Sources */,
-				D7D93432817570E25BEE3D9A /* DebuggerCheckerOperator.swift in Sources */,
+				E7FD108C357A816AF8BFBA47 /* DarkBlurredBackground.swift in Sources */,
+				C5EA22647EFADC126DC4BFE8 /* Date+IsoString.swift in Sources */,
+				B4C9FECB4894151E42A34F85 /* Date+TimeIntervalMilliseconds.swift in Sources */,
+				432FB2AE172725B4ED208416 /* DebugManager.swift in Sources */,
+				11FF1373BAAE0B019CE6AE21 /* DebugViewController.swift in Sources */,
 				73947C28195DF53EBD32EF45 /* Decimal+Rounding.swift in Sources */,
-				25FD4EA77E9D336E82E87727 /* DeviceHelper.swift in Sources */,
-				486B2E1BA64D50869DE4D696 /* DeviceTemplate.swift in Sources */,
+				B5AE7BCDCB6D49FC8493D55B /* DecodingError+Extensions.swift in Sources */,
+				3F4BE7ECC80EEA757454F9B6 /* DependencyContainer.swift in Sources */,
+				7FCDAF6C945FA04FC4C4E8E3 /* DeviceHelper.swift in Sources */,
+				191AA8FBBF617251EF6F8628 /* DeviceInfo.swift in Sources */,
+				3DCE95BAC148CCC7E6E7F608 /* DeviceTemplate.swift in Sources */,
 				84616856D40F775122FD9BF9 /* Dictionary+Cache.swift in Sources */,
 				C68EF5D7D3FD7E9FB2A95C47 /* Dictionary+Filter.swift in Sources */,
 				0911B1213899E3C4E1620119 /* Dictionary+Keys.swift in Sources */,
@@ -1904,111 +2454,151 @@
 				9EAE577E60052F5E1C7B9657 /* EmptyResponse.swift in Sources */,
 				CB1E11FB74879A29DD1C9EB1 /* Encodable+Dictionary.swift in Sources */,
 				11477D1EB60D1FDA32F5099A /* Endpoint.swift in Sources */,
+				B2842C329F0F9AAFC2040C35 /* EvaluateRules.swift in Sources */,
 				35597883CB038DBEE63E162B /* EventData.swift in Sources */,
 				211B94C3D7CEE3DEF10E5C79 /* EventsQueue.swift in Sources */,
 				F297363F2C4BFEE9D051D684 /* EventsRequest.swift in Sources */,
 				5FB78EB52A12BA704AD3AE31 /* EventsResponse.swift in Sources */,
-				2140649137BB5DE1EACC1B74 /* ExpressionEvaluator.swift in Sources */,
-				D2F18E95E1D1DCC3CFFD38F8 /* ExpressionEvaluatorLogic.swift in Sources */,
-				7146184F32B6CBB91A4474CA /* ExpressionEvaluatorParams.swift in Sources */,
-				2672C5705530C6C5242EBDE3 /* FeatureFlags.swift in Sources */,
+				412C74624BB8933162DAAC5F /* Experiment.swift in Sources */,
+				8B5AD068AF8D1CE959CC0D72 /* ExpressionEvaluator.swift in Sources */,
+				9552D9AC4CC00EC9630508D0 /* ExpressionEvaluatorParams.swift in Sources */,
+				C09B8BBB7002DA446E9F74E1 /* FactoryProtocols.swift in Sources */,
+				E0F3648081AB86077201EB5D /* FeatureFlags.swift in Sources */,
+				ED1C693657DA7FCBAE2DDDC6 /* FeatureGatingBehaviour.swift in Sources */,
 				767974DF68CE67AE2066E3D6 /* FileManagerMigrator.swift in Sources */,
-				850A43400768AEA8F173285C /* FreeTrialTemplate.swift in Sources */,
+				0A5EFFC920E6BB29814BD66B /* Foundation+ASN1Coder.swift in Sources */,
+				12D25E5674DF81B033C9659E /* FreeTrialTemplate.swift in Sources */,
 				D978EAD4FA4865B5E07BF03B /* Future+Async.swift in Sources */,
 				F958219E873CEF2A14079E22 /* GCControllerElement+buttonName.swift in Sources */,
-				30397EC05338A20D7EED99CB /* GameControllerEvent.swift in Sources */,
-				A0DA7968E68D48AAF593A2C0 /* GameControllerManager.swift in Sources */,
-				55623881B3106928D158F31A /* GetPaywallVcOperator.swift in Sources */,
-				425927D107115B9222564182 /* HandleTriggerOutcomeOperator.swift in Sources */,
-				8113C9A88414B6CA11476CF3 /* HiddenListener.swift in Sources */,
-				05469D2D28CC098F8497FFCF /* IdentityError.swift in Sources */,
-				D40D7F7DB3CDAA1360CA3B93 /* IdentityLogic.swift in Sources */,
-				5E00EFE0CB67691D55A151F0 /* IdentityManager.swift in Sources */,
-				6254D0B972C1A719FB78D1B3 /* InAppPurchase.swift in Sources */,
-				5EC3EF1FE5033E365E5A0A41 /* InAppReceiptAttribute.swift in Sources */,
-				83CA7ACD6AEE4D7BF81C588C /* InAppReceiptPayload.swift in Sources */,
-				B40F1FB68BB0FB6A1B46D17D /* InAppReceiptPayloadContainer.swift in Sources */,
-				3B3E0707096DF98E13E1D24B /* InternalPresentation.swift in Sources */,
-				4E8256BF3BEC5A3AE893AE4F /* InternalPresentationLogic.swift in Sources */,
+				803BFA630F96B638E3BDE715 /* GameControllerEvent.swift in Sources */,
+				D2E381B26362F434760F9AC0 /* GameControllerManager.swift in Sources */,
+				8544DEF9914769BCAE073DD5 /* GetExperiment.swift in Sources */,
+				5566DBCF96993C1E4D217F50 /* GetPaywallResult.swift in Sources */,
+				B1F2B0B6FF29C03A4C90636B /* GetPaywallVC.swift in Sources */,
+				6DC998F9CB808894AD3D41E8 /* GetPresentationResultLogic.swift in Sources */,
+				B238354BF9B5605366D0408E /* GetPresenter.swift in Sources */,
+				43EF1A9F46DECE0EECFD0368 /* HiddenListener.swift in Sources */,
+				2F33D9FC5A40496D6922CEBB /* IARError.swift in Sources */,
+				C9C5355AE4077E6A021F30FF /* IdentityInfo.swift in Sources */,
+				591DCE67E64C63AACFFB604B /* IdentityLogic.swift in Sources */,
+				67C020751429B5677D9A0727 /* IdentityManager.swift in Sources */,
+				FCF498808FF38EEC5E9895DB /* IdentityOptions.swift in Sources */,
+				7AD6B818E94D31DD9E1F67BB /* InAppPurchase.swift in Sources */,
+				22B3763157DF592D4E3B27A0 /* InAppReceipt+ASN1.swift in Sources */,
+				BD152F3BA0BC197A5C6C8CC1 /* InAppReceipt.swift in Sources */,
+				3CB65E105ADED11AEE69DEAF /* InAppReceiptAttribute.swift in Sources */,
+				2EBE499C9918DE5823659CD0 /* InAppReceiptPayload.swift in Sources */,
+				BCFF20903199DDDE379D81E0 /* InAppReceiptPayloadContainer.swift in Sources */,
+				D330BD5F814AC52E6D04C7E7 /* InternalGetPaywall.swift in Sources */,
+				AE0555AA0B433427E5D17309 /* InternalGetPresentationResult.swift in Sources */,
+				C39E9FF31A8943B772EBDCAA /* InternalPresentation.swift in Sources */,
+				F946296C5DD154BCF5C0B958 /* InternalPresentationLogic.swift in Sources */,
 				E63A7174E3B98690B073C373 /* JSONEncoder+Superwall.swift in Sources */,
 				5621A2D2FEC048847E22BF6C /* KeypathWritable.swift in Sources */,
 				88A5CA6515126BD3D09E0563 /* LimitedQueue.swift in Sources */,
 				68AF64973AC860BE2A41B8D4 /* LoadingInfo.swift in Sources */,
-				ADEDCF9F58A0742F3FE81D1B /* LoadingModel.swift in Sources */,
-				CEB30F92165CF9F526AB2E02 /* LoadingView.swift in Sources */,
-				94D9448CEA20F0BE74956D7C /* LoadingViewController.swift in Sources */,
-				2FE7B229B25CFE9A36EF7A2A /* LocalizationConfig.swift in Sources */,
+				3CF2307C2CB994D00A35FADD /* LoadingModel.swift in Sources */,
+				7DA2CF4C6FF5C8A1C44282E6 /* LoadingView.swift in Sources */,
+				D443CC56731E9A20E4F43F4C /* LoadingViewController.swift in Sources */,
+				999B569F8B14C4DF8FD5ACFF /* LocalNotification.swift in Sources */,
+				C90E075C3BEE92968BBC4E1B /* LocalizationConfig.swift in Sources */,
 				B84CA6014D8D6EF201DB3935 /* LocalizationGrouping.swift in Sources */,
 				7352E1493F1207737B393213 /* LocalizationLogic.swift in Sources */,
 				53227994995EA43A8CAFB0DA /* LocalizationManager.swift in Sources */,
 				749117DF0A2364453CCED102 /* LocalizationOption.swift in Sources */,
-				A8CB114A06AFAAB7420D88EA /* LogPresentationOperator.swift in Sources */,
+				2A6FD8DA68D888B413621772 /* LogErrors.swift in Sources */,
+				8F18BFB254E432BFBEAB1324 /* LogLevel.swift in Sources */,
+				4BEB01C5B5C5183511251D43 /* LogPresentation.swift in Sources */,
+				424F0357DA9A8BFBC6621047 /* LogScope.swift in Sources */,
+				6DCFC3B002082C9C2E1BBC67 /* Logger.swift in Sources */,
 				A1EE1654484802E9E08CC32E /* ManagedEventData.swift in Sources */,
 				234C1753A4606242CA765CA7 /* ManagedTriggerRuleOccurrence.swift in Sources */,
-				E937F2AB6D4C0E627F92489D /* Model.xcdatamodeld in Sources */,
+				E3DC0E7597234DC8CC508A33 /* MapSwiftErrors.swift in Sources */,
 				07862D18809FA5DEA95AE440 /* NSManagedObjectContext+mergeChanges.swift in Sources */,
 				2698874EEAE37BAECE7B8FD8 /* Network.swift in Sources */,
-				AFB9D5B24A0437C3A0A5F576 /* PaddingListener.swift in Sources */,
+				8F7AEBBA27B4278F55516CA7 /* NotificationScheduler.swift in Sources */,
+				4E5F1AB421E91E102B6D4800 /* OnDeviceCaching.swift in Sources */,
+				B7750B3709CE8073697C9A9C /* OpacityAnimation.swift in Sources */,
+				F75F5E1D503B9391ADD812EC /* PKCS7.swift in Sources */,
+				56408549E721E2ED524DEA35 /* PaddingListener.swift in Sources */,
 				F605AA51AB24B564D3A21B07 /* Paywall.swift in Sources */,
-				1115A2ED3A878282F00EEF29 /* PaywallCache.swift in Sources */,
-				39D4243678C35F8292A900FE /* PaywallCacheLogic.swift in Sources */,
-				6ECE340EEAE00D5CC93838D4 /* PaywallConfig.swift in Sources */,
-				1E94FABF1ED17AC6BCB133EE /* PaywallDismissedResult.swift in Sources */,
-				27E2E3782CCEE667F4FAFEBF /* PaywallGraveyard.swift in Sources */,
-				A40A57883A6ED18619244966 /* PaywallInfo.swift in Sources */,
-				D10C4C038D590A13EB6C1DFD /* PaywallLogic.swift in Sources */,
-				CFE9B0D5469664A8B34C1A63 /* PaywallManager.swift in Sources */,
-				D02157DA630A977D57B55EFD /* PaywallMessage.swift in Sources */,
-				3D16647EEC0AA822A8624EC0 /* PaywallMessageHandler.swift in Sources */,
-				1D6788C9CE2B4B4BC68EC359 /* PaywallOptions.swift in Sources */,
-				18754C1CF4D038E4B6961FFB /* PaywallOverrides.swift in Sources */,
+				9E0E10B5F04756D2B2DEB478 /* PaywallCacheLogic.swift in Sources */,
+				2D751F5C2F463DEEF0A49B42 /* PaywallCloseReason.swift in Sources */,
+				FCC6EF5807B709E920901174 /* PaywallConfig.swift in Sources */,
+				20DD915D754F7819C44A677F /* PaywallInfo.swift in Sources */,
+				480C37A4D7A8AB5EE0760BF1 /* PaywallLogic.swift in Sources */,
+				09AA071B4A67A6256D00BDD6 /* PaywallManager.swift in Sources */,
+				EB6540A8E1ECC3548C5E6368 /* PaywallMessage.swift in Sources */,
+				1F20D775BC035F8A75B79323 /* PaywallMessageHandler.swift in Sources */,
+				FCEF5A897E34F9B7AB691C56 /* PaywallOptions.swift in Sources */,
+				86D668D3851219380D12C58D /* PaywallOverrides.swift in Sources */,
+				E41B3EF729D9896C7E0FD10C /* PaywallPresentationHandler.swift in Sources */,
+				848B586F9024F10C52EF3B10 /* PaywallPresentationRequestStatus.swift in Sources */,
 				A2DC9FA3045DF056BC867D8B /* PaywallPresentationStyle.swift in Sources */,
 				CF3683E2AD703237EC0CE22E /* PaywallProducts.swift in Sources */,
-				CC4E746146D0A074392B7075 /* PaywallRequest.swift in Sources */,
+				8EC4001F5273FB1260618E84 /* PaywallRequest.swift in Sources */,
 				D461F38D019122194A9CB38C /* PaywallRequestBody.swift in Sources */,
-				DE46586224545C5B2AD41372 /* PaywallRequestManager.swift in Sources */,
-				EBD60DFCBEDFE311EDE63EA1 /* PaywallSkippedReason.swift in Sources */,
-				779B63AAD57260CF12FF2DFF /* PaywallState.swift in Sources */,
-				C6D63D3FA9D015DB03AA7416 /* PaywallViewController.swift in Sources */,
-				2DA159644BAD6737FD1996CE /* PaywallWebEvent.swift in Sources */,
+				BFBE808BCA151FAE95AE3276 /* PaywallRequestManager.swift in Sources */,
+				3CF6274768E338E617B58D6D /* PaywallSkippedReason.swift in Sources */,
+				07A6A1A089289D8C618F9DCD /* PaywallState.swift in Sources */,
+				00A15C51FC3B450A7B0F8806 /* PaywallViewController.swift in Sources */,
+				D56F32CB484F74EC7E49E581 /* PaywallViewControllerCache.swift in Sources */,
+				BE5BE4ECDE6505182DD92AA1 /* PaywallViewControllerDelegate.swift in Sources */,
+				B10030CC414C2C341487F4B8 /* PaywallViewControllerDelegateAdapter.swift in Sources */,
+				BF9ADF5761C34F584EC416B1 /* PaywallWebEvent.swift in Sources */,
 				C6747B1CFCA4C7D96D61649E /* Postback.swift in Sources */,
 				72FAD5E490B233658EDACC98 /* PostbackRequest.swift in Sources */,
-				A30B59DD743B66099D59DAEA /* PresentPaywallOperator.swift in Sources */,
+				30113C71D033ADDF01214C75 /* PreloadingDisabled.swift in Sources */,
+				9A4B85F1BC220968C8A42666 /* PresentPaywall.swift in Sources */,
 				B81474E6A0850E9951407926 /* PresentationCondition.swift in Sources */,
-				117DA7A3104B6B72E57AB526 /* PresentationInfo.swift in Sources */,
-				59B43621B2A93A3364C037D9 /* PresentationPipelineError.swift in Sources */,
-				A041F20F420D00BF53B5C0C9 /* PresentationRequest.swift in Sources */,
+				C583E63E93F418B8119FE2F1 /* PresentationErrors.swift in Sources */,
+				B49D61F76B0A35E5B6B01B9D /* PresentationInfo.swift in Sources */,
+				4EF50815E31F85400513F053 /* PresentationItems.swift in Sources */,
+				79FDB7149265B9F164ACEB6F /* PresentationRequest.swift in Sources */,
+				F5FBA532DB79848B0537720F /* PresentationResult.swift in Sources */,
+				9D919E6F6A12252033CFF813 /* PresentationValueObjc.swift in Sources */,
+				420A0086B6063248C101ED0A /* PriceFormatterProvider.swift in Sources */,
 				1386E66C93D643CAB36FA920 /* Product.swift in Sources */,
-				C1BA23CFF665B9D36AB6CC34 /* ProductPeriod.swift in Sources */,
-				EA42211867A18EC544172EC2 /* ProductPrice.swift in Sources */,
-				B58139A668F6E6A5B9546EB3 /* ProductTemplate.swift in Sources */,
-				23DF76717931E199DDE7375A /* ProductTrial.swift in Sources */,
+				431A9C6D8CD0BB9FBB005F4A /* ProductPeriod.swift in Sources */,
+				269F70B96D4D04C540A32429 /* ProductPrice.swift in Sources */,
+				A74BBEF8CCF5A35AB19BB70C /* ProductPurchaserLogic.swift in Sources */,
+				21F8518DE2D08B40125A79DA /* ProductPurchaserSK1.swift in Sources */,
+				9A802A666FD3BEE9B246EF4B /* ProductTemplate.swift in Sources */,
+				D6005FE1E75CD3796B709AB4 /* ProductTrial.swift in Sources */,
 				B456ED8E41AD35A0EF5C295F /* ProductVariable.swift in Sources */,
-				F6FE84ADA7107D9CC04639B8 /* ProductsManager.swift in Sources */,
-				D9D8E02D0943EE30C516CA86 /* PublicGameController.swift in Sources */,
-				926D1D7D4C3C0B87339B3B27 /* PublicIdentity.swift in Sources */,
-				F7C9D4352AA93BC8896BD160 /* PublicPresentation.swift in Sources */,
-				36C39E98FE6528FF6B72BF6D /* Publisher+Async.swift in Sources */,
-				C7BDBC371E86ACD7773C1469 /* Publisher+AsyncMap.swift in Sources */,
-				86C69BB773D53978B4EC9D03 /* Publisher+HasRetrieved.swift in Sources */,
-				35960B8492C96ED3FB40914B /* PurchaseResult.swift in Sources */,
-				C5B3004AACBE72FCD2951AD1 /* PushTransition.swift in Sources */,
-				7666A23DF5010191B52F6670 /* PushTransitionDelegate.swift in Sources */,
-				09E8E3EFFFD8A14688EE323A /* PushTransitionLogic.swift in Sources */,
+				633234099D510043E2D7D7EB /* ProductsFetcherSK1.swift in Sources */,
+				1E7EBE0C39AC302D9B5BFF27 /* PublicGameController.swift in Sources */,
+				02AA9A72A7FF3EE5773A0235 /* PublicGetPaywall.swift in Sources */,
+				F5CCDC90D8CBA5ED0C5BAD2E /* PublicGetPresentationResult.swift in Sources */,
+				0AB9CCC164DD87C81318AAB0 /* PublicIdentity.swift in Sources */,
+				8F24AAC773F119481E2C654F /* PublicPresentation.swift in Sources */,
+				D66461863D54A56BE9C29310 /* Publisher+Async.swift in Sources */,
+				23A34206DBEDD9DB79BAB702 /* PurchaseController.swift in Sources */,
+				8891C9D2F74407705E38FD89 /* PurchaseControllerObjc.swift in Sources */,
+				070DFAAB357CE1D547E946E1 /* PurchaseManager.swift in Sources */,
+				AD699B03E565AD6034AEC527 /* PurchaseResult.swift in Sources */,
+				2A1087A991658780B2B8036F /* PushTransition.swift in Sources */,
+				0DE74AADE698D455BDE2F36E /* PushTransitionDelegate.swift in Sources */,
+				C8BCF3C0404622139D002893 /* PushTransitionLogic.swift in Sources */,
 				FC051A3A8D640AF49D798B25 /* RawExperiment.swift in Sources */,
-				0401304BA8F70FBAA1B57C0B /* RawResponseOperator.swift in Sources */,
-				8EED10CD66775D1BDC606F72 /* RawWebMessageHandler.swift in Sources */,
-				EF1E845D1542855C1BEB8591 /* ReceiptLogic.swift in Sources */,
-				62666478F7A62BC63E4BCEE7 /* ReceiptManager.swift in Sources */,
-				4E952A1C6A9D721DE835C3A1 /* RestorationHandler.swift in Sources */,
-				3BC29573FB068209175AA6F3 /* RotationAnimation.swift in Sources */,
+				7477EFEA4C42BB441B92D096 /* RawPaywallResponse.swift in Sources */,
+				B3E6E82C0240EE6048360C9B /* RawWebMessageHandler.swift in Sources */,
+				4E7761949715C8BF8DEEF35C /* ReceiptLogic.swift in Sources */,
+				CF1F5D47BA8ABF223B0B2256 /* ReceiptManager.swift in Sources */,
+				338A97B83D26325FF3DB568A /* RestorationManager.swift in Sources */,
+				55CBCFC21A8DF3D8B14FBC19 /* RestorationResult.swift in Sources */,
+				76984544B2AEED280390BFB0 /* RotationAnimation.swift in Sources */,
+				4A86316A1F74FE8FC4BF889F /* RuleAttributes.swift in Sources */,
+				57543AA59192358A909ADCCF /* RuleLogic.swift in Sources */,
 				8EAEFA3BFACC09BE03A8D208 /* SDKJS.swift in Sources */,
-				1AF6D0FF3CD50E391BC1E9AC /* SKProduct+Helpers.swift in Sources */,
+				2BEA0C3FED992CB3BBD2F5CC /* SK1StoreProductDiscount.swift in Sources */,
+				83EE1B79C6BEB4A61929769F /* SK1StoreTransaction.swift in Sources */,
+				5773633643CA7DF61F73098C /* SK2StoreProduct.swift in Sources */,
+				E5678743A4C7E7917AE2E851 /* SK2StoreProductDiscount.swift in Sources */,
+				DBEE8C9C68C5AE64E1A80F50 /* SK2StoreTransaction.swift in Sources */,
 				1BDB91B70EAEC10097941381 /* SWBounceButton.swift in Sources */,
 				EDAEC46845C1DB11CB4C99AE /* SWConsoleViewController.swift in Sources */,
-				64585F844489D8A4D68BDDC9 /* SWDebugManager.swift in Sources */,
 				BEC00305295F34E7D6B4E82A /* SWDebugManagerLogic.swift in Sources */,
-				070509A5AA94C84993728566 /* SWDebugViewController.swift in Sources */,
 				213E7FC262106BFBC44462AC /* SWLocalizationViewController.swift in Sources */,
 				7F94C5006D67DDEBE7BC33C7 /* SWPriceTemplateVariable.swift in Sources */,
 				E0F69E406F64A1160FF55BFA /* SWProduct.swift in Sources */,
@@ -2019,62 +2609,69 @@
 				A2591FA256332165D0B0AFAF /* SWProductSubscriptionPeriod.swift in Sources */,
 				241192D89816E5EB2CF174E8 /* SWProductTemplateVariable.swift in Sources */,
 				C802FBEC68BF3153CB894040 /* SWSubscriptionTemplateVariable.swift in Sources */,
-				2BC7059002BF290E7E347B55 /* SWWebView.swift in Sources */,
-				35FA646E2C0A1778E586CDAE /* ScaleAnimation.swift in Sources */,
-				4029E33782C1477AC3B88115 /* SessionEventsManager.swift in Sources */,
-				44DF27A05B02B5A5EBBC7774 /* SessionEventsQueue.swift in Sources */,
+				26237FCC56AE2B7B68C9F1B1 /* SWWebView.swift in Sources */,
+				1753820CBFBDD8FF70455D71 /* ScaleAnimation.swift in Sources */,
+				889DAC79C6434B34CE56DCF8 /* SessionEventsManager.swift in Sources */,
+				6A3D32A64CC92B5AFB15621C /* SessionEventsQueue.swift in Sources */,
 				AD5EBB6DBA919E3CBC5B85B7 /* SessionEventsRequest.swift in Sources */,
-				0FDB9DD5D456AC7EE1A721D4 /* ShimmerView.swift in Sources */,
-				355A40470443886A8093794B /* Sk1TransactionObserver.swift in Sources */,
-				D3285BB8652564F7B7E308A0 /* Sk2TransactionObserver.swift in Sources */,
-				40C3C10AA178ECD322ED348C /* SpringAnimation.swift in Sources */,
+				5A6D06700C4E4E2C6C9BC1B2 /* ShimmerView.swift in Sources */,
+				BF4246F1F93C56DC39998549 /* Sk1StoreProduct.swift in Sources */,
+				7E355FE2557391CE4593B9B0 /* SpringAnimation.swift in Sources */,
 				FFC1A413FF8B96275C4C1649 /* Storage.swift in Sources */,
-				865D29C948809329640D2EF3 /* StoreKitManager.swift in Sources */,
+				60315CA6C1D6B9EAE7F71731 /* StoreKitCoordinator.swift in Sources */,
+				C053DEA1266E78107F828B19 /* StoreKitManager.swift in Sources */,
+				C37062A037D20AF1E5478AE2 /* StorePayment.swift in Sources */,
+				B523BBBB01E8A3D43F881400 /* StorePresentationObjects.swift in Sources */,
+				09DB853E1423A0EFE653B0E9 /* StoreProduct.swift in Sources */,
+				26E82881B51892D1CFD7390D /* StoreProductDiscount.swift in Sources */,
+				9D2B19788936FAED6F369768 /* StoreProductDiscountType.swift in Sources */,
+				D377D402D2E6126F79AED3C3 /* StoreProductType.swift in Sources */,
+				6D41217E107DA0E6FFAD0ACB /* StoreTransaction.swift in Sources */,
+				E48123B9CCCB7D02CAF15642 /* StoreTransactionType.swift in Sources */,
 				B5B83CE0D021A82950A51C47 /* String+CamelCase.swift in Sources */,
 				4AB907436D4A84932F09D8B3 /* String+MD5.swift in Sources */,
+				9C755FBB61B4D81CAFD0C0A0 /* String+RFC339.swift in Sources */,
 				E0728B4B771F020BF6CC405C /* String+RemoveChars.swift in Sources */,
 				B60C3A3AD25CE2E2C513A2D2 /* Stubbable.swift in Sources */,
-				94D8A80642BFFF0807B7DA30 /* Superwall.swift in Sources */,
-				1AA67756CFB437CDDA2090A5 /* SuperwallDelegate.swift in Sources */,
-				F494571A1A71840F891183A6 /* SuperwallDelegateAdapter.swift in Sources */,
-				389FED87EF4F78CBE68BC575 /* SuperwallDelegateObjc.swift in Sources */,
-				8490A243F8769FA73DE6B116 /* SuperwallEvent.swift in Sources */,
-				92ABF4A84F053ECAE668F4B0 /* SuperwallEventInfo.swift in Sources */,
-				7676D687F1785721C6B74C0E /* SuperwallEventObjc.swift in Sources */,
-				D676B7E6D1C79278219F651C /* SuperwallGraveyard.swift in Sources */,
-				6C6A7F67026F6A7CCEE45530 /* SuperwallLogic.swift in Sources */,
-				110F2CF8CFEAF85C4E99FD74 /* SuperwallOptions.swift in Sources */,
-				0023A25E51427F3BFB0429D2 /* SwiftUIGraveyard.swift in Sources */,
+				7B36EE4BCAA74CBFD91976C4 /* SubscriptionPeriod.swift in Sources */,
+				0DAFB898EE23890CBCEFAF41 /* SubscriptionStatus.swift in Sources */,
+				CFEB0D797815E8EDFB059767 /* Superwall.swift in Sources */,
+				17C0F1960CD89B6BFA8B2FBB /* SuperwallDelegate.swift in Sources */,
+				FA907E1BC8B68F238C791867 /* SuperwallDelegateAdapter.swift in Sources */,
+				C86B9D3992BBD1E8A1105F3C /* SuperwallDelegateObjc.swift in Sources */,
+				DA089BB7812726DCA236A48F /* SuperwallEvent.swift in Sources */,
+				F12D7D4F0F53C71B2A28445B /* SuperwallEventInfo.swift in Sources */,
+				348EA1CCD6C5276745FBECBC /* SuperwallEventObjc.swift in Sources */,
+				A78DC9BD71DD85831025D620 /* SuperwallGraveyard.swift in Sources */,
+				941F2296F5250A15DE6B5B70 /* SuperwallKit_Model.xcdatamodeld in Sources */,
+				0A1366F15DD3C1761C095DF5 /* SuperwallOptions.swift in Sources */,
 				AEB9D461AF5103FB7257AD25 /* SwiftyJSON.swift in Sources */,
 				534E94DCCD72F2F7D0EC1441 /* Task+Retrying.swift in Sources */,
 				D916475C6CE464EEB094F419 /* TaskRetryLogic.swift in Sources */,
-				CEEE66079046C63D431EAB2A /* TemplateLogic.swift in Sources */,
-				04184388675F18A1DDDE5EAD /* Trackable.swift in Sources */,
-				B3357D8577BA7CDA91A702B3 /* TrackableSuperwallEvent.swift in Sources */,
-				2A9A91EFD65458797F6B3D59 /* Tracking.swift in Sources */,
-				AFD7BDBF3518B2CB67B75C39 /* TrackingLogic.swift in Sources */,
-				3BAD4B9CF0D01385DBB61877 /* TrackingParameters.swift in Sources */,
-				9ABF279F63EFC6C82DE1F26C /* TrackingResult.swift in Sources */,
-				51984020B969A36162E3E65E /* TransactionErrorLogic.swift in Sources */,
-				F67A0DA424F15D3FB83EB5C9 /* TransactionManager.swift in Sources */,
-				38291090AEFC86AAF64E74DB /* TransactionModel.swift in Sources */,
-				87399276E22CF3308B7ACE88 /* TransactionPayment.swift in Sources */,
-				08D6A2B29A2969975A569083 /* TransactionProduct.swift in Sources */,
-				9CE266719FD631DE65ED3B06 /* TransactionRecorder.swift in Sources */,
+				25E2A4570B63FE36E4DD4E52 /* TemplateLogic.swift in Sources */,
+				31DE588B2B4A26745C33753C /* ThrowableDecodable.swift in Sources */,
+				6FE965326C139AB101BAC1CF /* Trackable.swift in Sources */,
+				78113F737BA99A2848850904 /* TrackableSuperwallEvent.swift in Sources */,
+				BDECE549960DB9A5662939BE /* Tracking.swift in Sources */,
+				E3F2F347326B8D206D341FB6 /* TrackingLogic.swift in Sources */,
+				369677E9A6E8754CFD20714D /* TrackingParameters.swift in Sources */,
+				D0E19F665C7B230BF3FA122D /* TrackingResult.swift in Sources */,
+				38A74D299EDFCA3F0A5261B7 /* TransactionErrorLogic.swift in Sources */,
+				AACC7BEE37DDDD7068A1E48C /* TransactionManager.swift in Sources */,
+				78C91388B9EA991A972C9536 /* TransactionProduct.swift in Sources */,
+				DA93155D0C405E32127089E2 /* TransactionVerifierSK2.swift in Sources */,
 				795E7752217DF07AD7EB8660 /* Trigger.swift in Sources */,
-				B7E9BC212E3E3CC98BE84E99 /* TriggerInfo.swift in Sources */,
-				21A354D6BC2136451BCCA38B /* TriggerOutcomeOperator.swift in Sources */,
+				2EC1D279019CD3FB64E4674A /* TriggerResult.swift in Sources */,
 				4FE19D26711ECB7B2EE8806D /* TriggerRule.swift in Sources */,
 				EB6A6ED6BD9965DC70A606DF /* TriggerRuleOccurrence.swift in Sources */,
-				959E679C31B894A29D4175F0 /* TriggerSession.swift in Sources */,
-				1C566DE7B035A21A76A23077 /* TriggerSessionExperiment.swift in Sources */,
-				15548573BCFA8370D2A305F4 /* TriggerSessionManager.swift in Sources */,
-				FDA86882DC58B8F9B831D1FE /* TriggerSessionManagerLogic.swift in Sources */,
-				6D7E7DE7EE8A541CC4EA97F9 /* TriggerSessionPaywall.swift in Sources */,
-				9187839D25693740ACA21B27 /* TriggerSessionProduct.swift in Sources */,
-				68032B8D2E7B57996F426601 /* TriggerSessionProducts.swift in Sources */,
-				C0A4031DC255DA772ECF6EC9 /* TriggerSessionTransaction.swift in Sources */,
-				E18B0385312E6FADC04D6F4B /* TriggerSessionTrigger.swift in Sources */,
+				EF32778E182D5FF3FCC86223 /* TriggerSession.swift in Sources */,
+				A17660D2723D600B5AA84CCA /* TriggerSessionManager.swift in Sources */,
+				656301FB982B22EFF291122F /* TriggerSessionManagerLogic.swift in Sources */,
+				7ED33A59F30F7C9BA080CB40 /* TriggerSessionPaywall.swift in Sources */,
+				ADA31CB0D14CEE6B4784039A /* TriggerSessionProduct.swift in Sources */,
+				188B39AA333F5C12E73C75AB /* TriggerSessionProducts.swift in Sources */,
+				4A0581431C658ADA17B40961 /* TriggerSessionTransaction.swift in Sources */,
+				589DA96DCAC1A4F0B08A2501 /* TriggerSessionTrigger.swift in Sources */,
 				0CC202CBE097714F963E0E3B /* Typealiases.swift in Sources */,
 				020D985745B77C21039115AC /* UIApplication+ActiveWindow.swift in Sources */,
 				8AEB577682D9AB9354CB8EE9 /* UIColor+Hex.swift in Sources */,
@@ -2084,11 +2681,14 @@
 				62CF18234F0EC4775DA8F828 /* UIViewController+AsyncPresent.swift in Sources */,
 				F3A7AF6D766960ECFE03E4B8 /* UIViewController+TopVc.swift in Sources */,
 				470D3FB2F3A7B61FD7881DF2 /* UIWindow+Landscape.swift in Sources */,
-				271D224C45C545EAAA47D4AD /* UserAttributes.swift in Sources */,
-				F0366D496C024FA8FE5F5823 /* UserInitiatedEvents.swift in Sources */,
+				9ABF8B3F8E320024252036F8 /* UNUserNotificationCenter+SuperwallNotifications.swift in Sources */,
+				7494124F44F712EC7138C7DF /* UserAttributes.swift in Sources */,
+				58170B6B2E4224AD27549567 /* UserInitiatedEvents.swift in Sources */,
 				E8C338D99A00BEFD9C908968 /* V1Migrator.swift in Sources */,
-				7E67A618C1144768C1B1D818 /* Variables.swift in Sources */,
+				7DCBF8A78D0B6A7A2649553D /* Validation.swift in Sources */,
+				5C504112376B6E0798CA20CE /* Variables.swift in Sources */,
 				DE2F41FF9D70AB13AD246E49 /* VariantOption.swift in Sources */,
+				BF97D6AAA3FDA03FE3ECF56F /* WaitToPresent.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -2332,14 +2932,38 @@
 		};
 /* End XCConfigurationList section */
 
+/* Begin XCRemoteSwiftPackageReference section */
+		6A0AB63DCE10E48A17E4F411 /* XCRemoteSwiftPackageReference "ASN1Swift" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/tikhop/ASN1Swift";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 1.2.4;
+			};
+		};
+/* End XCRemoteSwiftPackageReference section */
+
+/* Begin XCSwiftPackageProductDependency section */
+		36F71E474FE3523EF5DBADB3 /* ASN1Swift */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 6A0AB63DCE10E48A17E4F411 /* XCRemoteSwiftPackageReference "ASN1Swift" */;
+			productName = ASN1Swift;
+		};
+		5BE89F371D9B5971F3271921 /* ASN1Swift */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 6A0AB63DCE10E48A17E4F411 /* XCRemoteSwiftPackageReference "ASN1Swift" */;
+			productName = ASN1Swift;
+		};
+/* End XCSwiftPackageProductDependency section */
+
 /* Begin XCVersionGroup section */
-		E36770FA7C30179E09D62489 /* Model.xcdatamodeld */ = {
+		EC51351CA716C5C3B71E2FA1 /* SuperwallKit_Model.xcdatamodeld */ = {
 			isa = XCVersionGroup;
 			children = (
-				9AD77244B0329A08D176B56B /* Model.xcdatamodel */,
+				2845A6B61C43D18F869D750E /* Model.xcdatamodel */,
 			);
-			currentVersion = 9AD77244B0329A08D176B56B /* Model.xcdatamodel */;
-			path = Model.xcdatamodeld;
+			currentVersion = 2845A6B61C43D18F869D750E /* Model.xcdatamodel */;
+			path = SuperwallKit_Model.xcdatamodeld;
 			sourceTree = "<group>";
 			versionGroupType = wrapper.xcdatamodel;
 		};

--- a/SuperwallKit.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/SuperwallKit.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,0 +1,14 @@
+{
+  "pins" : [
+    {
+      "identity" : "asn1swift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/tikhop/ASN1Swift",
+      "state" : {
+        "revision" : "b53bee03a942623db25afc5bfb80227b2cb3b425",
+        "version" : "1.2.4"
+      }
+    }
+  ],
+  "version" : 2
+}

--- a/SuperwallKit.xcodeproj/xcshareddata/xcschemes/SuperwallKit.xcscheme
+++ b/SuperwallKit.xcodeproj/xcshareddata/xcschemes/SuperwallKit.xcscheme
@@ -28,7 +28,7 @@
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       onlyGenerateCoverageForSpecifiedTargets = "NO"
-      shouldUseLaunchSchemeArgsEnv = "YES">
+      shouldUseLaunchSchemeArgsEnv = "NO">
       <Testables>
          <TestableReference
             skipped = "NO">
@@ -51,6 +51,10 @@
          </BuildableReference>
       </MacroExpansion>
       <CommandLineArguments>
+         <CommandLineArgument
+            argument = "SUPERWALL_UNIT_TESTS"
+            isEnabled = "YES">
+         </CommandLineArgument>
       </CommandLineArguments>
    </TestAction>
    <LaunchAction
@@ -73,11 +77,15 @@
          </BuildableReference>
       </MacroExpansion>
       <CommandLineArguments>
+         <CommandLineArgument
+            argument = "SUPERWALL_UNIT_TESTS"
+            isEnabled = "YES">
+         </CommandLineArgument>
       </CommandLineArguments>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"
-      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldUseLaunchSchemeArgsEnv = "NO"
       savedToolIdentifier = ""
       useCustomWorkingDirectory = "NO"
       debugDocumentVersioning = "YES">
@@ -92,6 +100,10 @@
          </BuildableReference>
       </BuildableProductRunnable>
       <CommandLineArguments>
+         <CommandLineArgument
+            argument = "SUPERWALL_UNIT_TESTS"
+            isEnabled = "YES">
+         </CommandLineArgument>
       </CommandLineArguments>
    </ProfileAction>
    <AnalyzeAction

--- a/project.yml
+++ b/project.yml
@@ -11,6 +11,8 @@ targets:
     scheme:
       testTargets:
         - SuperwallKitTests
+      commandLineArguments:
+        SUPERWALL_UNIT_TESTS: true
     settings:
       PRODUCT_BUNDLE_IDENTIFIER: "com.superwall.SuperwallKit"
     info:
@@ -42,6 +44,7 @@ targets:
       - package: ASN1Swift
     settings:
       PRODUCT_BUNDLE_IDENTIFIER: "com.superwall.SuperwallTests"
+
     info:
       path: SuperwallKit.xcodeproj/SuperwallTests_Info.plist
       properties:


### PR DESCRIPTION
## Changes in this pull request

### Enhancements

- Adds `shouldShowPurchaseFailureAlert` as a `PaywallOption`. This defaults to `true`. If you're using a `PurchaseController`, set this to `false` to disable the alert that shows after the purchase fails.

### Fixes

- Fixes issue where a secondary paywall wouldn't present with the `transaction_fail` trigger.
- Fixes issue where the paywall preview wasn't obeying free trial/default paywall overrides.
- Fixes issue where preloaded paywalls may be associated with the incorrect experiment.
- Fixes the tests not being generated by xcodegen. That caused the launch arguments to not exist.

### Checklist

- [x] All tests pass. Demo project builds and runs.
- [x] I added tests, an experiment, or detailed why my change isn't tested.
- [x] I added an entry to the `CHANGELOG.md` for any breaking changes, enhancements, or bug fixes.
- [x] I have run `swiftlint` in the main directory and fixed any issues.
- [ ] I have updated the SDK documentation as well as the online docs.
- [x] I have reviewed the [contributing guide](https://github.com/superwall-me/paywall-ios/tree/master/.github/CONTRIBUTING.md)
