### PR TITLE
Feature/add restore to purchase result

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,10 @@ The changelog for `SuperwallKit`. Also see the [releases](https://github.com/sup
 
 ## 3.4.3-beta.1
 
-### Fixes
+### Enhancements
 
 - Adds a `.restored` case to `PurchaseResult` and `PurchaseResultObjc`. Return this from your `PurchaseController` when you detect a user has tried to purchase a product that they've already purchased. If you let Superwall handle purchasing, then we will automatically detect this.
-- Adds `restore_via_purchase_attempt` to a `transaction_restore` event.
+- Adds `restore_via_purchase_attempt` to a `transaction_restore` event. This indicates whether the restoration happened due to the user purchasing or restoring.
 
 ## 3.4.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 The changelog for `SuperwallKit`. Also see the [releases](https://github.com/superwall-me/Superwall-iOS/releases) on GitHub.
 
+## 3.4.3-beta.1
+
+### Fixes
+
+- Adds a `.restored` case to `PurchaseResult` and `PurchaseResultObjc`. Return this from your `PurchaseController` when you detect a user has tried to purchase a product that they've already purchased. If you let Superwall handle purchasing, then we will automatically detect this.
+
+
 ## 3.4.2
 
 ### Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,14 +2,14 @@
 
 The changelog for `SuperwallKit`. Also see the [releases](https://github.com/superwall-me/Superwall-iOS/releases) on GitHub.
 
-## 3.4.4
+## 3.4.3
 
 ### Enhancements
 
 - Exposes `isPaywallPresented` convenience variable.
 - Adds `device_attributes` event, which tracks the device attributes every new session.
 - Stops preloading paywalls that we know won't ever match.
-- Adds a `.restored` case to `PurchaseResult` and `PurchaseResultObjc`. Return this from your `PurchaseController` when you detect a user has tried to purchase a product that they've already purchased. If you let Superwall handle purchasing, then we will automatically detect this.
+- Adds a `.restored` case to `PurchaseResult` and `PurchaseResultObjc`. Return this from your `PurchaseController` when you detect a user has tried to purchase a product that they've already purchased. This happens when `transaction.transactionDate < purchaseDate`, where `purchaseDate` is the date that the purchase was initiated. Check out `RCPurchaseController.swift` in our Superwall-UIKit+RevenueCat example app for how to implement this. If you let Superwall handle purchasing, then we will automatically detect this.
 - Adds `restore_via_purchase_attempt` to a `transaction_restore` event. This indicates whether the restoration happened due to the user purchasing or restoring.
 
 ## 3.4.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ The changelog for `SuperwallKit`. Also see the [releases](https://github.com/sup
 ### Fixes
 
 - Adds a `.restored` case to `PurchaseResult` and `PurchaseResultObjc`. Return this from your `PurchaseController` when you detect a user has tried to purchase a product that they've already purchased. If you let Superwall handle purchasing, then we will automatically detect this.
-
+- Adds `restore_via_purchase_attempt` to a `transaction_restore` event.
 
 ## 3.4.2
 

--- a/Examples/UIKit+RevenueCat/Superwall-UIKit+RevenueCat/RCPurchaseController.swift
+++ b/Examples/UIKit+RevenueCat/Superwall-UIKit+RevenueCat/RCPurchaseController.swift
@@ -45,12 +45,18 @@ final class RCPurchaseController: PurchaseController {
   /// someone tries to purchase a product on one of your paywalls.
   func purchase(product: SKProduct) async -> PurchaseResult {
     do {
+      let purchaseDate = Date()
       let storeProduct = RevenueCat.StoreProduct(sk1Product: product)
       let revenueCatResult = try await Purchases.shared.purchase(product: storeProduct)
       if revenueCatResult.userCancelled {
         return .cancelled
       } else {
-        return .purchased
+        if let transaction = revenueCatResult.transaction,
+           purchaseDate > transaction.purchaseDate {
+          return .restored
+        } else {
+          return .purchased
+        }
       }
     } catch let error as ErrorCode {
       if error == .paymentPendingError {

--- a/Sources/SuperwallKit/Analytics/Internal Tracking/Trackable Events/TrackableSuperwallEvent.swift
+++ b/Sources/SuperwallKit/Analytics/Internal Tracking/Trackable Events/TrackableSuperwallEvent.swift
@@ -399,7 +399,7 @@ enum InternalSuperwallEvent {
       case fail(TransactionError)
       case abandon(StoreProduct)
       case complete(StoreProduct, StoreTransaction?)
-      case restore(viaPurchase: Bool)
+      case restore(RestoreType)
       case timeout
     }
     let state: State
@@ -427,8 +427,11 @@ enum InternalSuperwallEvent {
           product: product,
           paywallInfo: paywallInfo
         )
-      case .restore:
-        return .transactionRestore(paywallInfo: paywallInfo)
+      case .restore(let restoreType):
+        return .transactionRestore(
+          restoreType: restoreType,
+          paywallInfo: paywallInfo
+        )
       case .timeout:
         return .transactionTimeout(paywallInfo: paywallInfo)
       }
@@ -442,12 +445,12 @@ enum InternalSuperwallEvent {
 
     func getSuperwallParameters() async -> [String: Any] {
       switch state {
-      case .restore(let viaPurchase):
+      case .restore:
         var eventParams = await paywallInfo.eventParams(forProduct: product)
         if let transactionDict = model?.dictionary(withSnakeCase: true) {
           eventParams += transactionDict
         }
-        eventParams["restore_via_purchase_attempt"] = viaPurchase
+        eventParams["restore_via_purchase_attempt"] = model != nil
         return eventParams
       case .start,
         .abandon,

--- a/Sources/SuperwallKit/Analytics/Internal Tracking/Trackable Events/TrackableSuperwallEvent.swift
+++ b/Sources/SuperwallKit/Analytics/Internal Tracking/Trackable Events/TrackableSuperwallEvent.swift
@@ -399,7 +399,7 @@ enum InternalSuperwallEvent {
       case fail(TransactionError)
       case abandon(StoreProduct)
       case complete(StoreProduct, StoreTransaction?)
-      case restore
+      case restore(viaPurchase: Bool)
       case timeout
     }
     let state: State
@@ -442,10 +442,16 @@ enum InternalSuperwallEvent {
 
     func getSuperwallParameters() async -> [String: Any] {
       switch state {
+      case .restore(let viaPurchase):
+        var eventParams = await paywallInfo.eventParams(forProduct: product)
+        if let transactionDict = model?.dictionary(withSnakeCase: true) {
+          eventParams += transactionDict
+        }
+        eventParams["restore_via_purchase_attempt"] = viaPurchase
+        return eventParams
       case .start,
         .abandon,
         .complete,
-        .restore,
         .timeout:
         var eventParams = await paywallInfo.eventParams(forProduct: product)
         if let transactionDict = model?.dictionary(withSnakeCase: true) {

--- a/Sources/SuperwallKit/Analytics/Superwall Event/SuperwallEvent.swift
+++ b/Sources/SuperwallKit/Analytics/Superwall Event/SuperwallEvent.swift
@@ -79,8 +79,8 @@ public enum SuperwallEvent {
   /// When the user successfully completes a transaction for a subscription product with an introductory offer.
   case freeTrialStart(product: StoreProduct, paywallInfo: PaywallInfo)
 
-  /// When the user successfully restores their purchases.
-  case transactionRestore(paywallInfo: PaywallInfo)
+  /// When the user successfully restores purchases..
+  case transactionRestore(restoreType: RestoreType, paywallInfo: PaywallInfo)
 
   /// When the transaction took > 5 seconds to show the payment sheet.
   case transactionTimeout(paywallInfo: PaywallInfo)

--- a/Sources/SuperwallKit/Delegate/PurchaseResult.swift
+++ b/Sources/SuperwallKit/Delegate/PurchaseResult.swift
@@ -39,6 +39,9 @@ public enum PurchaseResult: Sendable, Equatable {
   /// The product was purchased.
   case purchased
 
+  /// The product was restored.
+  case restored
+
   /// The purchase is pending and requires action from the developer.
   ///
   /// In StoreKit 1, this is the same as the `.deferred` transaction state.
@@ -86,6 +89,9 @@ public enum PurchaseResultObjc: Int, Sendable, Equatable {
 
   /// The product was purchased.
   case purchased
+
+  /// The product was restored.
+  case restored
 
   /// The purchase is pending and requires action from the developer.
   ///

--- a/Sources/SuperwallKit/Misc/Constants.swift
+++ b/Sources/SuperwallKit/Misc/Constants.swift
@@ -18,5 +18,5 @@ let sdkVersion = """
 */
 
 let sdkVersion = """
-3.4.2
+3.4.3-beta.1
 """

--- a/Sources/SuperwallKit/Misc/Constants.swift
+++ b/Sources/SuperwallKit/Misc/Constants.swift
@@ -18,5 +18,5 @@ let sdkVersion = """
 */
 
 let sdkVersion = """
-3.4.3-beta.1
+3.4.3
 """

--- a/Sources/SuperwallKit/StoreKit/InternalPurchaseController.swift
+++ b/Sources/SuperwallKit/StoreKit/InternalPurchaseController.swift
@@ -73,59 +73,6 @@ extension InternalPurchaseController {
       return result
     }
   }
-
-  @MainActor
-  func tryToRestore(from paywallViewController: PaywallViewController) async {
-    Logger.debug(
-      logLevel: .debug,
-      scope: .paywallTransactions,
-      message: "Attempting Restore"
-    )
-
-    paywallViewController.loadingState = .loadingPurchase
-
-    let restorationResult = await restorePurchases()
-
-    let hasRestored = restorationResult == .restored
-    let isUserSubscribed = Superwall.shared.subscriptionStatus == .active
-
-    if hasRestored && isUserSubscribed {
-      Logger.debug(
-        logLevel: .debug,
-        scope: .paywallTransactions,
-        message: "Transactions Restored"
-      )
-      await transactionWasRestored(paywallViewController: paywallViewController)
-    } else {
-      Logger.debug(
-        logLevel: .debug,
-        scope: .paywallTransactions,
-        message: "Transactions Failed to Restore"
-      )
-
-      paywallViewController.presentAlert(
-        title: Superwall.shared.options.paywalls.restoreFailed.title,
-        message: Superwall.shared.options.paywalls.restoreFailed.message,
-        closeActionTitle: Superwall.shared.options.paywalls.restoreFailed.closeButtonTitle
-      )
-    }
-  }
-
-  private func transactionWasRestored(paywallViewController: PaywallViewController) async {
-    let paywallInfo = await paywallViewController.info
-
-    let trackedEvent = InternalSuperwallEvent.Transaction(
-      state: .restore,
-      paywallInfo: paywallInfo,
-      product: nil,
-      model: nil
-    )
-    await Superwall.shared.track(trackedEvent)
-
-    if Superwall.shared.options.paywalls.automaticallyDismiss {
-      await Superwall.shared.dismiss(paywallViewController, result: .restored)
-    }
-  }
 }
 
 // MARK: - Purchasing
@@ -146,6 +93,8 @@ extension InternalPurchaseController {
             switch result {
             case .purchased:
               continuation.resume(returning: .purchased)
+            case .restored:
+              continuation.resume(returning: .restored)
             case .pending:
               continuation.resume(returning: .pending)
             case .cancelled:

--- a/Sources/SuperwallKit/StoreKit/Transactions/Purchasing/ProductPurchaserSK1.swift
+++ b/Sources/SuperwallKit/StoreKit/Transactions/Purchasing/ProductPurchaserSK1.swift
@@ -4,6 +4,7 @@
 //
 //  Created by Yusuf Tör on 06/12/2022.
 //
+// swiftlint:disable function_body_length
 
 import Foundation
 import StoreKit

--- a/Sources/SuperwallKit/StoreKit/Transactions/Purchasing/ProductPurchaserSK1.swift
+++ b/Sources/SuperwallKit/StoreKit/Transactions/Purchasing/ProductPurchaserSK1.swift
@@ -186,10 +186,17 @@ extension ProductPurchaserSK1: SKPaymentTransactionObserver {
         )
         SKPaymentQueue.default().finishTransaction(skTransaction)
 
-        await coordinator.completePurchase(
-          of: skTransaction,
-          result: .purchased
-        )
+        if hasRestored(skTransaction, purchaseDate: purchaseDate) {
+          await coordinator.completePurchase(
+            of: skTransaction,
+            result: .restored
+          )
+        } else {
+          await coordinator.completePurchase(
+            of: skTransaction,
+            result: .purchased
+          )
+        }
       } catch {
         SKPaymentQueue.default().finishTransaction(skTransaction)
         await coordinator.completePurchase(
@@ -258,29 +265,18 @@ extension ProductPurchaserSK1: SKPaymentTransactionObserver {
     )
   }
 
-  @available(iOS 15.0, *)
   private func hasRestored(
-    _ transaction: StoreTransaction,
-    purchaseStartAt: Date?
+    _ transaction: SKPaymentTransaction,
+    purchaseDate: Date?
   ) -> Bool {
-    guard let purchaseStartAt = purchaseStartAt else {
+    guard let purchaseDate = purchaseDate else {
       return false
     }
     // If has a transaction date and that happened before purchase
     // button was pressed...
     if let transactionDate = transaction.transactionDate,
-      transactionDate < purchaseStartAt {
-      // ...and if it has an expiration date that expires in the future,
-      // then we must have restored.
-      if let expirationDate = transaction.expirationDate {
-        if expirationDate >= Date() {
-          return true
-        }
-      } else {
-        // If no expiration date, it must be a non-consumable product
-        // which has been restored.
-        return true
-      }
+      transactionDate < purchaseDate {
+      return true
     }
 
     return false

--- a/Sources/SuperwallKit/StoreKit/Transactions/Purchasing/PurchasingCoordinator.swift
+++ b/Sources/SuperwallKit/StoreKit/Transactions/Purchasing/PurchasingCoordinator.swift
@@ -126,8 +126,8 @@ actor PurchasingCoordinator {
       guard dateIsWithinLastHour(transaction.transactionDate) else {
         return
       }
+      lastInternalTransaction = transaction
     }
-    lastInternalTransaction = transaction
     completion?(result)
     completion = nil
     productId = nil

--- a/Sources/SuperwallKit/StoreKit/Transactions/Purchasing/PurchasingCoordinator.swift
+++ b/Sources/SuperwallKit/StoreKit/Transactions/Purchasing/PurchasingCoordinator.swift
@@ -36,7 +36,8 @@ actor PurchasingCoordinator {
     self.productId = productId
   }
 
-  /// Gets the latest transaction of a specified product ID.
+  /// Gets the latest transaction of a specified product ID. Used with purchases, including when a purchase has
+  /// resulted in a restore.
   func getLatestTransaction(
     forProductId productId: String,
     factory: StoreTransactionFactory
@@ -62,7 +63,9 @@ actor PurchasingCoordinator {
     // If no transaction retrieved, try to get last transaction if
     // the SDK handled purchasing.
     if let transaction = lastInternalTransaction {
-      return await factory.makeStoreTransaction(from: transaction)
+      let storeTransaction = await factory.makeStoreTransaction(from: transaction)
+      lastInternalTransaction = nil
+      return storeTransaction
     }
 
     func getLastExternalStoreTransaction() async -> StoreTransaction? {
@@ -73,7 +76,10 @@ actor PurchasingCoordinator {
       return nil
     }
 
-    // Otherwise get the last externally purchased transaction from the payment queue.
+    // Otherwise get the last externally purchased
+    // transaction from the payment queue. This won't work
+    // with a purchase that results in a restore. That
+    // should be caught by the above  instead.
     if let transaction = await getLastExternalStoreTransaction() {
       return transaction
     }
@@ -126,8 +132,8 @@ actor PurchasingCoordinator {
       guard dateIsWithinLastHour(transaction.transactionDate) else {
         return
       }
-      lastInternalTransaction = transaction
     }
+    lastInternalTransaction = transaction
     completion?(result)
     completion = nil
     productId = nil

--- a/Sources/SuperwallKit/StoreKit/Transactions/RestoreType.swift
+++ b/Sources/SuperwallKit/StoreKit/Transactions/RestoreType.swift
@@ -1,0 +1,17 @@
+//
+//  File.swift
+//  
+//
+//  Created by Yusuf Tör on 09/10/2023.
+//
+
+import Foundation
+
+/// An enum whose cases describe the type of restore that occurred.
+public enum RestoreType {
+  /// The user tried to purchase a product and it resulted in a restore.
+  case viaPurchase(StoreTransaction?)
+
+  /// The user tried to restore purchases.
+  case viaRestore
+}

--- a/Sources/SuperwallKit/StoreKit/Transactions/TransactionManager.swift
+++ b/Sources/SuperwallKit/StoreKit/Transactions/TransactionManager.swift
@@ -58,6 +58,8 @@ final class TransactionManager {
         product,
         from: paywallViewController
       )
+    case .restored:
+      await transactionWasRestored(paywallViewController: paywallViewController)
     case .failed(let error):
       let superwallOptions = factory.makeSuperwallOptions()
       guard let outcome = TransactionErrorLogic.handle(
@@ -94,6 +96,59 @@ final class TransactionManager {
       await handlePendingTransaction(from: paywallViewController)
     case .cancelled:
       await trackCancelled(product: product, from: paywallViewController)
+    }
+  }
+
+  @MainActor
+  func tryToRestore(from paywallViewController: PaywallViewController) async {
+    Logger.debug(
+      logLevel: .debug,
+      scope: .paywallTransactions,
+      message: "Attempting Restore"
+    )
+
+    paywallViewController.loadingState = .loadingPurchase
+
+    let restorationResult = await storeKitManager.purchaseController.restorePurchases()
+
+    let hasRestored = restorationResult == .restored
+    let isUserSubscribed = Superwall.shared.subscriptionStatus == .active
+
+    if hasRestored && isUserSubscribed {
+      Logger.debug(
+        logLevel: .debug,
+        scope: .paywallTransactions,
+        message: "Transactions Restored"
+      )
+      await transactionWasRestored(paywallViewController: paywallViewController)
+    } else {
+      Logger.debug(
+        logLevel: .debug,
+        scope: .paywallTransactions,
+        message: "Transactions Failed to Restore"
+      )
+
+      paywallViewController.presentAlert(
+        title: Superwall.shared.options.paywalls.restoreFailed.title,
+        message: Superwall.shared.options.paywalls.restoreFailed.message,
+        closeActionTitle: Superwall.shared.options.paywalls.restoreFailed.closeButtonTitle
+      )
+    }
+  }
+
+  private func transactionWasRestored(paywallViewController: PaywallViewController) async {
+    let paywallInfo = await paywallViewController.info
+
+    let trackedEvent = InternalSuperwallEvent.Transaction(
+      state: .restore,
+      paywallInfo: paywallInfo,
+      product: nil,
+      model: nil
+    )
+    await Superwall.shared.track(trackedEvent)
+
+    if Superwall.shared.options.paywalls.automaticallyDismiss {
+      await Superwall.shared.dismiss(paywallViewController, result: .restored)
     }
   }
 

--- a/Sources/SuperwallKit/StoreKit/Transactions/TransactionManager.swift
+++ b/Sources/SuperwallKit/StoreKit/Transactions/TransactionManager.swift
@@ -59,7 +59,10 @@ final class TransactionManager {
         from: paywallViewController
       )
     case .restored:
-      await transactionWasRestored(paywallViewController: paywallViewController)
+      await transactionWasRestored(
+        paywallViewController: paywallViewController,
+        viaPurchase: true
+      )
     case .failed(let error):
       let superwallOptions = factory.makeSuperwallOptions()
       guard let outcome = TransactionErrorLogic.handle(
@@ -120,7 +123,10 @@ final class TransactionManager {
         scope: .paywallTransactions,
         message: "Transactions Restored"
       )
-      await transactionWasRestored(paywallViewController: paywallViewController)
+      await transactionWasRestored(
+        paywallViewController: paywallViewController,
+        viaPurchase: false
+      )
     } else {
       Logger.debug(
         logLevel: .debug,
@@ -136,11 +142,14 @@ final class TransactionManager {
     }
   }
 
-  private func transactionWasRestored(paywallViewController: PaywallViewController) async {
+  private func transactionWasRestored(
+    paywallViewController: PaywallViewController,
+    viaPurchase: Bool
+  ) async {
     let paywallInfo = await paywallViewController.info
 
     let trackedEvent = InternalSuperwallEvent.Transaction(
-      state: .restore,
+      state: .restore(viaPurchase: viaPurchase),
       paywallInfo: paywallInfo,
       product: nil,
       model: nil

--- a/Sources/SuperwallKit/Superwall.swift
+++ b/Sources/SuperwallKit/Superwall.swift
@@ -478,7 +478,7 @@ extension Superwall: PaywallViewControllerEventDelegate {
         from: paywallViewController
       )
     case .initiateRestore:
-      await dependencyContainer.storeKitManager.purchaseController.tryToRestore(from: paywallViewController)
+      await dependencyContainer.transactionManager.tryToRestore(from: paywallViewController)
     case .openedURL(let url):
       dependencyContainer.delegateAdapter.paywallWillOpenURL(url: url)
     case .openedUrlInSafari(let url):

--- a/SuperwallKit.podspec
+++ b/SuperwallKit.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
 
 	s.name         = "SuperwallKit"
-    s.version      = "3.4.3-beta.1"
+    s.version      = "3.4.3"
 	s.summary      = "Superwall: In-App Paywalls Made Easy"
 	s.description  = "Paywall infrastructure for mobile apps :) we make things like editing your paywall and running price tests as easy as clicking a few buttons. superwall.com"
 

--- a/SuperwallKit.podspec
+++ b/SuperwallKit.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
 
 	s.name         = "SuperwallKit"
-    s.version      = "3.4.2"
+    s.version      = "3.4.3-beta.1"
 	s.summary      = "Superwall: In-App Paywalls Made Easy"
 	s.description  = "Paywall infrastructure for mobile apps :) we make things like editing your paywall and running price tests as easy as clicking a few buttons. superwall.com"
 

--- a/Tests/SuperwallKitTests/Analytics/Internal Tracking/TrackTests.swift
+++ b/Tests/SuperwallKitTests/Analytics/Internal Tracking/TrackTests.swift
@@ -1006,11 +1006,12 @@ final class TrackingTests: XCTestCase {
     let dependencyContainer = DependencyContainer()
     let skTransaction = MockSKPaymentTransaction(state: .purchased)
     let transaction = await dependencyContainer.makeStoreTransaction(from: skTransaction)
-    let result = await Superwall.shared.track(InternalSuperwallEvent.Transaction(state: .restore, paywallInfo: paywallInfo, product: product, model: transaction))
+    let result = await Superwall.shared.track(InternalSuperwallEvent.Transaction(state: .restore(RestoreType.viaPurchase(transaction)), paywallInfo: paywallInfo, product: product, model: transaction))
     XCTAssertNotNil(result.parameters.eventParams["$app_session_id"])
     XCTAssertTrue(result.parameters.eventParams["$is_standard_event"] as! Bool)
 
     XCTAssertEqual(result.parameters.eventParams["$paywall_id"] as! String, paywallInfo.databaseId)
+    XCTAssertTrue(result.parameters.eventParams["$restore_via_purchase_attempt"] as! Bool)
     XCTAssertEqual(result.parameters.eventParams["$paywalljs_version"] as? String, paywallInfo.paywalljsVersion)
     XCTAssertEqual(result.parameters.eventParams["$paywall_identifier"] as! String, paywallInfo.identifier)
     XCTAssertEqual(result.parameters.eventParams["$paywall_name"] as! String, paywallInfo.name)


### PR DESCRIPTION
## Changes in this pull request

- Add in hasRestored when superwall purchases. 
- Add restored to PurchaseResult.
- Checks whether `transactionDate` is before `purchaseDate` after purchase. If it is, then it means its a restore. This happens when letting Superwall handle purchasing. Otherwise we rely on the dev returning restored. Updates the `RCPurchaseController` in our example app to reflect this.
- Makes the version 3.4.3.

Things to think about:
- We’re returning the transaction that occurred within the last hour on purchase. But we’re also going to count a purchase that happened before the purchase date as a restore… That kinda voids the need for the last hour check because any purchase that occurred before the purchase date will automatically be a restore (if using Superwall), and therefore any transactions before the purchase date won't be logged.

### Checklist

- [x] All unit tests pass.
- [x] All UI tests pass.
- [x] Demo project builds and runs.
- [x] I added/updated tests or detailed why my change isn't tested.
- [x] I added an entry to the `CHANGELOG.md` for any breaking changes, enhancements, or bug fixes.
- [x] I have run `swiftlint` in the main directory and fixed any issues.
- [ ] I have updated the SDK documentation as well as the online docs.
- [x] I have reviewed the [contributing guide](https://github.com/superwall-me/paywall-ios/tree/master/.github/CONTRIBUTING.md)
