### PR TITLE
Fallback to SK1 Transaction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ The changelog for `SuperwallKit`. Also see the [releases](https://github.com/sup
 
 - Fixes issue where a survey attached to a paywall wouldn't show if you were also using the `paywall_decline` trigger.
 - Fixes issue where verification was happening after the finishing of transactions when not using a `PurchaseController`.
+- Fixes issue where the retrieved `StoreTransaction` associated with the purchased product may be `nil`.
 
 ## 3.3.2
 

--- a/Sources/SuperwallKit/Analytics/Internal Tracking/Tracking.swift
+++ b/Sources/SuperwallKit/Analytics/Internal Tracking/Tracking.swift
@@ -83,11 +83,11 @@ extension Superwall {
       type: .presentation
     )
 
-     do {
-       try await waitForSubsStatusAndConfig(request, paywallStatePublisher: nil)
-     } catch {
-       return logErrors(from: request, error)
-     }
+    do {
+      try await waitForSubsStatusAndConfig(request, paywallStatePublisher: nil)
+    } catch {
+      return logErrors(from: request, error)
+    }
 
     let outcome = TrackingLogic.canTriggerPaywall(
       event,

--- a/Sources/SuperwallKit/Dependencies/DependencyContainer.swift
+++ b/Sources/SuperwallKit/Dependencies/DependencyContainer.swift
@@ -455,11 +455,7 @@ extension DependencyContainer: ComputedPropertyRequestsFactory {
 
 // MARK: - Purchased Transactions Factory
 extension DependencyContainer: PurchasedTransactionsFactory {
-  func makeInternallyPurchasedTransaction() async -> SKPaymentTransaction? {
-    return await storeKitManager.purchaseController.productPurchaser.purchasing.lastTransaction
-  }
-
-  func makeLastPurchasedTransaction(for productId: String) -> SKPaymentTransaction? {
-    return storeKitManager.purchaseController.productPurchaser.purchasedTransactions[productId]
+  func makePurchasingCoordinator() -> PurchasingCoordinator {
+    return storeKitManager.purchaseController.productPurchaser.coordinator
   }
 }

--- a/Sources/SuperwallKit/Dependencies/DependencyContainer.swift
+++ b/Sources/SuperwallKit/Dependencies/DependencyContainer.swift
@@ -9,6 +9,7 @@
 import UIKit
 import Combine
 import SystemConfiguration
+import StoreKit
 
 /// Contains all of the SDK's core utility objects that are normally directly injected as dependencies.
 ///
@@ -448,5 +449,16 @@ extension DependencyContainer: FeatureFlagsFactory {
 extension DependencyContainer: ComputedPropertyRequestsFactory {
   func makeComputedPropertyRequests() -> [ComputedPropertyRequest] {
     return configManager.config?.allComputedProperties ?? []
+  }
+}
+
+// MARK: - Purchased Transactions Factory
+extension DependencyContainer: PurchasedTransactionsFactory {
+  func makeInternallyPurchasedTransaction() async -> SKPaymentTransaction? {
+    return await storeKitManager.purchaseController.productPurchaser.purchasing.lastTransaction
+  }
+
+  func makeLastPurchasedTransaction(for productId: String) -> SKPaymentTransaction? {
+    return storeKitManager.purchaseController.productPurchaser.purchasedTransactions[productId]
   }
 }

--- a/Sources/SuperwallKit/Dependencies/FactoryProtocols.swift
+++ b/Sources/SuperwallKit/Dependencies/FactoryProtocols.swift
@@ -135,7 +135,5 @@ protocol TriggerFactory: AnyObject {
 }
 
 protocol PurchasedTransactionsFactory {
-  func makeInternallyPurchasedTransaction() async -> SKPaymentTransaction?
-
-  func makeLastPurchasedTransaction(for productId: String) -> SKPaymentTransaction?
+  func makePurchasingCoordinator() -> PurchasingCoordinator
 }

--- a/Sources/SuperwallKit/Dependencies/FactoryProtocols.swift
+++ b/Sources/SuperwallKit/Dependencies/FactoryProtocols.swift
@@ -8,6 +8,7 @@
 import UIKit
 import Combine
 import SystemConfiguration
+import StoreKit
 
 protocol ViewControllerFactory: AnyObject {
   @MainActor
@@ -131,4 +132,10 @@ protocol OptionsFactory: AnyObject {
 
 protocol TriggerFactory: AnyObject {
   func makeTriggers() -> Set<String>
+}
+
+protocol PurchasedTransactionsFactory {
+  func makeInternallyPurchasedTransaction() async -> SKPaymentTransaction?
+
+  func makeLastPurchasedTransaction(for productId: String) -> SKPaymentTransaction?
 }

--- a/Sources/SuperwallKit/Paywall/View Controller/PaywallViewController.swift
+++ b/Sources/SuperwallKit/Paywall/View Controller/PaywallViewController.swift
@@ -660,6 +660,9 @@ extension PaywallViewController {
 
   /// Determines whether a survey will show.
   private var willShowSurvey: Bool {
+    if paywall.surveys.isEmpty {
+      return false
+    }
     guard
       modalPresentationStyle == .formSheet ||
       modalPresentationStyle == .pageSheet ||

--- a/Sources/SuperwallKit/StoreKit/Transactions/Purchasing/ProductPurchaserSK1.swift
+++ b/Sources/SuperwallKit/StoreKit/Transactions/Purchasing/ProductPurchaserSK1.swift
@@ -38,6 +38,7 @@ final class ProductPurchaserSK1: NSObject {
     }
   }
   let purchasing = Purchasing()
+  var purchasedTransactions: [String: SKPaymentTransaction] = [:]
 
   // MARK: Restoration
   final class Restoration {
@@ -147,7 +148,7 @@ extension ProductPurchaserSK1: SKPaymentTransactionObserver {
         await checkForTimeout(of: transaction, in: paywallViewController)
         await updatePurchaseCompletionBlock(for: transaction)
         await checkForRestoration(transaction, isPaywallPresented: isPaywallPresented)
-
+        storeIfPurchased(transaction)
         Task(priority: .background) {
           await record(transaction)
         }
@@ -158,6 +159,15 @@ extension ProductPurchaserSK1: SKPaymentTransactionObserver {
   }
 
   // MARK: - Private API
+
+  /// Stores the transaction if purchased. This is used as a fallback if we can't
+  /// retrieve the transaction using SK2.
+  private func storeIfPurchased(_ transaction: SKPaymentTransaction) {
+    guard case .purchased = transaction.transactionState else {
+      return
+    }
+    purchasedTransactions[transaction.payment.productIdentifier] = transaction
+  }
 
   private func checkForTimeout(
     of transaction: SKPaymentTransaction,

--- a/Sources/SuperwallKit/StoreKit/Transactions/Purchasing/ProductPurchaserSK1.swift
+++ b/Sources/SuperwallKit/StoreKit/Transactions/Purchasing/ProductPurchaserSK1.swift
@@ -145,10 +145,10 @@ extension ProductPurchaserSK1: SKPaymentTransactionObserver {
       let isPaywallPresented = Superwall.shared.isPaywallPresented
       let paywallViewController = Superwall.shared.paywallViewController
       for transaction in transactions {
+        storeIfPurchased(transaction)
         await checkForTimeout(of: transaction, in: paywallViewController)
         await updatePurchaseCompletionBlock(for: transaction)
         await checkForRestoration(transaction, isPaywallPresented: isPaywallPresented)
-        storeIfPurchased(transaction)
         Task(priority: .background) {
           await record(transaction)
         }

--- a/Sources/SuperwallKit/StoreKit/Transactions/Purchasing/ProductPurchaserSK1.swift
+++ b/Sources/SuperwallKit/StoreKit/Transactions/Purchasing/ProductPurchaserSK1.swift
@@ -189,7 +189,10 @@ extension ProductPurchaserSK1: SKPaymentTransactionObserver {
         )
       } catch {
         SKPaymentQueue.default().finishTransaction(skTransaction)
-        await coordinator.completePurchase(result: .failed(error))
+        await coordinator.completePurchase(
+          of: skTransaction,
+          result: .failed(error)
+        )
       }
     case .failed:
       SKPaymentQueue.default().finishTransaction(skTransaction)
@@ -198,7 +201,10 @@ extension ProductPurchaserSK1: SKPaymentTransactionObserver {
           switch error.code {
           case .paymentCancelled,
             .overlayCancelled:
-            return await coordinator.completePurchase(result: .cancelled)
+            return await coordinator.completePurchase(
+              of: skTransaction,
+              result: .cancelled
+            )
           default:
             break
           }
@@ -206,13 +212,18 @@ extension ProductPurchaserSK1: SKPaymentTransactionObserver {
           if #available(iOS 14, *) {
             switch error.code {
             case .overlayTimeout:
-              await coordinator.completePurchase(result: .cancelled)
+              await coordinator.completePurchase(
+                of: skTransaction,
+                result: .cancelled
+              )
             default:
               break
             }
           }
         }
-        await coordinator.completePurchase(result: .failed(error))
+        await coordinator.completePurchase(
+          of: skTransaction,
+          result: .failed(error))
       }
     case .deferred:
       SKPaymentQueue.default().finishTransaction(skTransaction)

--- a/Sources/SuperwallKit/StoreKit/Transactions/Purchasing/PurchasingCoordinator.swift
+++ b/Sources/SuperwallKit/StoreKit/Transactions/Purchasing/PurchasingCoordinator.swift
@@ -1,0 +1,137 @@
+//
+//  File.swift
+//  
+//
+//  Created by Yusuf Tör on 14/09/2023.
+//
+
+import Foundation
+import StoreKit
+
+/// An actor that manages and coordinates the storing of types associated with purchasing.
+actor PurchasingCoordinator {
+  private var completion: ((PurchaseResult) -> Void)?
+  var productId: String?
+  var lastInternalTransaction: SKPaymentTransaction?
+  var purchaseDate: Date?
+  var transactions: [String: SKPaymentTransaction] = [:]
+
+  /// A boolean indicating whether the given `date` is within an hour of the `purchaseDate`.
+  func dateIsWithinLastHour(_ date: Date?) -> Bool {
+    guard
+      let date = date,
+      let transactionDate = purchaseDate
+    else {
+      return false
+    }
+    let oneHourBeforePurchase = date.addingTimeInterval(-3600)
+    return oneHourBeforePurchase.compare(transactionDate) == .orderedAscending
+  }
+
+  func setCompletion(_ completion: @escaping (PurchaseResult) -> Void) {
+    self.completion = completion
+  }
+
+  func beginPurchase(of productId: String) {
+    self.purchaseDate = Date()
+    self.productId = productId
+  }
+
+  /// Gets the latest transaction of a specified product ID.
+  func getLatestTransaction(
+    forProductId productId: String,
+    factory: StoreTransactionFactory
+  ) async -> StoreTransaction? {
+    // Get the date a purchase was initiated. This can never be nil after
+    // a purchase.
+    guard let purchaseDate = purchaseDate else {
+      return nil
+    }
+
+    // If on iOS 15+, try and get latest transaction using SK2.
+    if #available(iOS 15.0, *) {
+      let verificationResult = await Transaction.latest(for: productId)
+
+      // Get the unverified transaction (as verification step will have
+      // been done by now).
+      // The date must be within an hour of purchase.
+      if let transaction = verificationResult.map({ $0.unsafePayloadValue }),
+        purchaseDate.addingTimeInterval(-3600).compare(transaction.purchaseDate) == .orderedAscending {
+        return await factory.makeStoreTransaction(from: transaction)
+      }
+    }
+
+    // If no transaction retrieved, try to get last transaction if
+    // the SDK handled purchasing.
+    if let transaction = lastInternalTransaction {
+      return await factory.makeStoreTransaction(from: transaction)
+    }
+
+    func getLastExternalStoreTransaction() async -> StoreTransaction? {
+      if let transaction = transactions[productId],
+        dateIsWithinLastHour(transaction.transactionDate) {
+        return await factory.makeStoreTransaction(from: transaction)
+      }
+      return nil
+    }
+
+    // Otherwise get the last externally purchased transaction from the payment queue.
+    if let transaction = await getLastExternalStoreTransaction() {
+      return transaction
+    }
+
+    // If still no transaction, wait 500ms and try again before returning nil.
+    try? await Task.sleep(nanoseconds: 500_000_000)
+
+    if let transaction = await getLastExternalStoreTransaction() {
+      return transaction
+    }
+
+    return nil
+  }
+
+  /// Stores the transaction if purchased and is the latest for a specific product ID.
+  /// This is used as a fallback if we can't retrieve the transaction using SK2.
+  func storeIfPurchased(_ transaction: SK1Transaction) async {
+    guard case .purchased = transaction.transactionState else {
+      return
+    }
+    let productId = transaction.payment.productIdentifier
+
+    // If there is an existing transaction, which has a transaction date...
+    if let existingTransaction = transactions[productId],
+      let existingTransactionDate = existingTransaction.transactionDate {
+      // And if the new transaction date was after the stored transaction, update.
+      // Else, ignore.
+      if transaction.transactionDate?.compare(existingTransactionDate) == .orderedDescending {
+        transactions[productId] = transaction
+      }
+    } else {
+      // If there isn't an existing transaction, store.
+      transactions[productId] = transaction
+    }
+  }
+
+  func completePurchase(
+    of transaction: SK1Transaction? = nil,
+    result: PurchaseResult
+  ) {
+    // Only complete if the product ID of the transaction is the same as
+    // the purchasing transaction.
+    guard productId == transaction?.payment.productIdentifier else {
+      return
+    }
+    // If the transaction completed a purchase, check it is within the last
+    // hour since starting purchase. Otherwise old purchased products may come
+    // through and complete the purchase.
+    if result == .purchased {
+      guard dateIsWithinLastHour(transaction?.transactionDate) else {
+        return
+      }
+    }
+    lastInternalTransaction = transaction
+    completion?(result)
+    completion = nil
+    productId = nil
+  }
+}

--- a/Sources/SuperwallKit/StoreKit/Transactions/Purchasing/PurchasingCoordinator.swift
+++ b/Sources/SuperwallKit/StoreKit/Transactions/Purchasing/PurchasingCoordinator.swift
@@ -113,19 +113,19 @@ actor PurchasingCoordinator {
   }
 
   func completePurchase(
-    of transaction: SK1Transaction? = nil,
+    of transaction: SK1Transaction,
     result: PurchaseResult
   ) {
     // Only complete if the product ID of the transaction is the same as
     // the purchasing transaction.
-    guard productId == transaction?.payment.productIdentifier else {
+    guard productId == transaction.payment.productIdentifier else {
       return
     }
     // If the transaction completed a purchase, check it is within the last
     // hour since starting purchase. Otherwise old purchased products may come
     // through and complete the purchase.
     if result == .purchased {
-      guard dateIsWithinLastHour(transaction?.transactionDate) else {
+      guard dateIsWithinLastHour(transaction.transactionDate) else {
         return
       }
     }

--- a/Tests/SuperwallKitTests/Config/Models/SurveyTests.swift
+++ b/Tests/SuperwallKitTests/Config/Models/SurveyTests.swift
@@ -29,7 +29,7 @@ final class SurveyTests: XCTestCase {
       presentationProbability: 0,
       includeOtherOption: true,
       includeCloseOption: true,
-      surveyPresentationCondition: .onManualClose
+      presentationCondition: .onManualClose
     )
     let isHoldout = survey.shouldAssignHoldout(
       isDebuggerLaunched: false,
@@ -48,7 +48,7 @@ final class SurveyTests: XCTestCase {
       presentationProbability: 1,
       includeOtherOption: true,
       includeCloseOption: true,
-      surveyPresentationCondition: .onManualClose
+      presentationCondition: .onManualClose
     )
     let isHoldout = survey.shouldAssignHoldout(
       isDebuggerLaunched: false,
@@ -67,7 +67,7 @@ final class SurveyTests: XCTestCase {
       presentationProbability: 0.4,
       includeOtherOption: true,
       includeCloseOption: true,
-      surveyPresentationCondition: .onManualClose
+      presentationCondition: .onManualClose
     )
     func random(in: Range<Double>) -> Double {
       return 0.5
@@ -97,7 +97,7 @@ final class SurveyTests: XCTestCase {
       presentationProbability: 0.4,
       includeOtherOption: true,
       includeCloseOption: true,
-      surveyPresentationCondition: .onManualClose
+      presentationCondition: .onManualClose
     )
     let existingAssignmentKey = "abc"
     let storage = StorageMock(internalSurveyAssignmentKey: existingAssignmentKey)
@@ -115,7 +115,7 @@ final class SurveyTests: XCTestCase {
       presentationProbability: 0.4,
       includeOtherOption: true,
       includeCloseOption: true,
-      surveyPresentationCondition: .onManualClose
+      presentationCondition: .onManualClose
     )
     let existingAssignmentKey = "abc"
     let storage = StorageMock(internalSurveyAssignmentKey: existingAssignmentKey)

--- a/Tests/SuperwallKitTests/Paywall/View Controller/SurveyManagerTests.swift
+++ b/Tests/SuperwallKitTests/Paywall/View Controller/SurveyManagerTests.swift
@@ -14,7 +14,7 @@ final class SurveyManagerTests: XCTestCase {
   func test_presentSurveyIfAvailable_paywallDeclined_purchaseSurvey() {
     let surveys = [
       Survey.stub()
-        .setting(\.surveyPresentationCondition, to: .onPurchase)
+        .setting(\.presentationCondition, to: .onPurchase)
     ]
     let expectation = expectation(description: "called completion block")
     let dependencyContainer = DependencyContainer()
@@ -122,7 +122,7 @@ final class SurveyManagerTests: XCTestCase {
     )
 
     SurveyManager.presentSurveyIfAvailable(
-      [.stub().setting(\.surveyPresentationCondition, to: .onPurchase)],
+      [.stub().setting(\.presentationCondition, to: .onPurchase)],
       paywallResult: .purchased(productId: "abc"),
       paywallCloseReason: .systemLogic,
       using: paywallVc,
@@ -163,7 +163,7 @@ final class SurveyManagerTests: XCTestCase {
     )
 
     SurveyManager.presentSurveyIfAvailable(
-      [.stub().setting(\.surveyPresentationCondition, to: .onManualClose)],
+      [.stub().setting(\.presentationCondition, to: .onManualClose)],
       paywallResult: .declined,
       paywallCloseReason: .manualClose,
       using: paywallVc,
@@ -204,7 +204,7 @@ final class SurveyManagerTests: XCTestCase {
     )
 
     SurveyManager.presentSurveyIfAvailable(
-      [.stub().setting(\.surveyPresentationCondition, to: .onManualClose)],
+      [.stub().setting(\.presentationCondition, to: .onManualClose)],
       paywallResult: .declined,
       paywallCloseReason: .manualClose,
       using: paywallVc,
@@ -245,7 +245,7 @@ final class SurveyManagerTests: XCTestCase {
     )
 
     SurveyManager.presentSurveyIfAvailable(
-      [.stub().setting(\.surveyPresentationCondition, to: .onManualClose)],
+      [.stub().setting(\.presentationCondition, to: .onManualClose)],
       paywallResult: .declined,
       paywallCloseReason: .manualClose,
       using: paywallVc,
@@ -267,7 +267,7 @@ final class SurveyManagerTests: XCTestCase {
     let surveys = [
       Survey.stub()
         .setting(\.assignmentKey, to: "1")
-        .setting(\.surveyPresentationCondition, to: .onManualClose)
+        .setting(\.presentationCondition, to: .onManualClose)
     ]
     let expectation = expectation(description: "called completion block")
     let dependencyContainer = DependencyContainer()
@@ -316,7 +316,7 @@ final class SurveyManagerTests: XCTestCase {
     let surveys = [
       Survey.stub()
         .setting(\.presentationProbability, to: 0)
-        .setting(\.surveyPresentationCondition, to: .onManualClose)
+        .setting(\.presentationCondition, to: .onManualClose)
     ]
 
     let expectation = expectation(description: "called completion block")
@@ -415,7 +415,7 @@ final class SurveyManagerTests: XCTestCase {
     let surveys = [
       Survey.stub()
         .setting(\.presentationProbability, to: 1)
-        .setting(\.surveyPresentationCondition, to: .onManualClose)
+        .setting(\.presentationCondition, to: .onManualClose)
     ]
 
     let expectation = expectation(description: "called completion block")


### PR DESCRIPTION
## Changes in this pull request

- Fixes issue where the retrieved `StoreTransaction` associated with the purchased product may be `nil`. This stores every purchased transaction by product ID if the transaction date of the purchased transaction is > the last stored transaction. Then, when getting the latest transaction it defaults to SK2 and checks it has a transaction date within the last hour. If that fails, then it gets the `lastInternalTransaction`, i.e. the transaction that caused the internal purchase controller to mark the transaction as purchased. Otherwise, we fallback to getting the last transaction whose date is within the last hour. If that fails, we wait 500ms before trying again and finally returning nil.
- When completing a purchase, we check whether the productId of the purchase is the one being purchased. We also check that the `transactionDate` of the purchase is within the last hour to stop old purchases from completing the purchase.

### Checklist

- [x] All unit and UI tests pass. Demo project builds and runs.
- [ ] I added tests, an experiment, or detailed why my change isn't tested.
- [x] I added an entry to the `CHANGELOG.md` for any breaking changes, enhancements, or bug fixes.
- [x] I have run `swiftlint` in the main directory and fixed any issues.
- [ ] I have updated the SDK documentation as well as the online docs.
- [ ] I have reviewed the [contributing guide](https://github.com/superwall-me/paywall-ios/tree/master/.github/CONTRIBUTING.md)
