### PR TITLE
Feature/3.4.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The changelog for `SuperwallKit`. Also see the [releases](https://github.com/superwall-me/Superwall-iOS/releases) on GitHub.
 
+## 3.4.4
+
+### Enhancements
+
+- Exposes `isPaywallPresented` convenience variable.
+
 ## 3.4.2
 
 ### Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The changelog for `SuperwallKit`. Also see the [releases](https://github.com/sup
 ### Enhancements
 
 - Exposes `isPaywallPresented` convenience variable.
+- Adds `device_attributes` event, which tracks the device attributes every new session.
 
 ## 3.4.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The changelog for `SuperwallKit`. Also see the [releases](https://github.com/sup
 
 - Exposes `isPaywallPresented` convenience variable.
 - Adds `device_attributes` event, which tracks the device attributes every new session.
+- Stops preloading paywalls that we know won't ever match.
 
 ## 3.4.2
 

--- a/Examples/UIKit+RevenueCat/Superwall-UIKit+RevenueCat.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Examples/UIKit+RevenueCat/Superwall-UIKit+RevenueCat.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/RevenueCat/purchases-ios.git",
         "state": {
           "branch": null,
-          "revision": "4601c1e0c246f3d74094229737e894a9f2339e6a",
-          "version": "4.25.7"
+          "revision": "011c94e0c2e93eb666ae57f71b413b9f4f200bb7",
+          "version": "4.27.2"
         }
       }
     ]

