### PR TITLE
feature/fix-paywall-decline-with-survey

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The changelog for `SuperwallKit`. Also see the [releases](https://github.com/sup
 
 ### Fixes
 
+- Fixes issue where a survey attached to a paywall wouldn't show if you were also using the `paywall_decline` trigger.
 - Fixes issue where verification was happening after the finishing of transactions when not using a `PurchaseController`.
 
 ## 3.3.2

--- a/Sources/SuperwallKit/Superwall.swift
+++ b/Sources/SuperwallKit/Superwall.swift
@@ -465,29 +465,11 @@ extension Superwall: PaywallViewControllerEventDelegate {
 
     switch paywallEvent {
     case .closed:
-      let trackedEvent = InternalSuperwallEvent.PaywallDecline(paywallInfo: paywallViewController.info)
-
-      let presentationResult = await internallyGetPresentationResult(
-        forEvent: trackedEvent,
-        requestType: .getImplicitPresentationResult
+      dismiss(
+        paywallViewController,
+        result: .declined,
+        closeReason: .manualClose
       )
-      let paywallPresenterEvent = paywallViewController.info.presentedByEventWithName
-      let presentedByPaywallDecline = paywallPresenterEvent == SuperwallEventObjc.paywallDecline.description
-
-      if case .paywall = presentationResult,
-        !presentedByPaywallDecline {
-        // If a paywall_decline trigger is active and the current paywall wasn't presented
-        // by paywall_decline, it lands here so as not to dismiss the paywall.
-        // track() will do that before presenting the next paywall.
-      } else {
-        dismiss(
-          paywallViewController,
-          result: .declined,
-          closeReason: .manualClose
-        )
-      }
-
-      await Superwall.shared.track(trackedEvent)
     case .initiatePurchase(let productId):
       await dependencyContainer.transactionManager.purchase(
         productId,


### PR DESCRIPTION
## Changes in this pull request

- Moved the tracking of `paywall_decline` until after a potential survey shows

### Checklist

- [x] All unit and UI tests pass. Demo project builds and runs.
- [ ] I added tests, an experiment, or detailed why my change isn't tested.
- [x] I added an entry to the `CHANGELOG.md` for any breaking changes, enhancements, or bug fixes.
- [x] I have run `swiftlint` in the main directory and fixed any issues.
- [ ] I have updated the SDK documentation as well as the online docs.
- [x] I have reviewed the [contributing guide](https://github.com/superwall-me/paywall-ios/tree/master/.github/CONTRIBUTING.md)
