### PR TITLE
v3.4.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ The changelog for `SuperwallKit`. Also see the [releases](https://github.com/sup
 
 ## 3.4.7
 
+### Enhancements
+
+- SW-2667: Adds `preferredLanguageCode` and `preferredLocale` to device attributes. If your app isn't already localized for a language you're trying to target, the `deviceLanguageCode` and `deviceLocale` may not be what you're expecting. Use these device attributes instead to access the first preferred locale the user has in their device settings.
+
 ### Fixes
 
 - Fixes bug where a `transaction_abandon` or `transaction_fail` event would prevent the presented paywall from dismissing if `paywall_decline` was a trigger.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The changelog for `SuperwallKit`. Also see the [releases](https://github.com/sup
 ### Fixes
 
 - Fixes bug where a `transaction_abandon` or `transaction_fail` event would prevent the presented paywall from dismissing if `paywall_decline` was a trigger.
+- SW-2678: Fixes issue where the `subscription_start` event was being fired even if a non-recurring product was purchased.
 
 ## 3.4.6
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The changelog for `SuperwallKit`. Also see the [releases](https://github.com/superwall-me/Superwall-iOS/releases) on GitHub.
 
+## 3.4.6
+
+### Enhancements
+
+- Adds internal code for SDK wrappers like flutter.
+
 ## 3.4.5
 
 ### Enhancements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The changelog for `SuperwallKit`. Also see the [releases](https://github.com/sup
 
 - Fixes bug where a `transaction_abandon` or `transaction_fail` event would prevent the presented paywall from dismissing if `paywall_decline` was a trigger.
 - SW-2678: Fixes issue where the `subscription_start` event was being fired even if a non-recurring product was purchased.
+- SW-2659: Fixes issue on macOS where the window behind a paywall wasn't being removed when a paywall was dismissed, leading to the app appearing to be in a frozen state.
 
 ## 3.4.6
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,17 @@
 
 The changelog for `SuperwallKit`. Also see the [releases](https://github.com/superwall-me/Superwall-iOS/releases) on GitHub.
 
+## 3.4.7
+
+### Fixes
+
+- Fixes bug where a `transaction_abandon` or `transaction_fail` event would prevent the presented paywall from dismissing if `paywall_decline` was a trigger.
+
 ## 3.4.6
 
 ### Enhancements
 
-- Adds internal code for SDK wrappers like flutter.
+- Adds internal code for SDK wrappers like Flutter.
 
 ## 3.4.5
 

--- a/Sources/SuperwallKit/Analytics/Internal Tracking/Tracking.swift
+++ b/Sources/SuperwallKit/Analytics/Internal Tracking/Tracking.swift
@@ -58,7 +58,7 @@ extension Superwall {
       disableVerboseEvents: verboseEvents,
       isSandbox: dependencyContainer.makeIsSandbox()
     ) {
-      await dependencyContainer.queue.enqueue(event: eventData.jsonData)
+      await dependencyContainer.eventsQueue.enqueue(event: eventData.jsonData)
     }
     dependencyContainer.storage.coreDataManager.saveEventData(eventData)
 

--- a/Sources/SuperwallKit/Dependencies/DependencyContainer.swift
+++ b/Sources/SuperwallKit/Dependencies/DependencyContainer.swift
@@ -30,7 +30,7 @@ final class DependencyContainer {
   var paywallManager: PaywallManager!
   var paywallRequestManager: PaywallRequestManager!
   var deviceHelper: DeviceHelper!
-  var queue: EventsQueue!
+  var eventsQueue: EventsQueue!
   var debugManager: DebugManager!
   var api: Api!
   var transactionManager: TransactionManager!
@@ -83,7 +83,7 @@ final class DependencyContainer {
       factory: self
     )
 
-    queue = EventsQueue(
+    eventsQueue = EventsQueue(
       network: network,
       configManager: configManager
     )
@@ -124,6 +124,7 @@ final class DependencyContainer {
       receiptManager: receiptManager,
       purchaseController: purchaseController,
       sessionEventsManager: sessionEventsManager,
+      eventsQueue: eventsQueue,
       factory: self
     )
 

--- a/Sources/SuperwallKit/Misc/Constants.swift
+++ b/Sources/SuperwallKit/Misc/Constants.swift
@@ -18,5 +18,5 @@ let sdkVersion = """
 */
 
 let sdkVersion = """
-3.4.5
+3.4.6
 """

--- a/Sources/SuperwallKit/Misc/Constants.swift
+++ b/Sources/SuperwallKit/Misc/Constants.swift
@@ -18,5 +18,5 @@ let sdkVersion = """
 */
 
 let sdkVersion = """
-3.4.6
+3.4.7
 """

--- a/Sources/SuperwallKit/Network/Device Helper/DeviceHelper.swift
+++ b/Sources/SuperwallKit/Network/Device Helper/DeviceHelper.swift
@@ -15,6 +15,14 @@ class DeviceHelper {
     let localeIdentifier = factory.makeLocaleIdentifier()
     return localeIdentifier ?? Locale.autoupdatingCurrent.identifier
   }
+
+  var preferredLocale: String {
+    guard let preferredIdentifier = Locale.preferredLanguages.first else {
+      return locale
+    }
+    return Locale(identifier: preferredIdentifier).identifier
+  }
+
   let appInstalledAtString: String
 
   private let reachability: SCNetworkReachability?
@@ -57,7 +65,22 @@ class DeviceHelper {
   }()
 
   var languageCode: String {
-    Locale.autoupdatingCurrent.languageCode ?? ""
+    if #available(iOS 16, *) {
+      Locale.autoupdatingCurrent.language.languageCode?.identifier ?? ""
+    } else {
+      Locale.autoupdatingCurrent.languageCode ?? ""
+    }
+  }
+
+  var preferredLanguageCode: String {
+    guard let preferredIdentifier = Locale.preferredLanguages.first else {
+      return languageCode
+    }
+    if #available(iOS 16, *) {
+      return Locale(identifier: preferredIdentifier).language.languageCode?.identifier ?? ""
+    } else {
+      return Locale(identifier: preferredIdentifier).languageCode ?? ""
+    }
   }
 
   var currencyCode: String {
@@ -400,7 +423,9 @@ class DeviceHelper {
       osVersion: osVersion,
       deviceModel: model,
       deviceLocale: locale,
+      preferredLocale: preferredLocale,
       deviceLanguageCode: languageCode,
+      preferredLanguageCode: preferredLanguageCode,
       deviceCurrencyCode: currencyCode,
       deviceCurrencySymbol: currencySymbol,
       interfaceType: interfaceType,

--- a/Sources/SuperwallKit/Network/Device Helper/DeviceHelper.swift
+++ b/Sources/SuperwallKit/Network/Device Helper/DeviceHelper.swift
@@ -66,9 +66,9 @@ class DeviceHelper {
 
   var languageCode: String {
     if #available(iOS 16, *) {
-      Locale.autoupdatingCurrent.language.languageCode?.identifier ?? ""
+      return Locale.autoupdatingCurrent.language.languageCode?.identifier ?? ""
     } else {
-      Locale.autoupdatingCurrent.languageCode ?? ""
+      return Locale.autoupdatingCurrent.languageCode ?? ""
     }
   }
 

--- a/Sources/SuperwallKit/Paywall/Presentation/Internal/Operators/GetPresenter.swift
+++ b/Sources/SuperwallKit/Paywall/Presentation/Internal/Operators/GetPresenter.swift
@@ -82,8 +82,7 @@ extension Superwall {
         logLevel: .error,
         scope: .paywallPresentation,
         message: "No Presenter To Present Paywall",
-        info: debugInfo,
-        error: nil
+        info: debugInfo
       )
 
       let error = InternalPresentationLogic.presentationError(

--- a/Sources/SuperwallKit/Paywall/Presentation/Internal/Operators/GetPresenter.swift
+++ b/Sources/SuperwallKit/Paywall/Presentation/Internal/Operators/GetPresenter.swift
@@ -142,6 +142,7 @@ extension Superwall {
 
   @MainActor
   func destroyPresentingWindow() {
+    presentationItems.window?.windowScene = nil
     presentationItems.window = nil
   }
 }

--- a/Sources/SuperwallKit/Paywall/View Controller/PaywallViewController.swift
+++ b/Sources/SuperwallKit/Paywall/View Controller/PaywallViewController.swift
@@ -787,14 +787,18 @@ extension PaywallViewController {
         )
         let paywallPresenterEvent = info.presentedByEventWithName
         let presentedByPaywallDecline = paywallPresenterEvent == SuperwallEventObjc.paywallDecline.description
+        let presentedByTransactionAbandon = paywallPresenterEvent == SuperwallEventObjc.transactionAbandon.description
+        let presentedByTransactionFail = paywallPresenterEvent == SuperwallEventObjc.transactionFail.description
 
         await Superwall.shared.track(trackedEvent)
 
         if case .paywall = presentationResult,
-          !presentedByPaywallDecline {
+          !presentedByPaywallDecline,
+          !presentedByTransactionAbandon,
+          !presentedByTransactionFail {
           // If a paywall_decline trigger is active and the current paywall wasn't presented
-          // by paywall_decline, it lands here so as not to dismiss the paywall.
-          // track() will do that before presenting the next paywall.
+          // by paywall_decline, transaction_abandon, or transaction_fail, it lands here so
+          // as not to dismiss the paywall. track() will do that before presenting the next paywall.
           return
         }
       }

--- a/Sources/SuperwallKit/Paywall/View Controller/Web View/Message Handling/PaywallMessageHandler.swift
+++ b/Sources/SuperwallKit/Paywall/View Controller/Web View/Message Handling/PaywallMessageHandler.swift
@@ -119,8 +119,7 @@ final class PaywallMessageHandler: WebEventDelegate {
       logLevel: .debug,
       scope: .paywallViewController,
       message: "Posting Message",
-      info: ["message": messageScript],
-      error: nil
+      info: ["message": messageScript]
     )
 
     delegate?.webView.evaluateJavaScript(messageScript) { _, error in

--- a/Sources/SuperwallKit/Paywall/View Controller/Web View/Templating/Models/DeviceTemplate.swift
+++ b/Sources/SuperwallKit/Paywall/View Controller/Web View/Templating/Models/DeviceTemplate.swift
@@ -17,7 +17,9 @@ struct DeviceTemplate: Codable {
   var osVersion: String
   var deviceModel: String
   var deviceLocale: String
+  var preferredLocale: String
   var deviceLanguageCode: String
+  var preferredLanguageCode: String
   var deviceCurrencyCode: String
   var deviceCurrencySymbol: String
   var interfaceType: String

--- a/Sources/SuperwallKit/Storage/EventsQueue.swift
+++ b/Sources/SuperwallKit/Storage/EventsQueue.swift
@@ -82,7 +82,7 @@ actor EventsQueue {
     return true
   }
 
-  private func flushInternal(depth: Int = 10) {
+  func flushInternal(depth: Int = 10) {
     var eventsToSend: [JSON] = []
 
     var i = 0

--- a/Sources/SuperwallKit/StoreKit/Transactions/TransactionManager.swift
+++ b/Sources/SuperwallKit/StoreKit/Transactions/TransactionManager.swift
@@ -399,26 +399,26 @@ final class TransactionManager {
         product: product
       )
       await Superwall.shared.track(trackedEvent)
-    }
-
-    if didStartFreeTrial {
-      let trackedEvent = InternalSuperwallEvent.FreeTrialStart(
-        paywallInfo: paywallInfo,
-        product: product
-      )
-      await Superwall.shared.track(trackedEvent)
-
-      let notifications = paywallInfo.localNotifications.filter {
-        $0.type == .trialStarted
-      }
-
-      await NotificationScheduler.scheduleNotifications(notifications, factory: factory)
     } else {
-      let trackedEvent = InternalSuperwallEvent.SubscriptionStart(
-        paywallInfo: paywallInfo,
-        product: product
-      )
-      await Superwall.shared.track(trackedEvent)
+      if didStartFreeTrial {
+        let trackedEvent = InternalSuperwallEvent.FreeTrialStart(
+          paywallInfo: paywallInfo,
+          product: product
+        )
+        await Superwall.shared.track(trackedEvent)
+
+        let notifications = paywallInfo.localNotifications.filter {
+          $0.type == .trialStarted
+        }
+
+        await NotificationScheduler.scheduleNotifications(notifications, factory: factory)
+      } else {
+        let trackedEvent = InternalSuperwallEvent.SubscriptionStart(
+          paywallInfo: paywallInfo,
+          product: product
+        )
+        await Superwall.shared.track(trackedEvent)
+      }
     }
   }
 }

--- a/SuperwallKit.podspec
+++ b/SuperwallKit.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
 
 	s.name         = "SuperwallKit"
-    s.version      = "3.4.5"
+    s.version      = "3.4.6"
 	s.summary      = "Superwall: In-App Paywalls Made Easy"
 	s.description  = "Paywall infrastructure for mobile apps :) we make things like editing your paywall and running price tests as easy as clicking a few buttons. superwall.com"
 


### PR DESCRIPTION
## Changes in this pull request

### Enhancements

- SW-2667: Adds `preferredLanguageCode` and `preferredLocale` to device attributes. If your app isn't already localized for a language you're trying to target, the `deviceLanguageCode` and `deviceLocale` may not be what you're expecting. Use these device attributes instead to access the first preferred locale the user has in their device settings.

### Fixes

- Fixes bug where a `transaction_abandon` or `transaction_fail` event would prevent the presented paywall from dismissing if `paywall_decline` was a trigger.
- SW-2678: Fixes issue where the `subscription_start` event was being fired even if a non-recurring product was purchased.
- SW-2659: Fixes issue on macOS where the window behind a paywall wasn't being removed when a paywall was dismissed, leading to the app appearing to be in a frozen state. (#192)

### Checklist

- [x] All unit tests pass.
- [x] All UI tests pass.
- [x] Demo project builds and runs.
- [x] I added/updated tests or detailed why my change isn't tested.
- [x] I added an entry to the `CHANGELOG.md` for any breaking changes, enhancements, or bug fixes.
- [x] I have run `swiftlint` in the main directory and fixed any issues.
- [ ] I have updated the SDK documentation as well as the online docs.
- [x] I have reviewed the [contributing guide](https://github.com/superwall-me/paywall-ios/tree/master/.github/CONTRIBUTING.md)