--- a/Sources/SuperwallKit/Analytics/App Session/AppSessionManager.swift
+++ b/Sources/SuperwallKit/Analytics/App Session/AppSessionManager.swift
@@ -28,12 +28,12 @@ class AppSessionManager {
 
   private unowned let configManager: ConfigManager
   private unowned let storage: Storage
-  private unowned let delegate: AppManagerDelegate
+  private unowned let delegate: AppManagerDelegate & DeviceHelperFactory
 
   init(
     configManager: ConfigManager,
     storage: Storage,
-    delegate: AppManagerDelegate
+    delegate: DeviceHelperFactory & AppManagerDelegate
   ) {
     self.configManager = configManager
     self.storage = storage
@@ -125,7 +125,11 @@ class AppSessionManager {
     if didStartNewSession {
       appSession = AppSession()
       Task {
+        let attributes = await delegate.makeSessionDeviceAttributes()
         await Superwall.shared.track(InternalSuperwallEvent.SessionStart())
+        await Superwall.shared.track(InternalSuperwallEvent.DeviceAttributes(
+          deviceAttributes: attributes
+        ))
       }
     } else {
       appSession.endAt = nil

--- a/Sources/SuperwallKit/Analytics/Internal Tracking/Trackable Events/TrackableSuperwallEvent.swift
+++ b/Sources/SuperwallKit/Analytics/Internal Tracking/Trackable Events/TrackableSuperwallEvent.swift
@@ -182,6 +182,18 @@ enum InternalSuperwallEvent {
     func getSuperwallParameters() async -> [String: Any] { [:] }
   }
 
+  struct DeviceAttributes: TrackableSuperwallEvent {
+    var superwallEvent: SuperwallEvent {
+      return .deviceAttributes(attributes: deviceAttributes)
+    }
+    let deviceAttributes: [String: Any]
+
+    var customParameters: [String: Any] = [:]
+    func getSuperwallParameters() async -> [String: Any] {
+      return deviceAttributes
+    }
+  }
+
   struct PaywallLoad: TrackableSuperwallEvent {
     enum State {
       case start

--- a/Sources/SuperwallKit/Analytics/Superwall Event/SuperwallEvent.swift
+++ b/Sources/SuperwallKit/Analytics/Superwall Event/SuperwallEvent.swift
@@ -32,6 +32,9 @@ public enum SuperwallEvent {
   /// The raw value of this event can be added to a campaign to trigger a paywall.
   case sessionStart
 
+  /// When device attributes are sent to the backend.
+  case deviceAttributes(attributes: [String: Any])
+
   /// When the user's subscription status changes.
   case subscriptionStatusDidChange
 
@@ -196,6 +199,8 @@ extension SuperwallEvent {
       return .init(objcEvent: .appInstall)
     case .sessionStart:
       return .init(objcEvent: .sessionStart)
+    case .deviceAttributes:
+      return .init(objcEvent: .deviceAttributes)
     case .subscriptionStatusDidChange:
       return .init(objcEvent: .subscriptionStatusDidChange)
     case .appClose:

--- a/Sources/SuperwallKit/Analytics/Superwall Event/SuperwallEventObjc.swift
+++ b/Sources/SuperwallKit/Analytics/Superwall Event/SuperwallEventObjc.swift
@@ -33,6 +33,9 @@ public enum SuperwallEventObjc: Int, CaseIterable {
   /// This event can be used to trigger a paywall. Just add the `session_start` event to a campaign.
   case sessionStart
 
+  /// When device attributes are sent to the backend.
+  case deviceAttributes
+
   /// Anytime the app leaves the foreground.
   case appClose
 
@@ -149,6 +152,8 @@ public enum SuperwallEventObjc: Int, CaseIterable {
       return "app_install"
     case .sessionStart:
       return "session_start"
+    case .deviceAttributes:
+      return "device_attributes"
     case .subscriptionStatusDidChange:
       return "subscriptionStatus_didChange"
     case .appClose:

--- a/Sources/SuperwallKit/Dependencies/DependencyContainer.swift
+++ b/Sources/SuperwallKit/Dependencies/DependencyContainer.swift
@@ -161,6 +161,20 @@ extension DependencyContainer: DeviceHelperFactory {
   func makeIsSandbox() -> Bool {
     return deviceHelper.isSandbox == "true"
   }
+
+  func makeSessionDeviceAttributes() async -> [String: Any] {
+    var attributes = await deviceHelper.getTemplateDevice()
+
+    attributes["utcDate"] = nil
+    attributes["localDate"] = nil
+    attributes["localDate"] = nil
+    attributes["localTime"] = nil
+    attributes["utcTime"] = nil
+    attributes["utcDateTime"] = nil
+    attributes["localDateTime"] = nil
+
+    return attributes
+  }
 }
 
 // MARK: - DeviceInfofactory

--- a/Sources/SuperwallKit/Dependencies/FactoryProtocols.swift
+++ b/Sources/SuperwallKit/Dependencies/FactoryProtocols.swift
@@ -92,6 +92,7 @@ protocol LocaleIdentifierFactory: AnyObject {
 protocol DeviceHelperFactory: AnyObject {
   func makeDeviceInfo() -> DeviceInfo
   func makeIsSandbox() -> Bool
+  func makeSessionDeviceAttributes() async -> [String: Any]
 }
 
 protocol HasExternalPurchaseControllerFactory: AnyObject {

--- a/Sources/SuperwallKit/Models/Paywall/Paywall.swift
+++ b/Sources/SuperwallKit/Models/Paywall/Paywall.swift
@@ -155,7 +155,7 @@ struct Paywall: Decodable {
     let presentationStyle = try values.decode(PaywallPresentationStyle.self, forKey: .presentationStyle)
     let presentationCondition = try values.decode(PresentationCondition.self, forKey: .presentationCondition)
     let presentationDelay = try values.decode(Int.self, forKey: .presentationDelay)
-    
+
     presentation = Presentation(
       style: presentationStyle,
       condition: presentationCondition,

--- a/Sources/SuperwallKit/Models/Paywall/Paywall.swift
+++ b/Sources/SuperwallKit/Models/Paywall/Paywall.swift
@@ -31,13 +31,16 @@ struct Paywall: Decodable {
   struct Presentation {
     var style: PaywallPresentationStyle = .modal
     let condition: PresentationCondition
+    let delay: Int
 
     init(
       style: PaywallPresentationStyle,
-      condition: PresentationCondition
+      condition: PresentationCondition,
+      delay: Int
     ) {
       self.style = style
       self.condition = condition
+      self.delay = delay
     }
   }
   let presentation: Presentation
@@ -113,6 +116,7 @@ struct Paywall: Decodable {
     case htmlSubstitutions = "paywalljsEvent"
     case presentationStyle = "presentationStyleV2"
     case presentationCondition
+    case presentationDelay
     case backgroundColorHex
     case products
     case featureGating
@@ -150,10 +154,12 @@ struct Paywall: Decodable {
 
     let presentationStyle = try values.decode(PaywallPresentationStyle.self, forKey: .presentationStyle)
     let presentationCondition = try values.decode(PresentationCondition.self, forKey: .presentationCondition)
-
+    let presentationDelay = try values.decode(Int.self, forKey: .presentationDelay)
+    
     presentation = Presentation(
       style: presentationStyle,
-      condition: presentationCondition
+      condition: presentationCondition,
+      delay: presentationDelay
     )
 
     backgroundColorHex = try values.decode(String.self, forKey: .backgroundColorHex)
@@ -327,7 +333,8 @@ extension Paywall: Stubbable {
       htmlSubstitutions: "",
       presentation: Presentation(
         style: .modal,
-        condition: .checkUserSubscription
+        condition: .checkUserSubscription,
+        delay: 0
       ),
       backgroundColorHex: "",
       backgroundColor: .black,

--- a/Sources/SuperwallKit/Network/Device Helper/DeviceHelper.swift
+++ b/Sources/SuperwallKit/Network/Device Helper/DeviceHelper.swift
@@ -384,7 +384,7 @@ class DeviceHelper {
     return newVersion
   }
 
-  private func getTemplateDevice() async -> [String: Any] {
+  func getTemplateDevice() async -> [String: Any] {
     let identityInfo = await factory.makeIdentityInfo()
     let aliases = [identityInfo.aliasId]
 

--- a/Sources/SuperwallKit/Paywall/Presentation/Rule Logic/Expression Evaluator/ExpressionEvaluator.swift
+++ b/Sources/SuperwallKit/Paywall/Presentation/Rule Logic/Expression Evaluator/ExpressionEvaluator.swift
@@ -8,7 +8,14 @@
 import Foundation
 import JavaScriptCore
 
-struct ExpressionEvaluator {
+protocol ExpressionEvaluating {
+  func evaluateExpression(
+    fromRule rule: TriggerRule,
+    eventData: EventData?
+  ) async -> TriggerRuleOutcome
+}
+
+struct ExpressionEvaluator: ExpressionEvaluating {
   private let storage: Storage
   private unowned let factory: RuleAttributesFactory
 
@@ -22,7 +29,7 @@ struct ExpressionEvaluator {
 
   func evaluateExpression(
     fromRule rule: TriggerRule,
-    eventData: EventData
+    eventData: EventData?
   ) async -> TriggerRuleOutcome {
     // Expression matches all
     if rule.expressionJs == nil && rule.expression == nil {
@@ -81,7 +88,7 @@ struct ExpressionEvaluator {
 
   private func getBase64Params(
     from rule: TriggerRule,
-    withEventData eventData: EventData
+    withEventData eventData: EventData?
   ) async -> String? {
     let attributes = await factory.makeRuleAttributes(
       forEvent: eventData,

--- a/Sources/SuperwallKit/Paywall/View Controller/PaywallViewController.swift
+++ b/Sources/SuperwallKit/Paywall/View Controller/PaywallViewController.swift
@@ -226,6 +226,7 @@ public class PaywallViewController: UIViewController, LoadingDelegate {
     let triggerSessionManager = factory.getTriggerSessionManager()
     await triggerSessionManager.trackPaywallOpen()
     storage.trackPaywallOpen()
+    await webView.messageHandler.handle(.paywallOpen)
     let trackedEvent = await InternalSuperwallEvent.PaywallOpen(paywallInfo: info)
     await Superwall.shared.track(trackedEvent)
   }

--- a/Sources/SuperwallKit/Paywall/View Controller/Web View/Message Handling/PaywallMessage.swift
+++ b/Sources/SuperwallKit/Paywall/View Controller/Web View/Message Handling/PaywallMessage.swift
@@ -45,6 +45,7 @@ enum PaywallMessage: Decodable, Equatable {
   case openDeepLink(url: URL)
   case purchase(productId: String)
   case custom(data: String)
+  case paywallOpen
 
   private enum MessageTypes: String, Decodable {
     case onReady = "ping"

--- a/Sources/SuperwallKit/Paywall/View Controller/Web View/Message Handling/PaywallMessageHandler.swift
+++ b/Sources/SuperwallKit/Paywall/View Controller/Web View/Message Handling/PaywallMessageHandler.swift
@@ -172,7 +172,11 @@ final class PaywallMessageHandler: WebEventDelegate {
             error: error
           )
         }
-        self?.delegate?.loadingState = .ready
+
+        let delay = self?.delegate?.paywall.presentation.delay ?? 0
+        DispatchQueue.main.asyncAfter(deadline: .now() + .milliseconds(delay)) {
+          self?.delegate?.loadingState = .ready
+        }
       }
 
       // block selection

--- a/Sources/SuperwallKit/Paywall/View Controller/Web View/Message Handling/PaywallMessageHandler.swift
+++ b/Sources/SuperwallKit/Paywall/View Controller/Web View/Message Handling/PaywallMessageHandler.swift
@@ -62,6 +62,10 @@ final class PaywallMessageHandler: WebEventDelegate {
     case .close:
       hapticFeedback()
       delegate?.eventDidOccur(.closed)
+    case .paywallOpen:
+      Task {
+        await self.pass(eventName: "paywall_open", from: paywall)
+      }
     case .openUrl(let url):
       openUrl(url)
     case .openUrlInSafari(let url):
@@ -77,40 +81,57 @@ final class PaywallMessageHandler: WebEventDelegate {
     }
   }
 
+  nonisolated private func pass(
+    eventName: String,
+    from paywall: Paywall
+  ) async {
+    let event = [
+      "event_name": eventName,
+      "paywall_id": paywall.databaseId,
+      "paywall_identifier": paywall.identifier
+    ]
+    guard let jsonEncodedEvent = try? JSONEncoder().encode([event]) else {
+      return
+    }
+    let base64Event = jsonEncodedEvent.base64EncodedString()
+    await passMessageToWebView(base64Event)
+  }
+
   /// Passes the templated variables and params to the webview.
   ///
   /// This is called every paywall open incase variables like user attributes have changed.
   nonisolated private func passTemplatesToWebView(from paywall: Paywall) async {
     let eventData = await delegate?.request?.presentationInfo.eventData
-    let templates = await TemplateLogic.getBase64EncodedTemplates(
+    let base64Templates = await TemplateLogic.getBase64EncodedTemplates(
       from: paywall,
       event: eventData,
       factory: factory
     )
+    await passMessageToWebView(base64Templates)
+  }
 
-    let templateScript = """
-      window.paywall.accept64('\(templates)');
+  private func passMessageToWebView(_ base64String: String) {
+    let messageScript = """
+      window.paywall.accept64('\(base64String)');
     """
 
     Logger.debug(
       logLevel: .debug,
       scope: .paywallViewController,
       message: "Posting Message",
-      info: ["message": templateScript],
+      info: ["message": messageScript],
       error: nil
     )
 
-    await MainActor.run {
-      self.delegate?.webView.evaluateJavaScript(templateScript) { _, error in
-        if let error = error {
-          Logger.debug(
-            logLevel: .error,
-            scope: .paywallViewController,
-            message: "Error Evaluating JS",
-            info: ["message": templateScript],
-            error: error
-          )
-        }
+    delegate?.webView.evaluateJavaScript(messageScript) { _, error in
+      if let error = error {
+        Logger.debug(
+          logLevel: .error,
+          scope: .paywallViewController,
+          message: "Error Evaluating JS",
+          info: ["message": messageScript],
+          error: error
+        )
       }
     }
   }

--- a/Sources/SuperwallKit/Superwall.swift
+++ b/Sources/SuperwallKit/Superwall.swift
@@ -162,7 +162,7 @@ public final class Superwall: NSObject, ObservableObject {
   let presentationItems = PresentationItems()
 
   /// Determines whether a paywall is being presented.
-  var isPaywallPresented: Bool {
+  public var isPaywallPresented: Bool {
     paywallViewController != nil
   }
 

--- a/Tests/SuperwallKitTests/Analytics/App Session/AppSessionManagerMock.swift
+++ b/Tests/SuperwallKitTests/Analytics/App Session/AppSessionManagerMock.swift
@@ -8,7 +8,13 @@
 import Foundation
 @testable import SuperwallKit
 
-class AppManagerDelegateMock: AppManagerDelegate {
+class AppManagerDelegateMock: AppManagerDelegate, DeviceHelperFactory {
+  func makeDeviceInfo() -> SuperwallKit.DeviceInfo {
+    return .init(appInstalledAtString: "", locale: "")
+  }
+  func makeIsSandbox() -> Bool { return true}
+  func makeSessionDeviceAttributes() async -> [String : Any] { [:] }
+
   func didUpdateAppSession(_ appSession: AppSession) async {}
 }
 
@@ -24,7 +30,11 @@ final class AppSessionManagerMock: AppSessionManager {
     storage: Storage
   ) {
     internalAppSession = appSession
-    super.init(configManager: configManager, storage: storage, delegate: AppManagerDelegateMock())
+    super.init(
+      configManager: configManager,
+      storage: storage,
+      delegate: AppManagerDelegateMock()
+    )
   }
 
   override func listenForAppSessionTimeout() {

--- a/Tests/SuperwallKitTests/Config/Assignments/AssignmentLogicTests.swift
+++ b/Tests/SuperwallKitTests/Config/Assignments/AssignmentLogicTests.swift
@@ -25,7 +25,8 @@ class AssignmentLogicTests: XCTestCase {
       experiment: rawExperiment,
       expression: nil,
       expressionJs: nil,
-      computedPropertyRequests: []
+      computedPropertyRequests: [],
+      preload: .init(behavior: .always)
     )
     let trigger = Trigger(
       eventName: eventName,
@@ -88,7 +89,8 @@ class AssignmentLogicTests: XCTestCase {
       experiment: rawExperiment,
       expression: nil,
       expressionJs: nil,
-      computedPropertyRequests: []
+      computedPropertyRequests: [],
+      preload: .init(behavior: .always)
     )
     let trigger = Trigger(
       eventName: eventName,
@@ -152,7 +154,8 @@ class AssignmentLogicTests: XCTestCase {
       experiment: rawExperiment,
       expression: nil,
       expressionJs: nil,
-      computedPropertyRequests: []
+      computedPropertyRequests: [],
+      preload: .init(behavior: .always)
     )
     let trigger = Trigger(
       eventName: eventName,
@@ -209,7 +212,8 @@ class AssignmentLogicTests: XCTestCase {
       experiment: rawExperiment,
       expression: nil,
       expressionJs: nil,
-      computedPropertyRequests: []
+      computedPropertyRequests: [],
+      preload: .init(behavior: .always)
     )
     let trigger = Trigger(
       eventName: eventName,
@@ -272,7 +276,8 @@ class AssignmentLogicTests: XCTestCase {
       experiment: rawExperiment,
       expression: "params.a == \"c\"",
       expressionJs: nil,
-      computedPropertyRequests: []
+      computedPropertyRequests: [],
+      preload: .init(behavior: .always)
     )
     let trigger = Trigger(
       eventName: eventName,
@@ -327,7 +332,8 @@ class AssignmentLogicTests: XCTestCase {
       experiment: rawExperiment,
       expression: "params.a == \"c\"",
       expressionJs: nil,
-      computedPropertyRequests: []
+      computedPropertyRequests: [],
+      preload: .init(behavior: .always)
     )
     let trigger = Trigger(
       eventName: eventName,

--- a/Tests/SuperwallKitTests/Models/Config/ConfigResponseTests.swift
+++ b/Tests/SuperwallKitTests/Models/Config/ConfigResponseTests.swift
@@ -400,6 +400,7 @@ let response = #"""
       "productId": "sk.superwall.annual.89.99_7"
     }],
     "presentation_condition": "CHECK_USER_SUBSCRIPTION",
+    "presentation_delay": 0,
     "presentation_style": "FULLSCREEN",
     "presentation_style_v2": "FULLSCREEN",
     "launch_option": "EXPLICIT",

--- a/Tests/SuperwallKitTests/Models/Config/ConfigResponseTests.swift
+++ b/Tests/SuperwallKitTests/Models/Config/ConfigResponseTests.swift
@@ -24,6 +24,10 @@ let response = #"""
       "experiment_id": "80",
       "expression": null,
       "expression_js": null,
+      "preload": {
+        "behavior": "ALWAYS",
+        "requires_re_evaluation": true
+      },
       "variants": [{
         "percentage": 0,
         "variant_type": "HOLDOUT",
@@ -43,6 +47,10 @@ let response = #"""
       "experiment_id": "66",
       "expression": null,
       "expression_js": null,
+      "preload": {
+        "behavior": "ALWAYS",
+        "requires_re_evaluation": true
+      },
       "variants": [{
         "percentage": 0,
         "variant_type": "HOLDOUT",

--- a/Tests/SuperwallKitTests/Paywall/Presentation/Rule Logic/ExpressionEvaluator/ExpressionEvaluatorMock.swift
+++ b/Tests/SuperwallKitTests/Paywall/Presentation/Rule Logic/ExpressionEvaluator/ExpressionEvaluatorMock.swift
@@ -1,0 +1,18 @@
+//
+//  File.swift
+//  
+//
+//  Created by Yusuf Tör on 10/10/2023.
+//
+// swiftlint:disable all
+
+import Foundation
+@testable import SuperwallKit
+
+struct ExpressionEvaluatorMock: ExpressionEvaluating {
+  let outcome: TriggerRuleOutcome
+
+  func evaluateExpression(fromRule rule: TriggerRule, eventData: EventData?) async -> TriggerRuleOutcome {
+    return outcome
+  }
+}

--- a/Tests/SuperwallKitTests/Storage/StorageMock.swift
+++ b/Tests/SuperwallKitTests/Storage/StorageMock.swift
@@ -30,6 +30,10 @@ final class StorageMock: Storage {
     func makeHasExternalPurchaseController() -> Bool {
       return false
     }
+    
+    func makeSessionDeviceAttributes() async -> [String : Any] {
+      return [:]
+    }
   }
 
   init(

--- a/Tests/SuperwallKitTests/StoreKit/Transactions/NotificationSchedulerTests.swift
+++ b/Tests/SuperwallKitTests/StoreKit/Transactions/NotificationSchedulerTests.swift
@@ -41,6 +41,9 @@ class NotificationSchedulerTests: XCTestCase {
       func makeDeviceInfo() -> DeviceInfo {
         return .init(appInstalledAtString: "", locale: "")
       }
+      func makeSessionDeviceAttributes() async -> [String : Any] {
+        return [:]
+      }
     }
 
     class AuthorizedNotificationSettings: NotificationSettings {
@@ -76,6 +79,9 @@ class NotificationSchedulerTests: XCTestCase {
       }
       func makeDeviceInfo() -> DeviceInfo {
         return .init(appInstalledAtString: "", locale: "")
+      }
+      func makeSessionDeviceAttributes() async -> [String : Any] {
+        return [:]
       }
     }
 


### PR DESCRIPTION
## Changes in this pull request

- Exposes `isPaywallPresented` convenience variable.
- Adds `device_attributes` event, which tracks the device attributes every new session.
- Stops preloading paywalls that we know won't ever match.
- Add paywall-defined millisecond delay to setting the paywallvc as ready
- Merges in #165
- Updates RC version

### Checklist

- [x] All unit tests pass.
- [ ] All UI tests pass.
- [x] Demo project builds and runs.
- [x] I added/updated tests or detailed why my change isn't tested.
- [x] I added an entry to the `CHANGELOG.md` for any breaking changes, enhancements, or bug fixes.
- [x] I have run `swiftlint` in the main directory and fixed any issues.
- [ ] I have updated the SDK documentation as well as the online docs.
- [x] I have reviewed the [contributing guide](https://github.com/superwall-me/paywall-ios/tree/master/.github/CONTRIBUTING.md)
