### PR TITLE
feature/survey-on-transaction-complete

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -4,7 +4,9 @@
 
 ### Checklist
 
-- [ ] All unit and UI tests pass. Demo project builds and runs.
+- [ ] All unit tests pass.
+- [ ] All UI tests pass.
+- [ ] Demo project builds and runs.
 - [ ] I added/updated tests or detailed why my change isn't tested.
 - [ ] I added an entry to the `CHANGELOG.md` for any breaking changes, enhancements, or bug fixes.
 - [ ] I have run `swiftlint` in the main directory and fixed any issues.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The changelog for `SuperwallKit`. Also see the [releases](https://github.com/sup
 - When you experience `no_rule_match`, the `TriggerFire` event params will specify which part of the rules didn't match in the format `"unmatched_rule_<id>": "<outcome>"`. Where `outcome` will either be `OCCURRENCE`, referring to the limit applied to a rule, or `EXPRESSION`. The `id` is the experiment id.
 - Adds a `touches_began` implicit trigger. By adding the `touches_began` event to a campaign, you can show a paywall the first time a user touches anywhere in your app.
 - If running in sandbox, the duration of a free trial notification added to a paywall will be converted from days to minutes for testing purposes.
+- Adds the ability to trigger a survey after purchasing a product.
 
 ### Fixes
 

--- a/Sources/SuperwallKit/Analytics/Internal Tracking/Trackable Events/TrackableSuperwallEvent.swift
+++ b/Sources/SuperwallKit/Analytics/Internal Tracking/Trackable Events/TrackableSuperwallEvent.swift
@@ -358,7 +358,7 @@ enum InternalSuperwallEvent {
 
     func getSuperwallParameters() async -> [String: Any] {
       var params: [String: Any] = [
-        "survey_attached": paywallInfo.survey == nil ? false : true
+        "survey_attached": paywallInfo.surveys.isEmpty ? false : true
       ]
 
       if surveyPresentationResult != .noShow {

--- a/Sources/SuperwallKit/Config/Models/Survey.swift
+++ b/Sources/SuperwallKit/Config/Models/Survey.swift
@@ -28,6 +28,9 @@ final public class Survey: NSObject, Decodable {
   /// The options to display in the alert controller.
   public let options: [SurveyOption]
 
+  /// An enum whose cases indicate when the survey should show.
+  public let surveyPresentationCondition: SurveyShowCondition
+
   /// The probability that the survey will present to the user.
   public internal(set) var presentationProbability: Double
 
@@ -84,7 +87,8 @@ final public class Survey: NSObject, Decodable {
     message: String,
     options: [SurveyOption],
     presentationProbability: Double,
-    includeOtherOption: Bool
+    includeOtherOption: Bool,
+    surveyPresentationCondition: SurveyShowCondition
   ) {
     self.id = id
     self.assignmentKey = assignmentKey
@@ -93,6 +97,7 @@ final public class Survey: NSObject, Decodable {
     self.options = options
     self.presentationProbability = presentationProbability
     self.includeOtherOption = includeOtherOption
+    self.surveyPresentationCondition = surveyPresentationCondition
   }
 }
 
@@ -106,7 +111,8 @@ extension Survey: Stubbable {
       message: "test",
       options: [.stub()],
       presentationProbability: 1,
-      includeOtherOption: true
+      includeOtherOption: true,
+      surveyPresentationCondition: .onManualClose
     )
   }
 }

--- a/Sources/SuperwallKit/Config/Models/Survey.swift
+++ b/Sources/SuperwallKit/Config/Models/Survey.swift
@@ -7,6 +7,7 @@
 
 import Foundation
 
+/// A survey attached to a paywall.
 @objc(SWKSurvey)
 @objcMembers
 final public class Survey: NSObject, Decodable {

--- a/Sources/SuperwallKit/Config/Models/Survey.swift
+++ b/Sources/SuperwallKit/Config/Models/Survey.swift
@@ -29,7 +29,7 @@ final public class Survey: NSObject, Decodable {
   public let options: [SurveyOption]
 
   /// An enum whose cases indicate when the survey should show.
-  public let surveyPresentationCondition: SurveyShowCondition
+  public internal(set) var surveyPresentationCondition: SurveyShowCondition
 
   /// The probability that the survey will present to the user.
   public internal(set) var presentationProbability: Double

--- a/Sources/SuperwallKit/Config/Models/SurveyShowCondition.swift
+++ b/Sources/SuperwallKit/Config/Models/SurveyShowCondition.swift
@@ -1,0 +1,36 @@
+//
+//  File.swift
+//  
+//
+//  Created by Yusuf Tör on 06/09/2023.
+//
+
+import Foundation
+
+/// An enum whose cases indicate when a survey should
+/// show.
+@objc(SWKSurveyShowCondition)
+public enum SurveyShowCondition: Int, Decodable {
+  /// Shows the survey when the user manually closes the paywall.
+  case onManualClose
+
+  /// Shows the survey after the user purchases.
+  case onPurchase
+
+  enum CodingKeys: String, CodingKey {
+    case onManualClose = "ON_MANUAL_CLOSE"
+    case onPurchase = "ON_PURCHASE"
+  }
+
+  public init(from decoder: Decoder) throws {
+    let container = try decoder.singleValueContainer()
+    let rawValue = try container.decode(String.self)
+    let reason = CodingKeys(rawValue: rawValue) ?? .onManualClose
+    switch reason {
+    case .onManualClose:
+      self = .onManualClose
+    case .onPurchase:
+      self = .onPurchase
+    }
+  }
+}

--- a/Sources/SuperwallKit/Config/Models/SurveyShowCondition.swift
+++ b/Sources/SuperwallKit/Config/Models/SurveyShowCondition.swift
@@ -25,12 +25,20 @@ public enum SurveyShowCondition: Int, Decodable {
   public init(from decoder: Decoder) throws {
     let container = try decoder.singleValueContainer()
     let rawValue = try container.decode(String.self)
-    let reason = CodingKeys(rawValue: rawValue) ?? .onManualClose
+    let reason = CodingKeys(rawValue: rawValue)
     switch reason {
     case .onManualClose:
       self = .onManualClose
     case .onPurchase:
       self = .onPurchase
+    case .none:
+      throw DecodingError.valueNotFound(
+        String.self,
+        .init(
+          codingPath: [],
+          debugDescription: "Unsupported survey condition."
+        )
+      )
     }
   }
 }

--- a/Sources/SuperwallKit/Models/Paywall/Paywall.swift
+++ b/Sources/SuperwallKit/Models/Paywall/Paywall.swift
@@ -52,6 +52,9 @@ struct Paywall: Decodable {
   /// A survey to potentially show on close of the paywall.
   var survey: Survey?
 
+  /// An enum whose cases indicate when a survey should show.
+  var surveyShowCondition: SurveyShowCondition?
+
   /// The products associated with the paywall.
   var products: [Product] {
     didSet {
@@ -120,6 +123,7 @@ struct Paywall: Decodable {
     case localNotifications
     case computedPropertyRequests = "computedProperties"
     case survey
+    case surveyShowCondition
 
     case responseLoadStartTime
     case responseLoadCompleteTime
@@ -142,6 +146,7 @@ struct Paywall: Decodable {
     url = try values.decode(URL.self, forKey: .url)
     htmlSubstitutions = try values.decode(String.self, forKey: .htmlSubstitutions)
     survey = try values.decodeIfPresent(Survey.self, forKey: .survey)
+    surveyShowCondition = try values.decodeIfPresent(SurveyShowCondition.self, forKey: .surveyShowCondition)
 
     let presentationStyle = try values.decode(PaywallPresentationStyle.self, forKey: .presentationStyle)
     let presentationCondition = try values.decode(PresentationCondition.self, forKey: .presentationCondition)
@@ -285,7 +290,8 @@ struct Paywall: Decodable {
       closeReason: closeReason,
       localNotifications: localNotifications,
       computedPropertyRequests: computedPropertyRequests,
-      survey: survey
+      survey: survey,
+      surveyShowCondition: surveyShowCondition
     )
   }
 

--- a/Sources/SuperwallKit/Paywall/Presentation/PaywallInfo.swift
+++ b/Sources/SuperwallKit/Paywall/Presentation/PaywallInfo.swift
@@ -106,11 +106,8 @@ public final class PaywallInfo: NSObject {
   /// An array of requests to compute a device property associated with an event at runtime.
   public let computedPropertyRequests: [ComputedPropertyRequest]
 
-  /// A survey attached to a paywall.
-  public let survey: Survey?
-
-  /// An enum whose cases indicate when a survey should show.
-  public let surveyShowCondition: SurveyShowCondition?
+  /// Surveys attached to a paywall.
+  public let surveys: [Survey]
 
   private unowned let factory: TriggerSessionManagerFactory
 
@@ -139,8 +136,7 @@ public final class PaywallInfo: NSObject {
     closeReason: PaywallCloseReason = .none,
     localNotifications: [LocalNotification] = [],
     computedPropertyRequests: [ComputedPropertyRequest] = [],
-    survey: Survey?,
-    surveyShowCondition: SurveyShowCondition?
+    surveys: [Survey]
   ) {
     self.databaseId = databaseId
     self.identifier = identifier
@@ -158,8 +154,7 @@ public final class PaywallInfo: NSObject {
     self.featureGatingBehavior = featureGatingBehavior
     self.localNotifications = localNotifications
     self.computedPropertyRequests = computedPropertyRequests
-    self.survey = survey
-    self.surveyShowCondition = surveyShowCondition
+    self.surveys = surveys
 
     if eventData != nil {
       self.presentedBy = "event"
@@ -322,8 +317,7 @@ extension PaywallInfo: Stubbable {
       isFreeTrialAvailable: false,
       presentationSourceType: "register",
       factory: dependencyContainer,
-      survey: nil,
-      surveyShowCondition: nil
+      surveys: []
     )
   }
 }

--- a/Sources/SuperwallKit/Paywall/Presentation/PaywallInfo.swift
+++ b/Sources/SuperwallKit/Paywall/Presentation/PaywallInfo.swift
@@ -103,9 +103,14 @@ public final class PaywallInfo: NSObject {
   /// The local notifications associated with the paywall.
   public let localNotifications: [LocalNotification]
 
+  /// An array of requests to compute a device property associated with an event at runtime.
   public let computedPropertyRequests: [ComputedPropertyRequest]
 
+  /// A survey attached to a paywall.
   public let survey: Survey?
+
+  /// An enum whose cases indicate when a survey should show.
+  public let surveyShowCondition: SurveyShowCondition?
 
   private unowned let factory: TriggerSessionManagerFactory
 
@@ -134,7 +139,8 @@ public final class PaywallInfo: NSObject {
     closeReason: PaywallCloseReason = .none,
     localNotifications: [LocalNotification] = [],
     computedPropertyRequests: [ComputedPropertyRequest] = [],
-    survey: Survey?
+    survey: Survey?,
+    surveyShowCondition: SurveyShowCondition?
   ) {
     self.databaseId = databaseId
     self.identifier = identifier
@@ -153,6 +159,7 @@ public final class PaywallInfo: NSObject {
     self.localNotifications = localNotifications
     self.computedPropertyRequests = computedPropertyRequests
     self.survey = survey
+    self.surveyShowCondition = surveyShowCondition
 
     if eventData != nil {
       self.presentedBy = "event"
@@ -315,7 +322,8 @@ extension PaywallInfo: Stubbable {
       isFreeTrialAvailable: false,
       presentationSourceType: "register",
       factory: dependencyContainer,
-      survey: nil
+      survey: nil,
+      surveyShowCondition: nil
     )
   }
 }

--- a/Sources/SuperwallKit/Paywall/View Controller/PaywallViewController.swift
+++ b/Sources/SuperwallKit/Paywall/View Controller/PaywallViewController.swift
@@ -4,7 +4,7 @@
 //
 //  Created by brian on 7/21/21.
 //
-// swiftlint:disable file_length type_body_length function_body_length
+// swiftlint:disable file_length type_body_length
 
 import WebKit
 import UIKit
@@ -671,10 +671,8 @@ extension PaywallViewController {
       return false
     }
 
-    for survey in paywall.surveys {
-      if survey.hasSeenSurvey(storage: storage) {
-        return false
-      }
+    for survey in paywall.surveys where survey.hasSeenSurvey(storage: storage) {
+      return false
     }
     return true
   }

--- a/Sources/SuperwallKit/Paywall/View Controller/PaywallViewController.swift
+++ b/Sources/SuperwallKit/Paywall/View Controller/PaywallViewController.swift
@@ -4,7 +4,7 @@
 //
 //  Created by brian on 7/21/21.
 //
-// swiftlint:disable file_length type_body_length
+// swiftlint:disable file_length type_body_length function_body_length
 
 import WebKit
 import UIKit
@@ -769,6 +769,13 @@ extension PaywallViewController {
     paywall.closeReason = closeReason
 
     let isDeclined = paywallResult == .declined
+    let isPurchased: Bool
+    switch paywallResult {
+    case .purchased:
+      isPurchased = true
+    default:
+      isPurchased = false
+    }
     let isManualClose = closeReason == .manualClose
 
     func dismissView() async {
@@ -804,11 +811,21 @@ extension PaywallViewController {
       }
     }
 
+    let shouldShowSurvey: Bool
+    switch paywall.surveyShowCondition {
+    case .onManualClose:
+      shouldShowSurvey = isDeclined && isManualClose
+    case .onPurchase:
+      shouldShowSurvey = isPurchased
+    default:
+      shouldShowSurvey = false
+    }
+
     SurveyManager.presentSurveyIfAvailable(
       paywall.survey,
       using: self,
       loadingState: loadingState,
-      paywallIsManuallyDeclined: isDeclined && isManualClose,
+      shouldShow: shouldShowSurvey,
       isDebuggerLaunched: request?.flags.isDebuggerLaunched == true,
       paywallInfo: info,
       storage: storage,

--- a/Sources/SuperwallKit/Paywall/View Controller/Survey/SurveyManager.swift
+++ b/Sources/SuperwallKit/Paywall/View Controller/Survey/SurveyManager.swift
@@ -15,7 +15,7 @@ final class SurveyManager {
     _ survey: Survey?,
     using presenter: PaywallViewController,
     loadingState: PaywallLoadingState,
-    paywallIsManuallyDeclined: Bool,
+    shouldShow: Bool,
     isDebuggerLaunched: Bool,
     paywallInfo: PaywallInfo,
     storage: Storage,
@@ -26,11 +26,13 @@ final class SurveyManager {
       completion(.noShow)
       return
     }
-    guard loadingState == .ready else {
+    guard
+      loadingState == .ready || loadingState == .loadingPurchase
+    else {
       completion(.noShow)
       return
     }
-    guard paywallIsManuallyDeclined else {
+    guard shouldShow else {
       completion(.noShow)
       return
     }

--- a/Sources/SuperwallKit/Paywall/View Controller/Survey/SurveyManager.swift
+++ b/Sources/SuperwallKit/Paywall/View Controller/Survey/SurveyManager.swift
@@ -12,27 +12,29 @@ final class SurveyManager {
   static private var otherAlertController: UIAlertController?
 
   static func presentSurveyIfAvailable(
-    _ survey: Survey?,
+    _ surveys: [Survey],
+    paywallResult: PaywallResult,
+    paywallCloseReason: PaywallCloseReason,
     using presenter: PaywallViewController,
     loadingState: PaywallLoadingState,
-    shouldShow: Bool,
     isDebuggerLaunched: Bool,
     paywallInfo: PaywallInfo,
     storage: Storage,
     factory: TriggerFactory,
     completion: @escaping (SurveyPresentationResult) -> Void
   ) {
-    guard let survey = survey else {
+    guard let survey = selectSurvey(
+      from: surveys,
+      paywallResult: paywallResult,
+      paywallCloseReason: paywallCloseReason
+    ) else {
       completion(.noShow)
       return
     }
+
     guard
       loadingState == .ready || loadingState == .loadingPurchase
     else {
-      completion(.noShow)
-      return
-    }
-    guard shouldShow else {
       completion(.noShow)
       return
     }
@@ -193,6 +195,40 @@ final class SurveyManager {
       }
     }
     otherAlertController = nil
+  }
+
+  private static func selectSurvey(
+    from surveys: [Survey],
+    paywallResult: PaywallResult,
+    paywallCloseReason: PaywallCloseReason
+  ) -> Survey? {
+    let isPurchased: Bool
+    switch paywallResult {
+    case .purchased:
+      isPurchased = true
+    default:
+      isPurchased = false
+    }
+    let isDeclined = paywallResult == .declined
+    let isManualClose = paywallCloseReason == .manualClose
+
+    let onManualClose = isDeclined && isManualClose
+    let onPurchase = isPurchased
+
+    for survey in surveys {
+      switch survey.surveyPresentationCondition {
+      case .onManualClose:
+        if onManualClose {
+          return survey
+        }
+      case .onPurchase:
+        if onPurchase {
+          return survey
+        }
+      }
+    }
+
+    return nil
   }
 
   @objc

--- a/Tests/SuperwallKitTests/Analytics/Internal Tracking/TrackTests.swift
+++ b/Tests/SuperwallKitTests/Analytics/Internal Tracking/TrackTests.swift
@@ -586,7 +586,7 @@ final class TrackingTests: XCTestCase {
 
   func test_paywallClose_survey_show() async {
     let paywall: Paywall = .stub()
-      .setting(\.survey, to: .stub())
+      .setting(\.surveys, to: [.stub()])
     let paywallInfo = paywall.getInfo(fromEvent: .stub(), factory: DependencyContainer())
     let result = await Superwall.shared.track(
       InternalSuperwallEvent.PaywallClose(
@@ -638,7 +638,7 @@ final class TrackingTests: XCTestCase {
 
   func test_paywallClose_survey_noShow() async {
     let paywall: Paywall = .stub()
-      .setting(\.survey, to: .stub())
+      .setting(\.surveys, to: [.stub()])
     let paywallInfo = paywall.getInfo(fromEvent: .stub(), factory: DependencyContainer())
     let result = await Superwall.shared.track(
       InternalSuperwallEvent.PaywallClose(
@@ -690,7 +690,7 @@ final class TrackingTests: XCTestCase {
 
   func test_paywallClose_survey_holdout() async {
     let paywall: Paywall = .stub()
-      .setting(\.survey, to: .stub())
+      .setting(\.surveys, to: [.stub()])
     let paywallInfo = paywall.getInfo(fromEvent: .stub(), factory: DependencyContainer())
     let result = await Superwall.shared.track(
       InternalSuperwallEvent.PaywallClose(
@@ -742,7 +742,7 @@ final class TrackingTests: XCTestCase {
 
   func test_paywallClose_noSurvey() async {
     let paywall: Paywall = .stub()
-      .setting(\.survey, to: nil)
+      .setting(\.surveys, to: [])
     let paywallInfo = paywall.getInfo(fromEvent: .stub(), factory: DependencyContainer())
     let result = await Superwall.shared.track(
       InternalSuperwallEvent.PaywallClose(

--- a/Tests/SuperwallKitTests/Config/Models/SurveyTests.swift
+++ b/Tests/SuperwallKitTests/Config/Models/SurveyTests.swift
@@ -27,7 +27,8 @@ final class SurveyTests: XCTestCase {
       message: "test",
       options: [.stub()],
       presentationProbability: 0,
-      includeOtherOption: true
+      includeOtherOption: true,
+      surveyPresentationCondition: .onManualClose
     )
     let isHoldout = survey.shouldAssignHoldout(
       isDebuggerLaunched: false,
@@ -44,7 +45,8 @@ final class SurveyTests: XCTestCase {
       message: "test",
       options: [.stub()],
       presentationProbability: 1,
-      includeOtherOption: true
+      includeOtherOption: true,
+      surveyPresentationCondition: .onManualClose
     )
     let isHoldout = survey.shouldAssignHoldout(
       isDebuggerLaunched: false,
@@ -61,7 +63,8 @@ final class SurveyTests: XCTestCase {
       message: "test",
       options: [.stub()],
       presentationProbability: 0.4,
-      includeOtherOption: true
+      includeOtherOption: true,
+      surveyPresentationCondition: .onManualClose
     )
     func random(in: Range<Double>) -> Double {
       return 0.5
@@ -89,7 +92,8 @@ final class SurveyTests: XCTestCase {
       message: "test",
       options: [.stub()],
       presentationProbability: 0.4,
-      includeOtherOption: true
+      includeOtherOption: true,
+      surveyPresentationCondition: .onManualClose
     )
     let existingAssignmentKey = "abc"
     let storage = StorageMock(internalSurveyAssignmentKey: existingAssignmentKey)
@@ -105,7 +109,8 @@ final class SurveyTests: XCTestCase {
       message: "test",
       options: [.stub()],
       presentationProbability: 0.4,
-      includeOtherOption: true
+      includeOtherOption: true,
+      surveyPresentationCondition: .onManualClose
     )
     let existingAssignmentKey = "abc"
     let storage = StorageMock(internalSurveyAssignmentKey: existingAssignmentKey)

--- a/Tests/SuperwallKitTests/Paywall/View Controller/SurveyManagerTests.swift
+++ b/Tests/SuperwallKitTests/Paywall/View Controller/SurveyManagerTests.swift
@@ -39,7 +39,7 @@ final class SurveyManagerTests: XCTestCase {
       survey,
       using: paywallVc,
       loadingState: .ready,
-      paywallIsManuallyDeclined: false,
+      shouldShow: false,
       isDebuggerLaunched: false,
       paywallInfo: .stub(),
       storage: StorageMock(),
@@ -79,7 +79,7 @@ final class SurveyManagerTests: XCTestCase {
       nil,
       using: paywallVc,
       loadingState: .ready,
-      paywallIsManuallyDeclined: true,
+      shouldShow: true,
       isDebuggerLaunched: false,
       paywallInfo: .stub(),
       storage: StorageMock(),
@@ -94,6 +94,7 @@ final class SurveyManagerTests: XCTestCase {
 
   func test_presentSurveyIfAvailable_loadingState_loadingPurchase() {
     let expectation = expectation(description: "called completion block")
+    expectation.isInverted = true
     let dependencyContainer = DependencyContainer()
 
     let messageHandler = PaywallMessageHandler(
@@ -119,17 +120,17 @@ final class SurveyManagerTests: XCTestCase {
       .stub(),
       using: paywallVc,
       loadingState: .loadingPurchase,
-      paywallIsManuallyDeclined: true,
+      shouldShow: true,
       isDebuggerLaunched: false,
       paywallInfo: .stub(),
       storage: StorageMock(),
       factory: dependencyContainer,
       completion: { result in
-        XCTAssertEqual(result, .noShow)
+        XCTAssertEqual(result, .show)
         expectation.fulfill()
       }
     )
-    wait(for: [expectation])
+    wait(for: [expectation], timeout: 0.2)
   }
 
   func test_presentSurveyIfAvailable_loadingState_loadingURL() {
@@ -159,7 +160,7 @@ final class SurveyManagerTests: XCTestCase {
       .stub(),
       using: paywallVc,
       loadingState: .loadingURL,
-      paywallIsManuallyDeclined: true,
+      shouldShow: true,
       isDebuggerLaunched: false,
       paywallInfo: .stub(),
       storage: StorageMock(),
@@ -199,7 +200,7 @@ final class SurveyManagerTests: XCTestCase {
       .stub(),
       using: paywallVc,
       loadingState: .manualLoading,
-      paywallIsManuallyDeclined: true,
+      shouldShow: true,
       isDebuggerLaunched: false,
       paywallInfo: .stub(),
       storage: StorageMock(),
@@ -239,7 +240,7 @@ final class SurveyManagerTests: XCTestCase {
       .stub(),
       using: paywallVc,
       loadingState: .unknown,
-      paywallIsManuallyDeclined: true,
+      shouldShow: true,
       isDebuggerLaunched: false,
       paywallInfo: .stub(),
       storage: StorageMock(),
@@ -283,7 +284,7 @@ final class SurveyManagerTests: XCTestCase {
       survey,
       using: paywallVc,
       loadingState: .ready,
-      paywallIsManuallyDeclined: true,
+      shouldShow: true,
       isDebuggerLaunched: false,
       paywallInfo: .stub(),
       storage: storageMock,
@@ -330,7 +331,7 @@ final class SurveyManagerTests: XCTestCase {
       survey,
       using: paywallVc,
       loadingState: .ready,
-      paywallIsManuallyDeclined: true,
+      shouldShow: true,
       isDebuggerLaunched: false,
       paywallInfo: .stub(),
       storage: storageMock,
@@ -376,7 +377,7 @@ final class SurveyManagerTests: XCTestCase {
       survey,
       using: paywallVc,
       loadingState: .ready,
-      paywallIsManuallyDeclined: true,
+      shouldShow: true,
       isDebuggerLaunched: true,
       paywallInfo: .stub(),
       storage: storageMock,
@@ -424,7 +425,7 @@ final class SurveyManagerTests: XCTestCase {
       survey,
       using: paywallVc,
       loadingState: .ready,
-      paywallIsManuallyDeclined: true,
+      shouldShow: true,
       isDebuggerLaunched: false,
       paywallInfo: .stub(),
       storage: storageMock,

--- a/Tests/SuperwallKitTests/Paywall/View Controller/SurveyManagerTests.swift
+++ b/Tests/SuperwallKitTests/Paywall/View Controller/SurveyManagerTests.swift
@@ -11,8 +11,11 @@ import XCTest
 @available(iOS 14.0, *)
 @MainActor
 final class SurveyManagerTests: XCTestCase {
-  func test_presentSurveyIfAvailable_paywallDeclined() {
-    let survey = Survey.stub()
+  func test_presentSurveyIfAvailable_paywallDeclined_purchaseSurvey() {
+    let surveys = [
+      Survey.stub()
+        .setting(\.surveyPresentationCondition, to: .onPurchase)
+    ]
     let expectation = expectation(description: "called completion block")
     let dependencyContainer = DependencyContainer()
 
@@ -36,10 +39,11 @@ final class SurveyManagerTests: XCTestCase {
     )
 
     SurveyManager.presentSurveyIfAvailable(
-      survey,
+      surveys,
+      paywallResult: .declined,
+      paywallCloseReason: .manualClose,
       using: paywallVc,
       loadingState: .ready,
-      shouldShow: false,
       isDebuggerLaunched: false,
       paywallInfo: .stub(),
       storage: StorageMock(),
@@ -49,7 +53,7 @@ final class SurveyManagerTests: XCTestCase {
         expectation.fulfill()
       }
     )
-    wait(for: [expectation])
+    wait(for: [expectation], timeout: 0.2)
   }
 
   func test_presentSurveyIfAvailable_surveyNil() {
@@ -76,10 +80,11 @@ final class SurveyManagerTests: XCTestCase {
     )
 
     SurveyManager.presentSurveyIfAvailable(
-      nil,
+      [],
+      paywallResult: .declined,
+      paywallCloseReason: .manualClose,
       using: paywallVc,
       loadingState: .ready,
-      shouldShow: true,
       isDebuggerLaunched: false,
       paywallInfo: .stub(),
       storage: StorageMock(),
@@ -89,7 +94,7 @@ final class SurveyManagerTests: XCTestCase {
         expectation.fulfill()
       }
     )
-    wait(for: [expectation])
+    wait(for: [expectation], timeout: 0.2)
   }
 
   func test_presentSurveyIfAvailable_loadingState_loadingPurchase() {
@@ -117,10 +122,11 @@ final class SurveyManagerTests: XCTestCase {
     )
 
     SurveyManager.presentSurveyIfAvailable(
-      .stub(),
+      [.stub().setting(\.surveyPresentationCondition, to: .onPurchase)],
+      paywallResult: .purchased(productId: "abc"),
+      paywallCloseReason: .systemLogic,
       using: paywallVc,
       loadingState: .loadingPurchase,
-      shouldShow: true,
       isDebuggerLaunched: false,
       paywallInfo: .stub(),
       storage: StorageMock(),
@@ -157,10 +163,11 @@ final class SurveyManagerTests: XCTestCase {
     )
 
     SurveyManager.presentSurveyIfAvailable(
-      .stub(),
+      [.stub().setting(\.surveyPresentationCondition, to: .onManualClose)],
+      paywallResult: .declined,
+      paywallCloseReason: .manualClose,
       using: paywallVc,
       loadingState: .loadingURL,
-      shouldShow: true,
       isDebuggerLaunched: false,
       paywallInfo: .stub(),
       storage: StorageMock(),
@@ -197,10 +204,11 @@ final class SurveyManagerTests: XCTestCase {
     )
 
     SurveyManager.presentSurveyIfAvailable(
-      .stub(),
+      [.stub().setting(\.surveyPresentationCondition, to: .onManualClose)],
+      paywallResult: .declined,
+      paywallCloseReason: .manualClose,
       using: paywallVc,
       loadingState: .manualLoading,
-      shouldShow: true,
       isDebuggerLaunched: false,
       paywallInfo: .stub(),
       storage: StorageMock(),
@@ -237,10 +245,11 @@ final class SurveyManagerTests: XCTestCase {
     )
 
     SurveyManager.presentSurveyIfAvailable(
-      .stub(),
+      [.stub().setting(\.surveyPresentationCondition, to: .onManualClose)],
+      paywallResult: .declined,
+      paywallCloseReason: .manualClose,
       using: paywallVc,
       loadingState: .unknown,
-      shouldShow: true,
       isDebuggerLaunched: false,
       paywallInfo: .stub(),
       storage: StorageMock(),
@@ -255,9 +264,11 @@ final class SurveyManagerTests: XCTestCase {
 
   func test_presentSurveyIfAvailable_sameAssignmentKey() {
     let storageMock = StorageMock(internalSurveyAssignmentKey: "1")
-    let survey = Survey.stub()
-      .setting(\.assignmentKey, to: "1")
-
+    let surveys = [
+      Survey.stub()
+        .setting(\.assignmentKey, to: "1")
+        .setting(\.surveyPresentationCondition, to: .onManualClose)
+    ]
     let expectation = expectation(description: "called completion block")
     let dependencyContainer = DependencyContainer()
 
@@ -281,10 +292,11 @@ final class SurveyManagerTests: XCTestCase {
     )
 
     SurveyManager.presentSurveyIfAvailable(
-      survey,
+      surveys,
+      paywallResult: .declined,
+      paywallCloseReason: .manualClose,
       using: paywallVc,
       loadingState: .ready,
-      shouldShow: true,
       isDebuggerLaunched: false,
       paywallInfo: .stub(),
       storage: storageMock,
@@ -301,8 +313,11 @@ final class SurveyManagerTests: XCTestCase {
   func test_presentSurveyIfAvailable_zeroPresentationProbability() {
     let storageMock = StorageMock()
 
-    let survey = Survey.stub()
-      .setting(\.presentationProbability, to: 0)
+    let surveys = [
+      Survey.stub()
+        .setting(\.presentationProbability, to: 0)
+        .setting(\.surveyPresentationCondition, to: .onManualClose)
+    ]
 
     let expectation = expectation(description: "called completion block")
     let dependencyContainer = DependencyContainer()
@@ -328,10 +343,11 @@ final class SurveyManagerTests: XCTestCase {
 
 
     SurveyManager.presentSurveyIfAvailable(
-      survey,
+      surveys,
+      paywallResult: .declined,
+      paywallCloseReason: .manualClose,
       using: paywallVc,
       loadingState: .ready,
-      shouldShow: true,
       isDebuggerLaunched: false,
       paywallInfo: .stub(),
       storage: storageMock,
@@ -348,7 +364,7 @@ final class SurveyManagerTests: XCTestCase {
   func test_presentSurveyIfAvailable_debuggerLaunched() {
     let storageMock = StorageMock()
 
-    let survey = Survey.stub()
+    let surveys = [Survey.stub()]
 
     let expectation = expectation(description: "called completion block")
     expectation.isInverted = true
@@ -374,10 +390,11 @@ final class SurveyManagerTests: XCTestCase {
     )
 
     SurveyManager.presentSurveyIfAvailable(
-      survey,
+      surveys,
+      paywallResult: .declined,
+      paywallCloseReason: .manualClose,
       using: paywallVc,
       loadingState: .ready,
-      shouldShow: true,
       isDebuggerLaunched: true,
       paywallInfo: .stub(),
       storage: storageMock,
@@ -395,8 +412,11 @@ final class SurveyManagerTests: XCTestCase {
     let storageMock = StorageMock()
     storageMock.reset()
 
-    let survey = Survey.stub()
-      .setting(\.presentationProbability, to: 1)
+    let surveys = [
+      Survey.stub()
+        .setting(\.presentationProbability, to: 1)
+        .setting(\.surveyPresentationCondition, to: .onManualClose)
+    ]
 
     let expectation = expectation(description: "called completion block")
     expectation.isInverted = true
@@ -422,10 +442,11 @@ final class SurveyManagerTests: XCTestCase {
     )
 
     SurveyManager.presentSurveyIfAvailable(
-      survey,
+      surveys,
+      paywallResult: .declined,
+      paywallCloseReason: .manualClose,
       using: paywallVc,
       loadingState: .ready,
-      shouldShow: true,
       isDebuggerLaunched: false,
       paywallInfo: .stub(),
       storage: storageMock,


### PR DESCRIPTION
## Changes in this pull request

- Adds an array of surveys on a paywall. Each survey has a `surveyPresentationCondition` which indicates whether it should show `ON_MANUAL_CLOSE` or `ON_PURCHASE`.

### Checklist

- [x] All unit and UI tests pass. Demo project builds and runs.
- [x] I added tests, an experiment, or detailed why my change isn't tested.
- [x] I added an entry to the `CHANGELOG.md` for any breaking changes, enhancements, or bug fixes.
- [x] I have run `swiftlint` in the main directory and fixed any issues.
- [ ] I have updated the SDK documentation as well as the online docs.
- [x] I have reviewed the [contributing guide](https://github.com/superwall-me/paywall-ios/tree/master/.github/CONTRIBUTING.md)
