### PR TITLE
feature/survey-close

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The changelog for `SuperwallKit`. Also see the [releases](https://github.com/sup
 - Adds `sdk_version`, `sdk_version_padded`, `app_build_string`, and `app_build_string_number` to the device object for use in rules. `sdk_version` is the version of the sdk, e.g. `3.3.3`. `sdk_version_padded` is the sdk version padded with zeros for use with string comparison. For example `003.003.003`. `app_build_string` is the build of your app and `app_build_string_number` is the build of your app casted as an Int.
 - When you experience `no_rule_match`, the `TriggerFire` event params will specify which part of the rules didn't match in the format `"unmatched_rule_<id>": "<outcome>"`. Where `outcome` will either be `OCCURRENCE`, referring to the limit applied to a rule, or `EXPRESSION`. The `id` is the experiment id.
 - Adds a `touches_began` implicit trigger. By adding the `touches_began` event to a campaign, you can show a paywall the first time a user touches anywhere in your app.
+- Adds the ability to include a close button on a survey.
 
 ### Fixes
 

--- a/Sources/SuperwallKit/Analytics/Internal Tracking/Trackable Events/TrackableSuperwallEvent.swift
+++ b/Sources/SuperwallKit/Analytics/Internal Tracking/Trackable Events/TrackableSuperwallEvent.swift
@@ -51,6 +51,12 @@ enum InternalSuperwallEvent {
     func getSuperwallParameters() async -> [String: Any] { [:] }
   }
 
+  struct SurveyClose: TrackableSuperwallEvent {
+    let superwallEvent: SuperwallEvent = .surveyClose
+    var customParameters: [String: Any] = [:]
+    func getSuperwallParameters() async -> [String: Any] { [:] }
+  }
+
   struct SurveyResponse: TrackableSuperwallEvent {
     var superwallEvent: SuperwallEvent {
       return .surveyResponse(

--- a/Sources/SuperwallKit/Analytics/Superwall Event/SuperwallEvent.swift
+++ b/Sources/SuperwallKit/Analytics/Superwall Event/SuperwallEvent.swift
@@ -138,7 +138,13 @@ public enum SuperwallEvent {
     reason: PaywallPresentationRequestStatusReason?
   )
 
+  /// When the first touch was detected on the UIWindow of the app.
+  ///
+  /// This is only registered if there's an active `touches_began` trigger on your dashboard.
   case touchesBegan
+
+  /// When the user chose the close button on a survey instead of responding.
+  case surveyClose
 
   var canImplicitlyTriggerPaywall: Bool {
     switch self {
@@ -252,6 +258,8 @@ extension SuperwallEvent {
       return .init(objcEvent: .surveyResponse)
     case .touchesBegan:
       return .init(objcEvent: .touchesBegan)
+    case .surveyClose:
+      return .init(objcEvent: .surveyClose)
     }
   }
 }

--- a/Sources/SuperwallKit/Analytics/Superwall Event/SuperwallEventObjc.swift
+++ b/Sources/SuperwallKit/Analytics/Superwall Event/SuperwallEventObjc.swift
@@ -125,7 +125,13 @@ public enum SuperwallEventObjc: Int, CaseIterable {
   /// When the response to a paywall survey as been recorded.
   case surveyResponse
 
+  /// When the user touches the app's UIWindow for the first time.
+  ///
+  /// This is only tracked if there is an active `touches_began` trigger in a campaign.
   case touchesBegan
+
+  /// When the user taps the close button to skip the survey without recording a response.
+  case surveyClose
 
   public init(event: SuperwallEvent) {
     self = event.backingData.objcEvent
@@ -205,6 +211,8 @@ public enum SuperwallEventObjc: Int, CaseIterable {
       return "survey_response"
     case .touchesBegan:
       return "touches_began"
+    case .surveyClose:
+      return "survey_close"
     }
   }
 }

--- a/Sources/SuperwallKit/Config/Models/Survey.swift
+++ b/Sources/SuperwallKit/Config/Models/Survey.swift
@@ -34,6 +34,9 @@ final public class Survey: NSObject, Decodable {
   /// response.
   public let includeOtherOption: Bool
 
+  /// Whether a close button should appear to allow users to skip the survey.
+  public let includeCloseButton: Bool
+
   /// Rolls dice to see if survey should present or is in holdout.
   ///
   /// - Returns: `true` if user is in holdout, false if survey should present.
@@ -83,7 +86,8 @@ final public class Survey: NSObject, Decodable {
     message: String,
     options: [SurveyOption],
     presentationProbability: Double,
-    includeOtherOption: Bool
+    includeOtherOption: Bool,
+    includeCloseButton: Bool
   ) {
     self.id = id
     self.assignmentKey = assignmentKey
@@ -92,6 +96,7 @@ final public class Survey: NSObject, Decodable {
     self.options = options
     self.presentationProbability = presentationProbability
     self.includeOtherOption = includeOtherOption
+    self.includeCloseButton = includeCloseButton
   }
 }
 
@@ -105,7 +110,8 @@ extension Survey: Stubbable {
       message: "test",
       options: [.stub()],
       presentationProbability: 1,
-      includeOtherOption: true
+      includeOtherOption: true,
+      includeCloseButton: true
     )
   }
 }

--- a/Sources/SuperwallKit/Config/Models/Survey.swift
+++ b/Sources/SuperwallKit/Config/Models/Survey.swift
@@ -39,7 +39,7 @@ final public class Survey: NSObject, Decodable {
   public let includeOtherOption: Bool
 
   /// Whether a close button should appear to allow users to skip the survey.
-  public let includeCloseButton: Bool
+  public let includeCloseOption: Bool
 
   /// Rolls dice to see if survey should present or is in holdout.
   ///
@@ -91,7 +91,7 @@ final public class Survey: NSObject, Decodable {
     options: [SurveyOption],
     presentationProbability: Double,
     includeOtherOption: Bool,
-    includeCloseButton: Bool
+    includeCloseOption: Bool,
     surveyPresentationCondition: SurveyShowCondition
   ) {
     self.id = id
@@ -101,7 +101,7 @@ final public class Survey: NSObject, Decodable {
     self.options = options
     self.presentationProbability = presentationProbability
     self.includeOtherOption = includeOtherOption
-    self.includeCloseButton = includeCloseButton
+    self.includeCloseOption = includeCloseOption
     self.surveyPresentationCondition = surveyPresentationCondition
   }
 }
@@ -117,7 +117,7 @@ extension Survey: Stubbable {
       options: [.stub()],
       presentationProbability: 1,
       includeOtherOption: true,
-      includeCloseButton: true
+      includeCloseOption: true,
       surveyPresentationCondition: .onManualClose
     )
   }

--- a/Sources/SuperwallKit/Paywall/View Controller/Survey/SurveyManager.swift
+++ b/Sources/SuperwallKit/Paywall/View Controller/Survey/SurveyManager.swift
@@ -149,7 +149,7 @@ final class SurveyManager {
       alertController.addAction(otherAction)
     }
 
-    if survey.includeCloseButton {
+    if survey.includeCloseOption {
       let closeButton = UIAlertAction(title: "Close", style: .cancel) { _ in
         Task {
           let event = InternalSuperwallEvent.SurveyClose()

--- a/Sources/SuperwallKit/Paywall/View Controller/Survey/SurveyManager.swift
+++ b/Sources/SuperwallKit/Paywall/View Controller/Survey/SurveyManager.swift
@@ -145,6 +145,17 @@ final class SurveyManager {
       alertController.addAction(otherAction)
     }
 
+    if survey.includeCloseButton {
+      let closeButton = UIAlertAction(title: "Close", style: .cancel) { _ in
+        Task {
+          let event = InternalSuperwallEvent.SurveyClose()
+          await Superwall.shared.track(event)
+        }
+        completion(.show)
+      }
+      alertController.addAction(closeButton)
+    }
+
     presenter.present(alertController, animated: true)
   }
 

--- a/Tests/SuperwallKitTests/Config/Models/SurveyTests.swift
+++ b/Tests/SuperwallKitTests/Config/Models/SurveyTests.swift
@@ -27,7 +27,8 @@ final class SurveyTests: XCTestCase {
       message: "test",
       options: [.stub()],
       presentationProbability: 0,
-      includeOtherOption: true
+      includeOtherOption: true,
+      includeCloseButton: true
     )
     let isHoldout = survey.shouldAssignHoldout(
       isDebuggerLaunched: false,
@@ -44,7 +45,8 @@ final class SurveyTests: XCTestCase {
       message: "test",
       options: [.stub()],
       presentationProbability: 1,
-      includeOtherOption: true
+      includeOtherOption: true,
+      includeCloseButton: true
     )
     let isHoldout = survey.shouldAssignHoldout(
       isDebuggerLaunched: false,
@@ -61,7 +63,8 @@ final class SurveyTests: XCTestCase {
       message: "test",
       options: [.stub()],
       presentationProbability: 0.4,
-      includeOtherOption: true
+      includeOtherOption: true,
+      includeCloseButton: true
     )
     func random(in: Range<Double>) -> Double {
       return 0.5
@@ -89,7 +92,8 @@ final class SurveyTests: XCTestCase {
       message: "test",
       options: [.stub()],
       presentationProbability: 0.4,
-      includeOtherOption: true
+      includeOtherOption: true,
+      includeCloseButton: true
     )
     let existingAssignmentKey = "abc"
     let storage = StorageMock(internalSurveyAssignmentKey: existingAssignmentKey)
@@ -105,7 +109,8 @@ final class SurveyTests: XCTestCase {
       message: "test",
       options: [.stub()],
       presentationProbability: 0.4,
-      includeOtherOption: true
+      includeOtherOption: true,
+      includeCloseButton: true
     )
     let existingAssignmentKey = "abc"
     let storage = StorageMock(internalSurveyAssignmentKey: existingAssignmentKey)

--- a/Tests/SuperwallKitTests/Config/Models/SurveyTests.swift
+++ b/Tests/SuperwallKitTests/Config/Models/SurveyTests.swift
@@ -28,7 +28,7 @@ final class SurveyTests: XCTestCase {
       options: [.stub()],
       presentationProbability: 0,
       includeOtherOption: true,
-      includeCloseButton: true
+      includeCloseOption: true,
       surveyPresentationCondition: .onManualClose
     )
     let isHoldout = survey.shouldAssignHoldout(
@@ -47,7 +47,7 @@ final class SurveyTests: XCTestCase {
       options: [.stub()],
       presentationProbability: 1,
       includeOtherOption: true,
-      includeCloseButton: true
+      includeCloseOption: true,
       surveyPresentationCondition: .onManualClose
     )
     let isHoldout = survey.shouldAssignHoldout(
@@ -66,7 +66,7 @@ final class SurveyTests: XCTestCase {
       options: [.stub()],
       presentationProbability: 0.4,
       includeOtherOption: true,
-      includeCloseButton: true
+      includeCloseOption: true,
       surveyPresentationCondition: .onManualClose
     )
     func random(in: Range<Double>) -> Double {
@@ -96,7 +96,7 @@ final class SurveyTests: XCTestCase {
       options: [.stub()],
       presentationProbability: 0.4,
       includeOtherOption: true,
-      includeCloseButton: true
+      includeCloseOption: true,
       surveyPresentationCondition: .onManualClose
     )
     let existingAssignmentKey = "abc"
@@ -114,7 +114,7 @@ final class SurveyTests: XCTestCase {
       options: [.stub()],
       presentationProbability: 0.4,
       includeOtherOption: true,
-      includeCloseButton: true
+      includeCloseOption: true,
       surveyPresentationCondition: .onManualClose
     )
     let existingAssignmentKey = "abc"


### PR DESCRIPTION
## Changes in this pull request

- Adds close button option to survey
- Tracks `survey_close` when the close button is tapped.

### Checklist

- [x] All unit and UI tests pass. Demo project builds and runs.
- [x] I added tests, an experiment, or detailed why my change isn't tested.
- [x] I added an entry to the `CHANGELOG.md` for any breaking changes, enhancements, or bug fixes.
- [x] I have run `swiftlint` in the main directory and fixed any issues.
- [ ] I have updated the SDK documentation as well as the online docs.
- [x] I have reviewed the [contributing guide](https://github.com/superwall-me/paywall-ios/tree/master/.github/CONTRIBUTING.md)
